### PR TITLE
feat: 채널 구독 기능 및 api 개발 

### DIFF
--- a/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
@@ -24,7 +24,7 @@ public class ChannelSubscriptionController {
 
     private final ChannelSubscriptionService channelSubscriptionService;
 
-    public ChannelSubscriptionController(ChannelSubscriptionService channelSubscriptionService) {
+    public ChannelSubscriptionController(final ChannelSubscriptionService channelSubscriptionService) {
         this.channelSubscriptionService = channelSubscriptionService;
     }
 

--- a/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
@@ -1,0 +1,32 @@
+package com.pickpick.controller;
+
+import com.pickpick.controller.dto.ChannelSubscriptionResponse;
+import com.pickpick.controller.dto.ChannelSubscriptionResponses;
+import com.pickpick.service.ChannelSubscriptionService;
+import com.pickpick.utils.AuthorizationExtractor;
+import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/channel-subscription")
+public class ChannelSubscriptionController {
+
+    private final ChannelSubscriptionService channelSubscriptionService;
+
+    public ChannelSubscriptionController(ChannelSubscriptionService channelSubscriptionService) {
+        this.channelSubscriptionService = channelSubscriptionService;
+    }
+
+    @GetMapping
+    public ChannelSubscriptionResponses getAllChannels(HttpServletRequest request) {
+        String memberId = AuthorizationExtractor.extract(request);
+        return new ChannelSubscriptionResponses(
+                channelSubscriptionService.findAllOrderByViewOrder(Long.parseLong(memberId))
+                        .stream()
+                        .map(ChannelSubscriptionResponse::from)
+                        .collect(Collectors.toList()));
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
@@ -1,12 +1,16 @@
 package com.pickpick.controller;
 
+import com.pickpick.controller.dto.ChannelOrderRequest;
 import com.pickpick.controller.dto.ChannelSubscriptionResponse;
 import com.pickpick.controller.dto.ChannelSubscriptionResponses;
 import com.pickpick.service.ChannelSubscriptionService;
 import com.pickpick.utils.AuthorizationExtractor;
+import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -28,5 +32,11 @@ public class ChannelSubscriptionController {
                         .stream()
                         .map(ChannelSubscriptionResponse::from)
                         .collect(Collectors.toList()));
+    }
+
+    @PutMapping
+    public void updateViewOrders(HttpServletRequest request, @RequestBody List<ChannelOrderRequest> orderRequests) {
+        String memberId = AuthorizationExtractor.extract(request);
+        channelSubscriptionService.updateOrders(orderRequests, Long.parseLong(memberId));
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
@@ -1,6 +1,7 @@
 package com.pickpick.controller;
 
 import com.pickpick.controller.dto.ChannelOrderRequest;
+import com.pickpick.controller.dto.ChannelSubscriptionRequest;
 import com.pickpick.controller.dto.ChannelSubscriptionResponse;
 import com.pickpick.controller.dto.ChannelSubscriptionResponses;
 import com.pickpick.service.ChannelSubscriptionService;
@@ -9,6 +10,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +34,13 @@ public class ChannelSubscriptionController {
                         .stream()
                         .map(ChannelSubscriptionResponse::from)
                         .collect(Collectors.toList()));
+    }
+
+    @PostMapping
+    public void subscribeChannel(HttpServletRequest request,
+                                 @RequestBody ChannelSubscriptionRequest subscriptionRequest) {
+        String memberId = AuthorizationExtractor.extract(request);
+        channelSubscriptionService.save(subscriptionRequest, Long.parseLong(memberId));
     }
 
     @PutMapping

--- a/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/controller/ChannelSubscriptionController.java
@@ -9,7 +9,9 @@ import com.pickpick.utils.AuthorizationExtractor;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,5 +49,11 @@ public class ChannelSubscriptionController {
     public void updateViewOrders(HttpServletRequest request, @RequestBody List<ChannelOrderRequest> orderRequests) {
         String memberId = AuthorizationExtractor.extract(request);
         channelSubscriptionService.updateOrders(orderRequests, Long.parseLong(memberId));
+    }
+
+    @DeleteMapping("/{channelId}")
+    public void unsubscribeChannel(HttpServletRequest request, @PathVariable Long channelId) {
+        String memberId = AuthorizationExtractor.extract(request);
+        channelSubscriptionService.delete(channelId, Long.parseLong(memberId));
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelOrderRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelOrderRequest.java
@@ -1,0 +1,15 @@
+package com.pickpick.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChannelOrderRequest {
+
+    private Long id;
+    private int order;
+
+    public ChannelOrderRequest(Long id, int order) {
+        this.id = id;
+        this.order = order;
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionRequest.java
@@ -1,0 +1,16 @@
+package com.pickpick.controller.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ChannelSubscriptionRequest {
+
+    private Long id;
+
+    private ChannelSubscriptionRequest() {
+    }
+
+    public ChannelSubscriptionRequest(Long id) {
+        this.id = id;
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionResponse.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionResponse.java
@@ -3,7 +3,7 @@ package com.pickpick.controller.dto;
 import com.pickpick.entity.ChannelSubscription;
 import lombok.Builder;
 import lombok.Getter;
-ø
+
 @Getter
 public class ChannelSubscriptionResponse {
 

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionResponse.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionResponse.java
@@ -1,0 +1,31 @@
+package com.pickpick.controller.dto;
+
+import com.pickpick.entity.ChannelSubscription;
+import lombok.Builder;
+import lombok.Getter;
+ø
+@Getter
+public class ChannelSubscriptionResponse {
+
+    private Long id;
+    private String name;
+    private int order;
+
+    private ChannelSubscriptionResponse() {
+    }
+
+    @Builder
+    private ChannelSubscriptionResponse(Long id, String name, int order) {
+        this.id = id;
+        this.name = name;
+        this.order = order;
+    }
+
+    public static ChannelSubscriptionResponse from(final ChannelSubscription channelSubscription) {
+        return ChannelSubscriptionResponse.builder()
+                .id(channelSubscription.getChannel().getId())
+                .name(channelSubscription.getChannel().getName())
+                .order(channelSubscription.getViewOrder())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionResponses.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelSubscriptionResponses.java
@@ -1,0 +1,14 @@
+package com.pickpick.controller.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class ChannelSubscriptionResponses {
+
+    private List<ChannelSubscriptionResponse> channels;
+
+    public ChannelSubscriptionResponses(List<ChannelSubscriptionResponse> channels) {
+        this.channels = channels;
+    }
+}

--- a/backend/src/main/java/com/pickpick/entity/ChannelSubscription.java
+++ b/backend/src/main/java/com/pickpick/entity/ChannelSubscription.java
@@ -39,4 +39,12 @@ public class ChannelSubscription {
         this.member = member;
         this.viewOrder = viewOrder;
     }
+
+    public void changeOrder(int order) {
+        this.viewOrder = order;
+    }
+
+    public Long getChannelId() {
+        return this.channel.getId();
+    }
 }

--- a/backend/src/main/java/com/pickpick/exception/ChannelNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/ChannelNotFoundException.java
@@ -1,0 +1,9 @@
+package com.pickpick.exception;
+
+public class ChannelNotFoundException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "채널을 찾지 못했습니다";
+
+    public ChannelNotFoundException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/ChannelNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/ChannelNotFoundException.java
@@ -1,6 +1,7 @@
 package com.pickpick.exception;
 
 public class ChannelNotFoundException extends RuntimeException {
+
     private static final String DEFAULT_MESSAGE = "채널을 찾지 못했습니다";
 
     public ChannelNotFoundException() {

--- a/backend/src/main/java/com/pickpick/exception/MemberNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/MemberNotFoundException.java
@@ -1,6 +1,7 @@
 package com.pickpick.exception;
 
 public class MemberNotFoundException extends RuntimeException {
+
     private static final String DEFAULT_MESSAGE = "사용자를 찾지 못했습니다";
 
     public MemberNotFoundException() {

--- a/backend/src/main/java/com/pickpick/exception/SlackEventNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/SlackEventNotFoundException.java
@@ -1,6 +1,7 @@
 package com.pickpick.exception;
 
 public class SlackEventNotFoundException extends RuntimeException {
+
     private static final String DEFAULT_MESSAGE = "지원하지 않는 Slack Event 입니다";
 
     public SlackEventNotFoundException() {

--- a/backend/src/main/java/com/pickpick/repository/ChannelRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/ChannelRepository.java
@@ -2,9 +2,12 @@ package com.pickpick.repository;
 
 import com.pickpick.entity.Channel;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
 public interface ChannelRepository extends Repository<Channel, Long> {
+
+    Optional<Channel> findById(Long id);
 
     List<Channel> findAll();
 

--- a/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
@@ -16,4 +16,5 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
+    List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
 }

--- a/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
@@ -1,6 +1,8 @@
 package com.pickpick.repository;
 
+import com.pickpick.entity.Channel;
 import com.pickpick.entity.ChannelSubscription;
+import com.pickpick.entity.Member;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
@@ -11,15 +13,13 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     void saveAll(Iterable<ChannelSubscription> channelSubscriptions);
 
-    List<ChannelSubscription> findAllByOrderByViewOrder();
-
     void deleteAllByMemberId(Long memberId);
-
-    void deleteByIdIn(List<Long> id);
 
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
     List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
 
     Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderDesc(Long memberId);
+
+    void deleteAllByChannelAndMember(Channel channel, Member member);
 }

--- a/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
@@ -6,6 +6,8 @@ import org.springframework.data.repository.Repository;
 
 public interface ChannelSubscriptionRepository extends Repository<ChannelSubscription, Long> {
 
+    void save(ChannelSubscription channelSubscription);
+
     void saveAll(Iterable<ChannelSubscription> channelSubscriptions);
 
     List<ChannelSubscription> findAllByOrderByViewOrder();

--- a/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
@@ -2,6 +2,7 @@ package com.pickpick.repository;
 
 import com.pickpick.entity.ChannelSubscription;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
 public interface ChannelSubscriptionRepository extends Repository<ChannelSubscription, Long> {
@@ -19,4 +20,6 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
     List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
+
+    Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderDesc(Long memberId);
 }

--- a/backend/src/main/java/com/pickpick/repository/MemberRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/MemberRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.Repository;
 
 public interface MemberRepository extends Repository<Member, Long> {
 
-    Member findById(Long id);
+    Optional<Member> findById(Long id);
 
     Optional<Member> findBySlackId(String slackId);
 

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -22,6 +22,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class ChannelSubscriptionService {
 
+    private static final int ORDER_FIRST = 1;
+    private static final int ORDER_NEXT = 1;
+
     private final ChannelSubscriptionRepository channelSubscriptions;
     private final ChannelRepository channels;
     private final MemberRepository members;
@@ -83,8 +86,8 @@ public class ChannelSubscriptionService {
 
     private int getMaxViewOrder(Long memberId) {
         return channelSubscriptions.findFirstByMemberIdOrderByViewOrderDesc(memberId)
-                .map(it -> it.getViewOrder() + 1)
-                .orElse(1);
+                .map(it -> it.getViewOrder() + ORDER_NEXT)
+                .orElse(ORDER_FIRST);
     }
 
     private List<ChannelSubscription> getChannelSubscriptionsByChannel(final List<Channel> channels,

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -34,6 +34,10 @@ public class ChannelSubscriptionService {
         return getChannelResponsesWithIsSubscribed(allChannels, subscribedChannels);
     }
 
+    public List<ChannelSubscription> findAllOrderByViewOrder(Long memberId) {
+        return channelSubscriptions.findAllByMemberIdOrderByViewOrder(memberId);
+    }
+
     private List<ChannelResponse> getChannelResponsesWithIsSubscribed(final List<Channel> allChannels,
                                                                       final List<Channel> subscribedChannels) {
         return allChannels.stream()

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -82,7 +82,9 @@ public class ChannelSubscriptionService {
     }
 
     private int getMaxViewOrder(Long memberId) {
-        return channelSubscriptions.findAllByMemberIdOrderByViewOrder(memberId).size() + 1;
+        return channelSubscriptions.findFirstByMemberIdOrderByViewOrderDesc(memberId)
+                .map(it -> it.getViewOrder() + 1)
+                .orElse(1);
     }
 
     private List<ChannelSubscription> getChannelSubscriptionsByChannel(final List<Channel> channels,

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -111,4 +111,15 @@ public class ChannelSubscriptionService {
         return orderRequests.stream()
                 .collect(Collectors.toMap(ChannelOrderRequest::getId, ChannelOrderRequest::getOrder));
     }
+
+    @Transactional
+    public void delete(Long channelId, Long memberId) {
+        Channel channel = channels.findById(channelId)
+                .orElseThrow(ChannelNotFoundException::new);
+
+        Member member = members.findById(memberId)
+                .orElseThrow(MemberNotFoundException::new);
+
+        channelSubscriptions.deleteAllByChannelAndMember(channel, member);
+    }
 }

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -29,9 +29,9 @@ public class ChannelSubscriptionService {
     private final ChannelRepository channels;
     private final MemberRepository members;
 
-    public ChannelSubscriptionService(ChannelSubscriptionRepository channelSubscriptions,
-                                      ChannelRepository channels,
-                                      MemberRepository members) {
+    public ChannelSubscriptionService(final ChannelSubscriptionRepository channelSubscriptions,
+                                      final ChannelRepository channels,
+                                      final MemberRepository members) {
         this.channelSubscriptions = channelSubscriptions;
         this.channels = channels;
         this.members = members;
@@ -44,7 +44,7 @@ public class ChannelSubscriptionService {
         return getChannelResponsesWithIsSubscribed(allChannels, subscribedChannels);
     }
 
-    public List<ChannelSubscription> findAllOrderByViewOrder(Long memberId) {
+    public List<ChannelSubscription> findAllOrderByViewOrder(final Long memberId) {
         return channelSubscriptions.findAllByMemberIdOrderByViewOrder(memberId);
     }
 
@@ -84,7 +84,7 @@ public class ChannelSubscriptionService {
         channelSubscriptions.save(new ChannelSubscription(channel, member, getMaxViewOrder(memberId)));
     }
 
-    private int getMaxViewOrder(Long memberId) {
+    private int getMaxViewOrder(final Long memberId) {
         return channelSubscriptions.findFirstByMemberIdOrderByViewOrderDesc(memberId)
                 .map(it -> it.getViewOrder() + ORDER_NEXT)
                 .orElse(ORDER_FIRST);
@@ -110,13 +110,13 @@ public class ChannelSubscriptionService {
         }
     }
 
-    private Map<Long, Integer> getOrdersMap(List<ChannelOrderRequest> orderRequests) {
+    private Map<Long, Integer> getOrdersMap(final List<ChannelOrderRequest> orderRequests) {
         return orderRequests.stream()
                 .collect(Collectors.toMap(ChannelOrderRequest::getId, ChannelOrderRequest::getOrder));
     }
 
     @Transactional
-    public void delete(Long channelId, Long memberId) {
+    public void delete(final Long channelId, final Long memberId) {
         Channel channel = channels.findById(channelId)
                 .orElseThrow(ChannelNotFoundException::new);
 


### PR DESCRIPTION
## 요약

채널 구독 추가, 수정, 삭제 api 개발 

<br>

## 작업 내용

- 구독한 채널 목록 조회 API (GET)
`GET /api/channel-subscription`  

- 채널 구독 추가 API (POST)
`POST /api/channel-subscription`  

- 드래그앤 드롭으로 순서를 바꿨을 경우 수정 API (PUT)
`PUT /api/channel-subscription`  

- 채널 구독 제거 API (DELETE)
`DELETE api/channel-subscription/{channelId}`

위 4가지 경우에 대한 기능과 API 를 구현완료 했습니다.

<br>

## 참고 사항

1. `read-channels`에서 파생된 브랜치라, 우선 base를 `read-channels`로 설정하여 pr 올립니다. 일단 기능 위주로 리뷰 남겨주시면 감사하겠습니다. 🥺  
2. 현재 채널 데이터가 모킹 상태라 데이터에 의존적인 테스트가 되어 추가하지 않았습니다.
해당 `PR`에 푸시하거나, 추후 이슈를 따로 파서 데이터와 격리된 테스트를 작성하려 합니다. 😅   


<br>

## 관련 이슈

- Close #87 
<br>
