### PR TITLE
hotfix: 메시지 조회 API 응답 관련 오류 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
@@ -6,9 +6,11 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.lang.Nullable;
 
+@ToString
 @Setter
 @Getter
 public class SlackMessageRequest {

--- a/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/SlackMessageRequest.java
@@ -6,11 +6,9 @@ import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.ToString;
 import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.lang.Nullable;
 
-@ToString
 @Setter
 @Getter
 public class SlackMessageRequest {

--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -148,10 +148,10 @@ public class MessageService {
 
     private Message getTargetMessage(final List<Message> messages, final boolean needPastMessage) {
         if (needPastMessage) {
-            return messages.get(0);
+            return messages.get(messages.size() - 1);
         }
 
-        return messages.get(messages.size() - 1);
+        return messages.get(0);
     }
 
     private BooleanBuilder createIsLastCondition(final SlackMessageRequest slackMessageRequest) {


### PR DESCRIPTION
## 요약

두 가지 이슈를 대응했습니다.
- `needPastMessage=false` 일 경우 응답값이 시간 오름차순으로 응답되는 오류
- 마지막 메시지임에도 `isLast` 가 `false` 로 응답되는 오류 

<br><br>

## 작업 내용

- QueryDSL 로 데이터를 조회해오는 부분에서 getTimeCondition 오류를 수정했습니다.
- 미래 메시지를 요청한 경우 조회해온 메시지를 Java에서 내림차순으로 재정렬해 응답해주었습니다.
- isLast 로직 관련 타겟 메시지를 가져오는 로직의 오류를 수정했습니다.

<br><br>

## 관련 이슈

- Close #121 
- Close #122

<br><br>
