### PR TITLE
fix: 메시지 조회 API 오류 수정.

### DIFF
--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -116,7 +116,7 @@ public class MessageService {
         Integer result = jpaQueryFactory
                 .selectOne()
                 .from(QMessage.message)
-                .where(QMessage.message.channel.id.in(slackMessageRequest.getMessageId()))
+                .where(QMessage.message.channel.id.in(slackMessageRequest.getChannelIds()))
                 .where(isLastExpression(targetMessage, slackMessageRequest.isNeedPastMessage()))
                 .where(builder)
                 .fetchFirst();


### PR DESCRIPTION
## 요약

메시지 조회 API 오류 수정

<br><br>

## 작업 내용

channelId를 검증해야 하는 곳에서 messageId를 검증하고 있어서 500 에러가 나고 있었어요.

<br><br>

## 관련 이슈

- Close #105 

<br><br>
