### PR TITLE
test: 채널과 채널 구독 인수테스트 추가

### DIFF
--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -8,7 +8,10 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -32,6 +35,17 @@ class AcceptanceTest {
                 .extract();
     }
 
+    ExtractableResponse<Response> postWithAuth(final String uri, final Object object, final Long memberId) {
+        return RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + memberId)
+                .body(object)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post(uri)
+                .then().log().all()
+                .extract();
+    }
+
     ExtractableResponse<Response> get(final String uri) {
         return RestAssured.given().log().all()
                 .when()
@@ -47,5 +61,29 @@ class AcceptanceTest {
                 .get(uri)
                 .then().log().all()
                 .extract();
+    }
+
+    ExtractableResponse<Response> putWithAuth(final String uri, final Object object, final Long memberId) {
+        return RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + memberId)
+                .body(object)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    ExtractableResponse<Response> deleteWithAuth(final String uri, final Long memberId) {
+        return RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + memberId)
+                .when()
+                .delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    void 상태코드_200_확인(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
@@ -1,22 +1,97 @@
 package com.pickpick.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.pickpick.controller.dto.ChannelResponse;
-import java.util.List;
+import com.pickpick.controller.dto.ChannelSubscriptionRequest;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Sql({"/truncate.sql", "/channel.sql"})
 @DisplayName("채널 기능")
 @SuppressWarnings("NonAsciiCharacters")
 public class ChannelAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 유저_전체_채널_목록_조회() {
-        List<ChannelResponse> list = getWithAuth("/api/channels", 2L)
-                .jsonPath()
-                .getList("channels.", ChannelResponse.class);
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
 
-        assertThat(list.size()).isEqualTo(6);
+        상태코드_200_확인(response);
+        조회된_채널_목록_개수_확인(response, 6);
+    }
+
+    @Test
+    void 채널_구독() {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        Long channelIdToSubscribe = unsubscribedChannelIds.get(0);
+        ExtractableResponse<Response> subscriptionResponse = 구독_요청(channelIdToSubscribe);
+
+        상태코드_200_확인(subscriptionResponse);
+        채널_구독_완료_확인(channelIdToSubscribe);
+    }
+
+    @Test
+    void 채널_구독_취소() {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        Long channelIdToSubscribe = unsubscribedChannelIds.get(0);
+        Long channelIdToUnSubscribe = unsubscribedChannelIds.get(1);
+
+        구독_요청(channelIdToSubscribe);
+        구독_요청(channelIdToUnSubscribe);
+
+        ExtractableResponse<Response> unsubscribeResponse = 구독_취소_요청(channelIdToUnSubscribe);
+
+        상태코드_200_확인(unsubscribeResponse);
+        채널_구독_취소_확인(channelIdToUnSubscribe);
+    }
+
+    protected ExtractableResponse<Response> 유저_전체_채널_목록_조회_요청() {
+        return getWithAuth("/api/channels", 2L);
+    }
+
+    protected List<Long> 구독중이_아닌_채널_id_목록_추출(ExtractableResponse<Response> response) {
+        return response.jsonPath()
+                .getList("channels.", ChannelResponse.class)
+                .stream()
+                .filter(it -> !it.isSubscribed())
+                .map(ChannelResponse::getId)
+                .collect(Collectors.toList());
+    }
+
+    protected ExtractableResponse<Response> 구독_요청(final Long channelId) {
+        ChannelSubscriptionRequest channelSubscriptionRequest = new ChannelSubscriptionRequest(channelId);
+        return postWithAuth("/api/channel-subscription", channelSubscriptionRequest, 2L);
+    }
+
+    private ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
+        return deleteWithAuth("/api/channel-subscription/" + channelId, 2L);
+    }
+
+    private void 채널_구독_완료_확인(final Long channelIdToSubscribe) {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        assertThat(unsubscribedChannelIds).doesNotContain(channelIdToSubscribe);
+    }
+
+    private void 채널_구독_취소_확인(final Long channelIdToUnSubscribe) {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        assertThat(unsubscribedChannelIds).contains(channelIdToUnSubscribe);
+    }
+
+    private void 조회된_채널_목록_개수_확인(final ExtractableResponse<Response> response, final int expectedSize) {
+        assertThat(response.jsonPath().getList("channels.", ChannelResponse.class)).hasSize(expectedSize);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
@@ -18,6 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("NonAsciiCharacters")
 public class ChannelAcceptanceTest extends AcceptanceTest {
 
+    protected static final String API_CHANNEL_SUBSCRIPTION = "/api/channel-subscription";
+
     @Test
     void 유저_전체_채널_목록_조회() {
         ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
@@ -70,11 +72,11 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
 
     protected ExtractableResponse<Response> 구독_요청(final Long channelId) {
         ChannelSubscriptionRequest channelSubscriptionRequest = new ChannelSubscriptionRequest(channelId);
-        return postWithAuth("/api/channel-subscription", channelSubscriptionRequest, 2L);
+        return postWithAuth(API_CHANNEL_SUBSCRIPTION, channelSubscriptionRequest, 2L);
     }
 
     private ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return deleteWithAuth("/api/channel-subscription/" + channelId, 2L);
+        return deleteWithAuth(API_CHANNEL_SUBSCRIPTION + "/" + channelId, 2L);
     }
 
     private void 채널_구독_완료_확인(final Long channelIdToSubscribe) {

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
@@ -1,0 +1,85 @@
+package com.pickpick.acceptance;
+
+import com.pickpick.controller.dto.ChannelOrderRequest;
+import com.pickpick.controller.dto.ChannelSubscriptionResponse;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Sql({"/truncate.sql", "/channel.sql"})
+@DisplayName("채널 구독 기능")
+@SuppressWarnings("NonAsciiCharacters")
+class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
+
+    Long channelIdToSubscribe1;
+    Long channelIdToSubscribe2;
+
+    @BeforeEach
+    void subscribe() {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        channelIdToSubscribe1 = unsubscribedChannelIds.get(0);
+        channelIdToSubscribe2 = unsubscribedChannelIds.get(1);
+
+        구독_요청(channelIdToSubscribe1);
+        구독_요청(channelIdToSubscribe2);
+    }
+
+    @Test
+    void 채널_구독_조회() {
+        ExtractableResponse<Response> response = 유저_구독_채널_목록_조회_요청();
+
+        상태코드_200_확인(response);
+        구독이_올바른_순서로_조회됨(response, channelIdToSubscribe1, channelIdToSubscribe2);
+    }
+
+    @Test
+    void 구독_채널_순서_변경() {
+        ExtractableResponse<Response> response = 구독_채널_순서_변경_요청();
+
+        상태코드_200_확인(response);
+
+        ExtractableResponse<Response> subscriptionResponse = 유저_구독_채널_목록_조회_요청();
+        구독이_올바른_순서로_조회됨(subscriptionResponse, channelIdToSubscribe2, channelIdToSubscribe1);
+    }
+
+
+    private ExtractableResponse<Response> 유저_구독_채널_목록_조회_요청() {
+        return getWithAuth("/api/channel-subscription", 2L);
+    }
+
+    private void 구독이_올바른_순서로_조회됨(
+            final ExtractableResponse<Response> response,
+            final Long firstOrderedId,
+            final Long secondOrderedId
+    ) {
+        List<ChannelSubscriptionResponse> channels = response.jsonPath()
+                .getList("channels.", ChannelSubscriptionResponse.class);
+
+        assertAll(() -> {
+            assertThat(channels).hasSize(2);
+            assertThat(channels.get(0).getId()).isEqualTo(firstOrderedId);
+            assertThat(channels.get(0).getOrder()).isEqualTo(1);
+            assertThat(channels.get(1).getId()).isEqualTo(secondOrderedId);
+            assertThat(channels.get(1).getOrder()).isEqualTo(2);
+        });
+    }
+
+    private ExtractableResponse<Response> 구독_채널_순서_변경_요청() {
+        List<ChannelOrderRequest> request = List.of(
+                new ChannelOrderRequest(channelIdToSubscribe2, 1),
+                new ChannelOrderRequest(channelIdToSubscribe1, 2)
+        );
+
+        return putWithAuth("/api/channel-subscription", request, 2L);
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
@@ -19,8 +19,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 @SuppressWarnings("NonAsciiCharacters")
 class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
-    Long channelIdToSubscribe1;
-    Long channelIdToSubscribe2;
+    private Long channelIdToSubscribe1;
+    private Long channelIdToSubscribe2;
 
     @BeforeEach
     void subscribe() {
@@ -54,7 +54,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
 
     private ExtractableResponse<Response> 유저_구독_채널_목록_조회_요청() {
-        return getWithAuth("/api/channel-subscription", 2L);
+        return getWithAuth(API_CHANNEL_SUBSCRIPTION, 2L);
     }
 
     private void 구독이_올바른_순서로_조회됨(
@@ -80,6 +80,6 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
                 new ChannelOrderRequest(channelIdToSubscribe1, 2)
         );
 
-        return putWithAuth("/api/channel-subscription", request, 2L);
+        return putWithAuth(API_CHANNEL_SUBSCRIPTION, request, 2L);
     }
 }

--- a/backend/src/test/resources/channel.sql
+++ b/backend/src/test/resources/channel.sql
@@ -1,0 +1,11 @@
+INSERT INTO `channel` (`id`, `name`, `slack_id`)
+VALUES
+(1, '백엔드-잡담', 'C03NNNFNY01'),
+(2, '팀-공지', 'C03N6B801S7'),
+(3, 'test-4기-잡담', 'C03MEKY23L7'),
+(4, 'test-4기-공지사항', 'C03N7SSTUMP'),
+(5, 'test-be-4기-공지', 'C03MV690W2X'),
+(6, 'test-fe-4기-공지', 'C03MEKQJBAB');
+
+insert into member (id, slack_id, thumbnail_url, username)
+values (2, 'U03MC231', 'https://avatars.slack-edge.com/2022-07-02/3764274541009_4d1fa8d13242781486fa_512.png', '써머');

--- a/backend/src/test/resources/truncate.sql
+++ b/backend/src/test/resources/truncate.sql
@@ -1,6 +1,8 @@
 delete
 from message;
 delete
+from channel_subscription;
+delete
 from channel;
 delete
 from member;


### PR DESCRIPTION
## 요약

채널과 채널 구독 인수테스트 추가

## 작업 내용

- channelAcceptanceTest 추가
- channelSubscriptionAcceptanceTest 추가

## 참고 사항

acceptanceTest 에 변경사항이 있습니다.
channel.sql 문이 추가되었습니다.
truncate.sql에 delete channel_subscription을 추가했습니다.

## 관련 이슈

- Close #104 

<br><br>
