### PR TITLE
docs: 리뷰어 자동 할당 github action 추가 

### DIFF
--- a/.github/reviewers.yml
+++ b/.github/reviewers.yml
@@ -1,0 +1,30 @@
+reviewers:
+  defaults:
+    - kkojae91
+    - moonheekim0118
+    - hyewoncc
+    - JangBomi
+    - yeon-06
+    - HJ-Rich
+  groups:
+    backend:
+      - hyewoncc
+      - JangBomi
+      - yeon-06
+      - HJ-Rich
+    frontend:
+      - kkojae91
+      - moonheekim0118
+
+files:
+  "frontend/**":
+    - frontend
+  "backend/**":
+    - backend
+
+options:
+  ignore_draft: true
+
+  enable_group_assignment: false
+
+  number_of_reviewers: 3

--- a/.github/workflows/auto_request_review.yml
+++ b/.github/workflows/auto_request_review.yml
@@ -1,0 +1,16 @@
+name: Auto Request Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-request-review:
+    name: Auto Request Review
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request review based on files changes and/or groups the author belongs to
+        uses: necojackarc/auto-request-review@v0.7.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/reviewers.yml # Config file location override


### PR DESCRIPTION
## 요약
- 리뷰어 자동 할당 github action 추가 

## 작업 내용
- auto_request_review.yml 작성
- reviewers.yml 작성

## 관련 이슈
- Closes #65 