### PR TITLE
feat: 메시지 조회 API 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,6 +23,7 @@ repositories {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'com.slack.api:slack-api-client:1.23.0'
     implementation 'com.querydsl:querydsl-jpa:5.0.0'
     implementation 'com.querydsl:querydsl-apt:5.0.0'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
     id 'java'
+    id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.pickpick'
@@ -12,6 +13,7 @@ configurations {
     compileOnly {
         extendsFrom annotationProcessor
     }
+    querydsl.extendsFrom compileClasspath
 }
 
 repositories {
@@ -22,6 +24,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'com.slack.api:slack-api-client:1.23.0'
+    implementation 'com.querydsl:querydsl-jpa:5.0.0'
+    implementation 'com.querydsl:querydsl-apt:5.0.0'
     compileOnly 'org.projectlombok:lombok'
     runtimeOnly 'mysql:mysql-connector-java'
     annotationProcessor 'org.projectlombok:lombok'
@@ -32,4 +36,16 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+querydsl {
+    jpa = true
+    querydslSourcesDir = querydslDir
+}
+sourceSets {
+    main.java.srcDir querydslDir
+}
+compileQuerydsl {
+    options.annotationProcessorPath = configurations.querydsl
 }

--- a/backend/src/main/java/com/pickpick/controller/MessageController.java
+++ b/backend/src/main/java/com/pickpick/controller/MessageController.java
@@ -22,10 +22,14 @@ public class MessageController {
 
     @GetMapping
     public SlackMessageResponses findSlackMessages(@Valid SlackMessageRequest slackMessageRequest) {
-        if (Objects.nonNull(slackMessageRequest.getDate()) && Objects.nonNull(slackMessageRequest.getMessageId())) {
+        if (duplicateFindCondition(slackMessageRequest)) {
             throw new WrongMessageRequestException();
         }
 
         return messageService.find(slackMessageRequest);
+    }
+
+    private boolean duplicateFindCondition(final SlackMessageRequest slackMessageRequest) {
+        return Objects.nonNull(slackMessageRequest.getDate()) && Objects.nonNull(slackMessageRequest.getMessageId());
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/MessageController.java
+++ b/backend/src/main/java/com/pickpick/controller/MessageController.java
@@ -1,0 +1,38 @@
+package com.pickpick.controller;
+
+import com.pickpick.controller.dto.SlackMessageResponses;
+import com.pickpick.exception.WrongMessageRequestException;
+import com.pickpick.service.MessageService;
+import java.time.LocalDateTime;
+import java.util.Objects;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/messages")
+public class MessageController {
+
+    private final MessageService messageService;
+
+    public MessageController(final MessageService messageService) {
+        this.messageService = messageService;
+    }
+
+    @GetMapping
+    public SlackMessageResponses findSlackMessages(
+            @RequestParam(required = false) String keyword,
+            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime date,
+            @RequestParam Long channelId,
+            @RequestParam(required = false, defaultValue = "true") boolean needPastMessage,
+            @RequestParam(required = false) Long messageId,
+            @RequestParam(defaultValue = "20") int messageCount) {
+        if (Objects.nonNull(date) && Objects.nonNull(messageId)) {
+            throw new WrongMessageRequestException("date와 messageId를 동시에 보내는 것은 불가능합니다.");
+        }
+        return messageService.find(keyword, date, channelId, needPastMessage, messageId, messageCount);
+    }
+
+}

--- a/backend/src/main/java/com/pickpick/controller/MessageController.java
+++ b/backend/src/main/java/com/pickpick/controller/MessageController.java
@@ -1,14 +1,10 @@
 package com.pickpick.controller;
 
 import com.pickpick.controller.dto.SlackMessageRequest;
-import com.pickpick.controller.dto.SlackMessageResponse;
 import com.pickpick.controller.dto.SlackMessageResponses;
-import com.pickpick.entity.Message;
 import com.pickpick.exception.WrongMessageRequestException;
 import com.pickpick.service.MessageService;
-import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -30,14 +26,6 @@ public class MessageController {
             throw new WrongMessageRequestException();
         }
 
-        List<Message> messages = messageService.find(slackMessageRequest);
-
-        return toSlackMessageResponses(messages);
-    }
-
-    private SlackMessageResponses toSlackMessageResponses(final List<Message> messages) {
-        return new SlackMessageResponses(messages.stream()
-                .map(SlackMessageResponse::from)
-                .collect(Collectors.toList()));
+        return messageService.find(slackMessageRequest);
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/MessageController.java
+++ b/backend/src/main/java/com/pickpick/controller/MessageController.java
@@ -1,10 +1,14 @@
 package com.pickpick.controller;
 
 import com.pickpick.controller.dto.SlackMessageRequest;
+import com.pickpick.controller.dto.SlackMessageResponse;
 import com.pickpick.controller.dto.SlackMessageResponses;
+import com.pickpick.entity.Message;
 import com.pickpick.exception.WrongMessageRequestException;
 import com.pickpick.service.MessageService;
+import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import javax.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,6 +29,15 @@ public class MessageController {
         if (Objects.nonNull(slackMessageRequest.getDate()) && Objects.nonNull(slackMessageRequest.getMessageId())) {
             throw new WrongMessageRequestException();
         }
-        return messageService.find(slackMessageRequest);
+
+        List<Message> messages = messageService.find(slackMessageRequest);
+
+        return toSlackMessageResponses(messages);
+    }
+
+    private SlackMessageResponses toSlackMessageResponses(final List<Message> messages) {
+        return new SlackMessageResponses(messages.stream()
+                .map(SlackMessageResponse::from)
+                .collect(Collectors.toList()));
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/MessageController.java
+++ b/backend/src/main/java/com/pickpick/controller/MessageController.java
@@ -1,14 +1,13 @@
 package com.pickpick.controller;
 
+import com.pickpick.controller.dto.SlackMessageRequest;
 import com.pickpick.controller.dto.SlackMessageResponses;
 import com.pickpick.exception.WrongMessageRequestException;
 import com.pickpick.service.MessageService;
-import java.time.LocalDateTime;
 import java.util.Objects;
-import org.springframework.format.annotation.DateTimeFormat;
+import javax.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,17 +21,10 @@ public class MessageController {
     }
 
     @GetMapping
-    public SlackMessageResponses findSlackMessages(
-            @RequestParam(required = false) String keyword,
-            @RequestParam(required = false) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME) LocalDateTime date,
-            @RequestParam Long channelId,
-            @RequestParam(required = false, defaultValue = "true") boolean needPastMessage,
-            @RequestParam(required = false) Long messageId,
-            @RequestParam(defaultValue = "20") int messageCount) {
-        if (Objects.nonNull(date) && Objects.nonNull(messageId)) {
-            throw new WrongMessageRequestException("date와 messageId를 동시에 보내는 것은 불가능합니다.");
+    public SlackMessageResponses findSlackMessages(@Valid SlackMessageRequest slackMessageRequest) {
+        if (Objects.nonNull(slackMessageRequest.getDate()) && Objects.nonNull(slackMessageRequest.getMessageId())) {
+            throw new WrongMessageRequestException();
         }
-        return messageService.find(keyword, date, channelId, needPastMessage, messageId, messageCount);
+        return messageService.find(slackMessageRequest);
     }
-
 }

--- a/backend/src/main/java/com/pickpick/controller/dto/MessageDto.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/MessageDto.java
@@ -8,16 +8,16 @@ import lombok.Getter;
 
 @Getter
 public class MessageDto {
+
+    private String slackId;
     private String memberSlackId;
     private LocalDateTime postedDate;
     private LocalDateTime modifiedDate;
     private String text;
 
-    public MessageDto(String memberSlackId,
-                      String postedDate,
-                      String modifiedDate,
-                      String text
-    ) {
+    public MessageDto(final String slackId, final String memberSlackId,
+                      final String postedDate, final String modifiedDate, final String text) {
+        this.slackId = slackId;
         this.memberSlackId = memberSlackId;
         this.postedDate = TimeUtils.toLocalDateTime(postedDate);
         this.modifiedDate = TimeUtils.toLocalDateTime(modifiedDate);
@@ -25,6 +25,6 @@ public class MessageDto {
     }
 
     public Message toEntity(final Member member) {
-        return new Message(text, member, postedDate, modifiedDate);
+        return new Message(slackId, text, member, postedDate, modifiedDate);
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
@@ -1,7 +1,9 @@
 package com.pickpick.controller.dto;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -18,8 +20,8 @@ public class SlackMessageRequest {
     @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
     private LocalDateTime date;
 
-    //    @NotNull
-    private Long channelId;
+    @NotNull
+    private List<Long> channelIds;
 
     private boolean needPastMessage = true;
 

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
@@ -33,4 +33,18 @@ public class SlackMessageRequest {
 
     private SlackMessageRequest() {
     }
+
+    public SlackMessageRequest(final String keyword,
+                               final LocalDateTime date,
+                               final List<Long> channelIds,
+                               final boolean needPastMessage,
+                               final Long messageId,
+                               final int messageCount) {
+        this.keyword = keyword;
+        this.date = date;
+        this.channelIds = channelIds;
+        this.needPastMessage = needPastMessage;
+        this.messageId = messageId;
+        this.messageCount = messageCount;
+    }
 }

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
@@ -1,0 +1,34 @@
+package com.pickpick.controller.dto;
+
+import java.time.LocalDateTime;
+import javax.validation.constraints.Min;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.lang.Nullable;
+
+@Setter
+@Getter
+public class SlackMessageRequest {
+
+    @Nullable
+    private String keyword;
+
+    @Nullable
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime date;
+
+    //    @NotNull
+    private Long channelId;
+
+    private boolean needPastMessage = true;
+
+    @Nullable
+    private Long messageId;
+
+    @Min(0)
+    private int messageCount = 20;
+
+    private SlackMessageRequest() {
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageResponse.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageResponse.java
@@ -1,0 +1,48 @@
+package com.pickpick.controller.dto;
+
+import com.pickpick.entity.Member;
+import com.pickpick.entity.Message;
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class SlackMessageResponse {
+
+    private final Long id;
+    private final Long memberId;
+    private final String username;
+    private final String userThumbnail;
+    private final String text;
+    private final LocalDateTime postedDate;
+    private final LocalDateTime modifiedDate;
+
+    public SlackMessageResponse(final Long id,
+                                final Long memberId,
+                                final String username,
+                                final String userThumbnail,
+                                final String text,
+                                final LocalDateTime postedDate,
+                                final LocalDateTime modifiedDate) {
+        this.id = id;
+        this.memberId = memberId;
+        this.username = username;
+        this.userThumbnail = userThumbnail;
+        this.text = text;
+        this.postedDate = postedDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    public static SlackMessageResponse from(final Message message) {
+        final Member member = message.getMember();
+
+        return new SlackMessageResponse(
+                message.getId(),
+                member.getId(),
+                member.getUsername(),
+                member.getThumbnailUrl(),
+                message.getText(),
+                message.getPostedDate(),
+                message.getModifiedDate()
+        );
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageResponses.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageResponses.java
@@ -7,8 +7,10 @@ import lombok.Getter;
 public class SlackMessageResponses {
 
     private final List<SlackMessageResponse> messages;
+    private final boolean isLast;
 
-    public SlackMessageResponses(final List<SlackMessageResponse> messages) {
+    public SlackMessageResponses(final List<SlackMessageResponse> messages, final boolean isLast) {
         this.messages = messages;
+        this.isLast = isLast;
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageResponses.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageResponses.java
@@ -1,0 +1,14 @@
+package com.pickpick.controller.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class SlackMessageResponses {
+
+    private final List<SlackMessageResponse> messages;
+
+    public SlackMessageResponses(final List<SlackMessageResponse> messages) {
+        this.messages = messages;
+    }
+}

--- a/backend/src/main/java/com/pickpick/entity/Channel.java
+++ b/backend/src/main/java/com/pickpick/entity/Channel.java
@@ -1,0 +1,18 @@
+package com.pickpick.entity;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.Getter;
+
+@Getter
+@Table(name = "channel")
+@Entity
+public class Channel {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+}

--- a/backend/src/main/java/com/pickpick/entity/Channel.java
+++ b/backend/src/main/java/com/pickpick/entity/Channel.java
@@ -1,5 +1,6 @@
 package com.pickpick.entity;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
 import javax.persistence.GenerationType;
@@ -11,8 +12,22 @@ import lombok.Getter;
 @Table(name = "channel")
 @Entity
 public class Channel {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "slack_id", length = 15, nullable = false, unique = true)
+    private String slackId;
+
+    @Column(name = "name", length = 80, nullable = false)
+    private String name;
+
+    protected Channel() {
+    }
+
+    public Channel(final String slackId, final String name) {
+        this.slackId = slackId;
+        this.name = name;
+    }
 }

--- a/backend/src/main/java/com/pickpick/entity/Message.java
+++ b/backend/src/main/java/com/pickpick/entity/Message.java
@@ -21,6 +21,10 @@ public class Message {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "channel_id")
+    private Channel channel;
+
     @Column(name = "text", length = 12000, nullable = false)
     private String text;
 

--- a/backend/src/main/java/com/pickpick/entity/Message.java
+++ b/backend/src/main/java/com/pickpick/entity/Message.java
@@ -21,6 +21,9 @@ public class Message {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(name = "slack_message_id", length = 50, nullable = false, updatable = false)
+    private String slackId;
+
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "channel_id")
     private Channel channel;
@@ -41,11 +44,17 @@ public class Message {
     protected Message() {
     }
 
-    public Message(final String text, final Member member, final LocalDateTime postedDate,
-                   final LocalDateTime modifiedDate) {
+    public Message(final String slackId, final String text, final Member member,
+                   final LocalDateTime postedDate, final LocalDateTime modifiedDate) {
+        this.slackId = slackId;
         this.text = text;
         this.member = member;
         this.postedDate = postedDate;
+        this.modifiedDate = modifiedDate;
+    }
+
+    public void changeText(final String text, final LocalDateTime modifiedDate) {
+        this.text = text;
         this.modifiedDate = modifiedDate;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/MessageNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/MessageNotFoundException.java
@@ -1,6 +1,7 @@
 package com.pickpick.exception;
 
 public class MessageNotFoundException extends RuntimeException {
+
     private static final String DEFAULT_MESSAGE = "메시지를 찾지 못했습니다";
 
     public MessageNotFoundException() {

--- a/backend/src/main/java/com/pickpick/exception/MessageNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/MessageNotFoundException.java
@@ -1,0 +1,9 @@
+package com.pickpick.exception;
+
+public class MessageNotFoundException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "메시지를 찾지 못했습니다";
+
+    public MessageNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/WrongMessageRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/WrongMessageRequestException.java
@@ -1,0 +1,7 @@
+package com.pickpick.exception;
+
+public class WrongMessageRequestException extends RuntimeException {
+    public WrongMessageRequestException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/WrongMessageRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/WrongMessageRequestException.java
@@ -1,7 +1,10 @@
 package com.pickpick.exception;
 
 public class WrongMessageRequestException extends RuntimeException {
-    public WrongMessageRequestException(final String message) {
-        super(message);
+
+    private static final String DEFAULT_MESSAGE = "date와 messageId를 동시에 보내는 것은 불가능합니다.";
+
+    public WrongMessageRequestException() {
+        super(DEFAULT_MESSAGE);
     }
 }

--- a/backend/src/main/java/com/pickpick/repository/MessageRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/MessageRepository.java
@@ -1,11 +1,14 @@
 package com.pickpick.repository;
 
 import com.pickpick.entity.Message;
-import org.springframework.data.repository.Repository;
-
 import java.util.List;
+import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
 public interface MessageRepository extends Repository<Message, Long> {
     void save(Message message);
+
     List<Message> findAll();
+
+    Optional<Message> findById(Long messageId);
 }

--- a/backend/src/main/java/com/pickpick/service/MessageCreatedService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageCreatedService.java
@@ -18,6 +18,7 @@ public class MessageCreatedService implements SlackEventService {
     private static final String USER = "user";
     private static final String TIMESTAMP = "ts";
     private static final String TEXT = "text";
+    private static final String CLIENT_MSG_ID = "client_msg_id";
 
     private final MessageRepository messages;
     private final MemberRepository members;
@@ -41,6 +42,7 @@ public class MessageCreatedService implements SlackEventService {
         final Map<String, Object> event = (Map<String, Object>) requestBody.get(EVENT);
 
         return new MessageDto(
+                (String) event.get(CLIENT_MSG_ID),
                 (String) event.get(USER),
                 (String) event.get(TIMESTAMP),
                 (String) event.get(TIMESTAMP),

--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -1,0 +1,95 @@
+package com.pickpick.service;
+
+import com.pickpick.controller.dto.SlackMessageResponse;
+import com.pickpick.controller.dto.SlackMessageResponses;
+import com.pickpick.entity.Message;
+import com.pickpick.entity.QMessage;
+import com.pickpick.exception.MessageNotFoundException;
+import com.pickpick.repository.MessageRepository;
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import javax.persistence.EntityManager;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Transactional(readOnly = true)
+@Service
+public class MessageService {
+
+    private final EntityManager entityManager;
+    private final MessageRepository messageRepository;
+    private JPAQueryFactory jpaQueryFactory;
+
+    public MessageService(final EntityManager entityManager, final MessageRepository messageRepository) {
+        this.entityManager = entityManager;
+        this.messageRepository = messageRepository;
+    }
+
+    public SlackMessageResponses find(final String keyword, final LocalDateTime date, final Long channelId,
+                                      final boolean needPastMessage, final Long messageId,
+                                      final int messageCount) {
+
+        jpaQueryFactory = new JPAQueryFactory(entityManager);
+
+        BooleanBuilder builder = createBooleanBuilder(keyword, date, needPastMessage, messageId);
+
+        List<Message> messages = jpaQueryFactory
+                .selectFrom(QMessage.message)
+                .leftJoin(QMessage.message.member)
+                .fetchJoin()
+                .distinct()
+                .where(QMessage.message.channel.id.eq(channelId))
+                .where(builder)
+                .orderBy(QMessage.message.postedDate.desc())
+                .limit(messageCount)
+                .fetch();
+
+        return new SlackMessageResponses(messages.stream()
+                .map(SlackMessageResponse::from)
+                .collect(Collectors.toList()));
+    }
+
+    //TODO https://whitepro.tistory.com/450 BooleanBuilder 리팩터링 참고
+    private BooleanBuilder createBooleanBuilder(final String keyword, final LocalDateTime date,
+                                                final boolean needPastMessage, final Long messageId) {
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (StringUtils.hasText(keyword)) {
+            builder.and(QMessage.message.text.contains(keyword));
+        }
+
+        if (Objects.nonNull(date)) {
+            if (needPastMessage) {
+                builder.and(
+                        QMessage.message.postedDate.eq(date)
+                                .or(QMessage.message.postedDate.before(date))
+                );
+                builder.and(QMessage.message.postedDate.before(date));
+            } else {
+                builder.and(
+                        QMessage.message.postedDate.eq(date)
+                                .or(QMessage.message.postedDate.after(date))
+                );
+            }
+        }
+
+        if (Objects.nonNull(messageId)) {
+            Message message = messageRepository.findById(messageId)
+                    .orElseThrow(MessageNotFoundException::new);
+
+            LocalDateTime messageDate = message.getPostedDate();
+
+            if (needPastMessage) {
+                builder.and(QMessage.message.postedDate.before(messageDate));
+            } else {
+                builder.and(QMessage.message.postedDate.after(messageDate));
+            }
+        }
+        return builder;
+    }
+}

--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -41,7 +41,6 @@ public class MessageService {
                 .selectFrom(QMessage.message)
                 .leftJoin(QMessage.message.member)
                 .fetchJoin()
-                .distinct()
                 .where(QMessage.message.channel.id.in(channelIds))
                 .where(builder)
                 .orderBy(QMessage.message.postedDate.desc())

--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -37,7 +37,7 @@ public class MessageService {
 
         BooleanBuilder builder = createBooleanBuilder(slackMessageRequest);
 
-        Long channelId = slackMessageRequest.getChannelId();
+        List<Long> channelIds = slackMessageRequest.getChannelIds();
         int messageCount = slackMessageRequest.getMessageCount();
 
         List<Message> messages = jpaQueryFactory
@@ -45,7 +45,7 @@ public class MessageService {
                 .leftJoin(QMessage.message.member)
                 .fetchJoin()
                 .distinct()
-                .where(QMessage.message.channel.id.eq(channelId))
+                .where(QMessage.message.channel.id.in(channelIds))
                 .where(builder)
                 .orderBy(QMessage.message.postedDate.desc())
                 .limit(messageCount)

--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -1,8 +1,6 @@
 package com.pickpick.service;
 
 import com.pickpick.controller.dto.SlackMessageRequest;
-import com.pickpick.controller.dto.SlackMessageResponse;
-import com.pickpick.controller.dto.SlackMessageResponses;
 import com.pickpick.entity.Message;
 import com.pickpick.entity.QMessage;
 import com.pickpick.exception.MessageNotFoundException;
@@ -12,7 +10,6 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.stream.Collectors;
 import javax.persistence.EntityManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +28,7 @@ public class MessageService {
         this.messageRepository = messageRepository;
     }
 
-    public SlackMessageResponses find(final SlackMessageRequest slackMessageRequest) {
+    public List<Message> find(final SlackMessageRequest slackMessageRequest) {
 
         jpaQueryFactory = new JPAQueryFactory(entityManager);
 
@@ -40,7 +37,7 @@ public class MessageService {
         List<Long> channelIds = slackMessageRequest.getChannelIds();
         int messageCount = slackMessageRequest.getMessageCount();
 
-        List<Message> messages = jpaQueryFactory
+        return jpaQueryFactory
                 .selectFrom(QMessage.message)
                 .leftJoin(QMessage.message.member)
                 .fetchJoin()
@@ -50,10 +47,6 @@ public class MessageService {
                 .orderBy(QMessage.message.postedDate.desc())
                 .limit(messageCount)
                 .fetch();
-
-        return new SlackMessageResponses(messages.stream()
-                .map(SlackMessageResponse::from)
-                .collect(Collectors.toList()));
     }
 
     //TODO https://whitepro.tistory.com/450 BooleanBuilder 리팩터링 참고

--- a/backend/src/test/java/com/pickpick/acceptance/EventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/EventAcceptanceTest.java
@@ -8,7 +8,9 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql("/message.sql")
 @DisplayName("메시지 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class EventAcceptanceTest extends AcceptanceTest {
@@ -38,11 +40,17 @@ class EventAcceptanceTest extends AcceptanceTest {
 
     private void 메시지_저장_성공() {
         // given
-        String user = "U03MKN0UWQN";
+        String user = "U03MC231";
         String timestamp = "1234567890.123456";
         String text = "메시지 전송!";
+        String slackMessageId = "db8a1f84-8acf-46ab-b93d-85177cee3e97";
 
-        Map<String, String> event = Map.of("type", "message", "user", user, "ts", timestamp, "text", text);
+        Map<String, String> event = Map.of(
+                "type", "message",
+                "user", user,
+                "ts", timestamp,
+                "text", text,
+                "client_msg_id", slackMessageId);
 
         String type = "event_callback";
         Map<String, Object> request = Map.of("type", type, "event", event);

--- a/backend/src/test/java/com/pickpick/service/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/service/MessageServiceTest.java
@@ -15,8 +15,12 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestConstructor;
 import org.springframework.test.context.TestConstructor.AutowireMode;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.transaction.annotation.Transactional;
 
+@Sql("/message.sql")
 @TestConstructor(autowireMode = AutowireMode.ALL)
+@Transactional
 @SpringBootTest
 class MessageServiceTest {
 
@@ -26,13 +30,12 @@ class MessageServiceTest {
         this.messageService = messageService;
     }
 
-    @ParameterizedTest
-    @MethodSource("slackMessageRequest")
     @DisplayName("메시지 조회 요청에 따른 메시지가 응답된다")
+    @MethodSource("slackMessageRequest")
+    @ParameterizedTest(name = "{0}")
     void findMessages(
-            final SlackMessageRequest slackMessageRequest,
-            final List<Long> expectedMessageIds,
-            final boolean expectedLast) {
+            final String description, final SlackMessageRequest slackMessageRequest,
+            final List<Long> expectedMessageIds, final boolean expectedLast) {
         // given
         SlackMessageResponses slackMessageResponses = messageService.find(slackMessageRequest);
 
@@ -50,6 +53,7 @@ class MessageServiceTest {
     private static Stream<Arguments> slackMessageRequest() {
         return Stream.of(
                 Arguments.of(
+                        "1번, 2번 채널에서 메시지ID가 1인 메시지 이후에 작성된 메시지 7개 조회",
                         new SlackMessageRequest(null, null, List.of(1L, 2L), false, 1L, 7),
                         List.of(222L, 3L, 4L, 5L, 6L, 7L, 8L),
                         true)

--- a/backend/src/test/java/com/pickpick/service/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/service/MessageServiceTest.java
@@ -1,0 +1,58 @@
+package com.pickpick.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.pickpick.controller.dto.SlackMessageRequest;
+import com.pickpick.controller.dto.SlackMessageResponse;
+import com.pickpick.controller.dto.SlackMessageResponses;
+import java.util.List;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestConstructor;
+import org.springframework.test.context.TestConstructor.AutowireMode;
+
+@TestConstructor(autowireMode = AutowireMode.ALL)
+@SpringBootTest
+class MessageServiceTest {
+
+    private final MessageService messageService;
+
+    public MessageServiceTest(final MessageService messageService) {
+        this.messageService = messageService;
+    }
+
+    @ParameterizedTest
+    @MethodSource("slackMessageRequest")
+    @DisplayName("메시지 조회 요청에 따른 메시지가 응답된다")
+    void findMessages(
+            final SlackMessageRequest slackMessageRequest,
+            final List<Long> expectedMessageIds,
+            final boolean expectedLast) {
+        // given
+        SlackMessageResponses slackMessageResponses = messageService.find(slackMessageRequest);
+
+        // when
+        List<SlackMessageResponse> messages = slackMessageResponses.getMessages();
+        boolean last = slackMessageResponses.isLast();
+
+        // then
+        assertAll(
+                () -> assertThat(messages).extracting("id").isEqualTo(expectedMessageIds),
+                () -> assertThat(last).isEqualTo(expectedLast)
+        );
+    }
+
+    private static Stream<Arguments> slackMessageRequest() {
+        return Stream.of(
+                Arguments.of(
+                        new SlackMessageRequest(null, null, List.of(1L, 2L), false, 1L, 7),
+                        List.of(222L, 3L, 4L, 5L, 6L, 7L, 8L),
+                        true)
+        );
+    }
+}

--- a/backend/src/test/resources/message.sql
+++ b/backend/src/test/resources/message.sql
@@ -1,0 +1,55 @@
+insert into channel (id, name, slack_id)
+values (1, '임시 채널', 1);
+
+insert into member (id, slack_id, thumbnail_url, username)
+values (46, 'U03MC231', 'https://avatars.slack-edge.com/2022-07-02/3764274541009_4d1fa8d13242781486fa_512.png',
+        '써머'),
+       (47, 'U03MKWQN',
+        'https://secure.gravatar.com/avatar/9303b7a88d498194de16f07405211458.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0011-512.png',
+        '리차드'),
+       (48, 'U03MSGD3',
+        'https://secure.gravatar.com/avatar/42ca58848dad05653d81635ce9c2c2a3.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0009-512.png',
+        ''),
+       (49, 'U03MS2F5', 'https://avatars.slack-edge.com/2022-06-30/3742679834690_946a429a80b00f86efd7_512.png', '봄'),
+       (50, 'U03MSY8K', 'https://avatars.slack-edge.com/2022-07-01/3747157066370_dede2d72f57dae7a582a_512.png', ''),
+       (51, 'U03MV3PE', 'https://avatars.slack-edge.com/2022-07-02/3775436666928_6e702b06b95d404b21b5_512.png',
+        '꼬재'),
+       (52, 'U03MLRD2',
+        'https://secure.gravatar.com/avatar/c9cfce948145f092c7a85aa0705b2ac0.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0015-512.png',
+        ''),
+       (53, 'U03N5VBK', 'https://avatars.slack-edge.com/2022-07-02/3746119703990_2306f90ec53f7fc3c807_512.png',
+        '호프'),
+       (54, 'U03NKKQ9', 'https://avatars.slack-edge.com/2022-07-03/3751682320325_084e06a3986a3940f25f_512.png', ''),
+       (55, 'U03NWS3B', 'https://avatars.slack-edge.com/2022-07-06/3767808931764_9c4a0e6556498b14b48c_512.png', ''),
+       (56, 'U03P3DKQ', 'https://avatars.slack-edge.com/2022-07-14/3800274950373_c0055af8cdee56527d13_512.png', '');
+
+insert into message (id, modified_date, posted_date, text, member_id, channel_id, slack_message_id)
+values (1, '2022-07-12 17:21:55', '2022-07-12 17:21:55', '과거다~~~ hi', 47, 1, 1),
+       (3, '2022-07-12 21:02:06', '2022-07-12 21:02:06', '미래다~~ *리차드(전형중)*  [오후 6:44]
+스레드에 답글을 남김:
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 2),
+       (4, '2022-07-12 21:03:06', '2022-07-12 21:03:06', '미래다~~ *리차드(전형중*  [오후 6:44]
+스레드에 답글을 남김:
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 3),
+       (5, '2022-07-12 21:04:06', '2022-07-12 21:04:06', '미래다~~ *리차드(전형중*  [오후 6:44]
+스레드에 답글을 남김:
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 4),
+       (6, '2022-07-12 21:05:06', '2022-07-12 21:05:06', '미래다~~ *리차드(전형중*  [오후 6:44]
+스레드에 답글을 남김:
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 5),
+       (7, '2022-07-12 21:06:06', '2022-07-12 21:06:06', '미래다~~ *리차드(전형중*  [오후 6:44]
+스레드에 답글을 남김:
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 6),
+       (8, '2022-07-12 21:02:06', '2022-07-12 21:07:06', '미래다~~ *리차드(전형중*  [오후 6:44]
+스레드에 답글을 남김:
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 7),
+       (222, '2022-07-12 21:01:56', '2022-07-12 21:01:56', '*리차드(전형중*  [오후 6:44]
+스레드에 답글을 남김: wow
+*<https://some.url.com/archives/C02U/p1657619082621909?thread_ts=1657596790.119479&amp;cid=C02U|@channel…>*
+인스턴스 유형이 `t4g.micro`로 변경되었습니다. 이후 새로 생성할 때 참고하세요!', 47, 1, 8);


### PR DESCRIPTION
## 요약

- 저장된 Slack 메시지들을 조회할 수 있는 API 구현

<br><br>

## 작업 내용

- QueryDSL 도입
- 채널 진입 시 -> 채널 ID로 최근 20개 메시지 조회
`/api/messages?channelId={channelId}`

- 특정 날짜로 이동 -> 채널 ID + 날짜로 과거 20개 조회 (날짜는 ISO 포맷으로)
`/api/messages?channelId={channelId}&date={date}`

  - 쿼리 스트링으로 과거 or 미래 방향 설정 가능
 `/api/messages?channelId={channelId}&date={date}&needPastMessage={true/false}`

  - 쿼리 스트링으로 조회 갯수 설정 가능
 `/api/messages?channelId={channelId}&date={date}&messageCount=10`

- 특정 메시지 이전 또는 이후 검색 -> 채널 ID + 메시지 ID 로 과거 20개 
`/api/messages?channelId={channelId}&messageId={messageId}`

  - 쿼리 스트링으로 과거 or 미래 방향 설정 가능
 `/api/messages?channelId={channelId}&messageId={messageId}&needPastMessage={true/false}`

  - 쿼리 스트링으로 조회 갯수 설정 가능
 `/api/messages?channelId={channelId}&messageId={messageId}&messageCount=10`


<br><br>
## 기타

- 연로그와 PR 올리는 부분은 합의하지 않았는데.. 아래와 같은 이유로 PR 작성해봅니다!
  - 봄, 써머가 빠르게 코드를 확인하고 피드백 주기 편할 것 같아서요! :)
  - 일단 올려놓고 추가 PUSH를 하는 방식으로 진행해도 될 것 같아서요~!
  - 메시지 API 관련해선 프론트도 같이 봐야할 것 같아서요!
  - 완전히 완성되기 전에 빠르게 피드백을 받는 게 좋을 것 같아서요!!
  (연로그 혹시 추후 PR 올리는 것 관련해서 피드백 주실 내용 있으면 말씀해주세요, 반영할게요!! ;ㅅ;)
- 따라서 현재 PR된 코드는 내용 공유 목적이 크며, 완전히 완성된 내용은 아닙니다. 
- 편하게 피드백 주시고 의견공유하고 그다음 추가 PUSH 하고 다시 리뷰요청드릴게요!!
- 아마... 제가 브랜칭을 잘못해서 members-setup 브랜치와 충돌이 있을 수 있는데,
members-setup 이 빠르게 merge가 가능할 것 같아서 이 브랜치에서 충돌 해결하고 추가 PUSH하겠습니다!

<br><br>
관련 이슈
- Close #27 
- Close #28 
