### PR TITLE
fix: z-index 수정

### DIFF
--- a/frontend/src/components/@shared/Dimmer/style.ts
+++ b/frontend/src/components/@shared/Dimmer/style.ts
@@ -8,7 +8,6 @@ export const Container = styled.div<Props>`
   left: 0;
   right: 0;
   bottom: 0;
-  z-index: 1;
 
   ${({
     theme,

--- a/frontend/src/components/Drawer/style.ts
+++ b/frontend/src/components/Drawer/style.ts
@@ -8,7 +8,6 @@ export const Container = styled.div`
   width: 228px;
   height: calc(100% - 62px);
   padding: 20px 0;
-  z-index: 10;
   border-radius: 0 4px 4px 0;
 
   ${({ theme }: { theme: Theme }) => css`

--- a/frontend/src/components/Dropdown/style.ts
+++ b/frontend/src/components/Dropdown/style.ts
@@ -2,6 +2,5 @@ import styled from "styled-components";
 
 export const Container = styled.div`
   position: relative;
-  z-index: 2;
   width: fit-content;
 `;

--- a/frontend/src/components/layouts/Navigation/style.ts
+++ b/frontend/src/components/layouts/Navigation/style.ts
@@ -6,12 +6,11 @@ export const Container = styled.nav`
   bottom: 0;
   left: 0;
   right: 0;
-  z-index: 3;
   height: 62px;
-
   display: flex;
   justify-content: space-around;
   padding: 5px;
+  z-index: 1;
   background-color: ${({ theme }: { theme: Theme }) =>
     `${theme.COLOR.BACKGROUND.SECONDARY}`};
 `;


### PR DESCRIPTION

## 요약
-  z-index 수정

<br><br>

## 작업 내용
- Dimmer, Drawer, Dropdown z-index 제거
- Navigation z-index 수정

<img width="1437" alt="스크린샷 2022-07-20 오전 11 05 41" src="https://user-images.githubusercontent.com/61469664/179880200-9d882b50-25b6-4d59-80b8-251e63988e6d.png">

기존에 위와 같이 DropDown 의 z index와 Dimmer 의 z-index 의 우선순위가 충돌되는 문제 해결

 
<br><br>

## 참고 사항
최대한 z-index 를 사용하지 않는 것이, 추후에 쌓임맥락을 관리할 때 간편할거라 생각하여,  일단 포털 상관없이 맨 최상단에 와야 하는 Navigation 을 제외하고 z-index를 모두 제거했습니다 ! ! 

### 쌓임 맥락 순서

1. Position 이 absolute 혹은 relative 
2. Position 이 fixed 혹은 sticky 

```
- DropDown - position relative
- Dimmer - position fixed
- Navigation - position fixed & z-index 1 
- Drawer - posiiton fixed
```


### Drawer 가 열리는 경우
- 포탈을 썼기 때문에 아래 div 에 추가 되어 Dropdown 의 position relative 쌓임맥락은 아래로 가게 된다.
- Dimmer , Drawer 두개는 쌓임맥락이 같지만, 순서대로 쌓여서  Drawer 가 더 먼저 오게 된다.
- Navigation 은 z-index 를 1로 두어 언제나 위에 두게 한다.


### DropDown 이 열리는 경우
- Navigation의 쌓임 맥락 > DropDown 의 쌓임 맥락 > Dimmer 쌓임맥락 


<br><br>

## 관련 이슈

- Close #114 

<br><br>
