### PR TITLE
feat: 구독 관련 중복 요청 시 예외처리 추가

### DIFF
--- a/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
@@ -1,6 +1,7 @@
 package com.pickpick.controller;
 
-import com.pickpick.exception.DuplicatedSubscriptionException;
+import com.pickpick.exception.SubscriptionDuplicatedException;
+import com.pickpick.exception.SubscriptionNotExistException;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
@@ -11,7 +12,8 @@ public class ControllerAdvice {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler({
-            DuplicatedSubscriptionException.class
+            SubscriptionDuplicatedException.class,
+            SubscriptionNotExistException.class
     })
     public void handleBadRequest() {
     }

--- a/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
@@ -18,6 +18,6 @@ public class ControllerAdvice {
             SubscriptionNotExistException.class
     })
     public void handleBadRequest(final RuntimeException e) {
-        log.error("예외 발생 : " + e.getMessage());
+        log.error("예외 발생 ){}", e.getMessage(), e);
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
@@ -2,11 +2,13 @@ package com.pickpick.controller;
 
 import com.pickpick.exception.SubscriptionDuplicatedException;
 import com.pickpick.exception.SubscriptionNotExistException;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
+@Slf4j
 @RestControllerAdvice
 public class ControllerAdvice {
 
@@ -15,6 +17,7 @@ public class ControllerAdvice {
             SubscriptionDuplicatedException.class,
             SubscriptionNotExistException.class
     })
-    public void handleBadRequest() {
+    public void handleBadRequest(final RuntimeException e) {
+        log.error("예외 발생 : " + e.getMessage());
     }
 }

--- a/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
+++ b/backend/src/main/java/com/pickpick/controller/ControllerAdvice.java
@@ -1,0 +1,18 @@
+package com.pickpick.controller;
+
+import com.pickpick.exception.DuplicatedSubscriptionException;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class ControllerAdvice {
+
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    @ExceptionHandler({
+            DuplicatedSubscriptionException.class
+    })
+    public void handleBadRequest() {
+    }
+}

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelOrderRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelOrderRequest.java
@@ -8,6 +8,9 @@ public class ChannelOrderRequest {
     private Long id;
     private int order;
 
+    public ChannelOrderRequest() {
+    }
+
     public ChannelOrderRequest(Long id, int order) {
         this.id = id;
         this.order = order;

--- a/backend/src/main/java/com/pickpick/controller/dto/ChannelOrderRequest.java
+++ b/backend/src/main/java/com/pickpick/controller/dto/ChannelOrderRequest.java
@@ -8,10 +8,10 @@ public class ChannelOrderRequest {
     private Long id;
     private int order;
 
-    public ChannelOrderRequest() {
+    private ChannelOrderRequest() {
     }
 
-    public ChannelOrderRequest(Long id, int order) {
+    public ChannelOrderRequest(final Long id, final int order) {
         this.id = id;
         this.order = order;
     }

--- a/backend/src/main/java/com/pickpick/exception/DuplicatedSubscriptionException.java
+++ b/backend/src/main/java/com/pickpick/exception/DuplicatedSubscriptionException.java
@@ -1,0 +1,10 @@
+package com.pickpick.exception;
+
+public class DuplicatedSubscriptionException extends RuntimeException {
+
+    private static final String DEFAULT_MESSAGE = "이미 구독 중인 채널입니다.";
+
+    public DuplicatedSubscriptionException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/SubscriptionDuplicatedException.java
+++ b/backend/src/main/java/com/pickpick/exception/SubscriptionDuplicatedException.java
@@ -7,4 +7,8 @@ public class SubscriptionDuplicatedException extends RuntimeException {
     public SubscriptionDuplicatedException() {
         super(DEFAULT_MESSAGE);
     }
+
+    public SubscriptionDuplicatedException(final Long slackId) {
+        super(String.format("%s : %s", DEFAULT_MESSAGE, slackId));
+    }
 }

--- a/backend/src/main/java/com/pickpick/exception/SubscriptionDuplicatedException.java
+++ b/backend/src/main/java/com/pickpick/exception/SubscriptionDuplicatedException.java
@@ -1,10 +1,10 @@
 package com.pickpick.exception;
 
-public class DuplicatedSubscriptionException extends RuntimeException {
+public class SubscriptionDuplicatedException extends RuntimeException {
 
     private static final String DEFAULT_MESSAGE = "이미 구독 중인 채널입니다.";
 
-    public DuplicatedSubscriptionException() {
+    public SubscriptionDuplicatedException() {
         super(DEFAULT_MESSAGE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/SubscriptionNotExistException.java
+++ b/backend/src/main/java/com/pickpick/exception/SubscriptionNotExistException.java
@@ -1,9 +1,14 @@
 package com.pickpick.exception;
 
 public class SubscriptionNotExistException extends RuntimeException {
+
     private static final String DEFAULT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
 
     public SubscriptionNotExistException() {
         super(DEFAULT_MESSAGE);
+    }
+
+    public SubscriptionNotExistException(final Long slackId) {
+        super(String.format("%s : %s", DEFAULT_MESSAGE, slackId));
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/SubscriptionNotExistException.java
+++ b/backend/src/main/java/com/pickpick/exception/SubscriptionNotExistException.java
@@ -1,0 +1,9 @@
+package com.pickpick.exception;
+
+public class SubscriptionNotExistException extends RuntimeException {
+    private static final String DEFAULT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
+
+    public SubscriptionNotExistException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/repository/ChannelSubscriptionRepository.java
@@ -15,13 +15,15 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     void saveAll(Iterable<ChannelSubscription> channelSubscriptions);
 
-    void deleteAllByMemberId(Long memberId);
-
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
     List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
 
     Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderDesc(Long memberId);
+
+    boolean existsByChannelAndMember(Channel channel, Member member);
+
+    void deleteAllByMemberId(Long memberId);
 
     void deleteAllByChannelAndMember(Channel channel, Member member);
 }

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -7,19 +7,19 @@ import com.pickpick.entity.Channel;
 import com.pickpick.entity.ChannelSubscription;
 import com.pickpick.entity.Member;
 import com.pickpick.exception.ChannelNotFoundException;
-import com.pickpick.exception.SubscriptionDuplicatedException;
 import com.pickpick.exception.MemberNotFoundException;
+import com.pickpick.exception.SubscriptionDuplicatedException;
 import com.pickpick.exception.SubscriptionNotExistException;
 import com.pickpick.repository.ChannelRepository;
 import com.pickpick.repository.ChannelSubscriptionRepository;
 import com.pickpick.repository.MemberRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @Service
@@ -90,7 +90,7 @@ public class ChannelSubscriptionService {
 
     private void validateDuplicatedSubscription(final Channel channel, final Member member) {
         if (channelSubscriptions.existsByChannelAndMember(channel, member)) {
-            throw new SubscriptionDuplicatedException();
+            throw new SubscriptionDuplicatedException(channel.getId());
         }
     }
 
@@ -140,7 +140,7 @@ public class ChannelSubscriptionService {
 
     private void validateSubscriptionExist(final Channel channel, final Member member) {
         if (!channelSubscriptions.existsByChannelAndMember(channel, member)) {
-            throw new SubscriptionNotExistException();
+            throw new SubscriptionNotExistException(channel.getId());
         }
     }
 }

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -7,8 +7,9 @@ import com.pickpick.entity.Channel;
 import com.pickpick.entity.ChannelSubscription;
 import com.pickpick.entity.Member;
 import com.pickpick.exception.ChannelNotFoundException;
-import com.pickpick.exception.DuplicatedSubscriptionException;
+import com.pickpick.exception.SubscriptionDuplicatedException;
 import com.pickpick.exception.MemberNotFoundException;
+import com.pickpick.exception.SubscriptionNotExistException;
 import com.pickpick.repository.ChannelRepository;
 import com.pickpick.repository.ChannelSubscriptionRepository;
 import com.pickpick.repository.MemberRepository;
@@ -18,7 +19,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
@@ -88,9 +88,9 @@ public class ChannelSubscriptionService {
         channelSubscriptions.save(new ChannelSubscription(channel, member, getMaxViewOrder(memberId)));
     }
 
-    private void validateDuplicatedSubscription(Channel channel, Member member) {
+    private void validateDuplicatedSubscription(final Channel channel, final Member member) {
         if (channelSubscriptions.existsByChannelAndMember(channel, member)) {
-            throw new DuplicatedSubscriptionException();
+            throw new SubscriptionDuplicatedException();
         }
     }
 
@@ -133,6 +133,14 @@ public class ChannelSubscriptionService {
         Member member = members.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
+        validateSubscriptionExist(channel, member);
+
         channelSubscriptions.deleteAllByChannelAndMember(channel, member);
+    }
+
+    private void validateSubscriptionExist(final Channel channel, final Member member) {
+        if (!channelSubscriptions.existsByChannelAndMember(channel, member)) {
+            throw new SubscriptionNotExistException();
+        }
     }
 }

--- a/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/service/ChannelSubscriptionService.java
@@ -7,6 +7,7 @@ import com.pickpick.entity.Channel;
 import com.pickpick.entity.ChannelSubscription;
 import com.pickpick.entity.Member;
 import com.pickpick.exception.ChannelNotFoundException;
+import com.pickpick.exception.DuplicatedSubscriptionException;
 import com.pickpick.exception.MemberNotFoundException;
 import com.pickpick.repository.ChannelRepository;
 import com.pickpick.repository.ChannelSubscriptionRepository;
@@ -82,7 +83,15 @@ public class ChannelSubscriptionService {
         Member member = members.findById(memberId)
                 .orElseThrow(MemberNotFoundException::new);
 
+        validateDuplicatedSubscription(channel, member);
+
         channelSubscriptions.save(new ChannelSubscription(channel, member, getMaxViewOrder(memberId)));
+    }
+
+    private void validateDuplicatedSubscription(Channel channel, Member member) {
+        if (channelSubscriptions.existsByChannelAndMember(channel, member)) {
+            throw new DuplicatedSubscriptionException();
+        }
     }
 
     private int getMaxViewOrder(final Long memberId) {

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
@@ -75,7 +75,7 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
         return postWithAuth(API_CHANNEL_SUBSCRIPTION, channelSubscriptionRequest, 2L);
     }
 
-    private ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
+    protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
         return deleteWithAuth(API_CHANNEL_SUBSCRIPTION + "/" + channelId, 2L);
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
@@ -7,6 +7,7 @@ import io.restassured.response.Response;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
 import java.util.List;
@@ -50,6 +51,21 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         ExtractableResponse<Response> subscriptionResponse = 유저_구독_채널_목록_조회_요청();
         구독이_올바른_순서로_조회됨(subscriptionResponse, channelIdToSubscribe2, channelIdToSubscribe1);
+    }
+
+    @Test
+    void 구독_중인_채널_다시_구독_요청() {
+        ExtractableResponse<Response> response = 구독_요청(channelIdToSubscribe1);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    @Test
+    void 구독하지_않은_채널_구독_취소() {
+        구독_취소_요청(channelIdToSubscribe1);
+        ExtractableResponse<Response> response = 구독_취소_요청(channelIdToSubscribe1);
+
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
 


### PR DESCRIPTION
## 요약

구독 관련 중복 요청 시 예외처리 추가

## 작업 내용

`POST /api/channel-description`
`DELETE /api/channel-description/{channelId}`
API 호출 시 
- 이미 구독 중인 채널을 다시 구독할 경우 DB에 중복저장되던 버그에 예외처리 추가
- 구독중이지 않은 채널을 구독 취소할 경우 예외처리 추가

## 참고 사항
**1)** @slf4j 를 이용하여 간단하게 로깅 추가했습니다.
<img width="503" alt="image" src="https://user-images.githubusercontent.com/55357130/179885473-47405385-48c6-446e-bd80-8c0e0dadc669.png">

로그로 남은 에러메시지 형식은 **추후 협의하여 수정**하면 좋을 것 같습니다.


**2)** #132 이슈를 반영하여 ChannelOrderRequest에 기본 생성자 추가했습니다. 
<br><br>

## 관련 이슈

- Close #107 
- Close #132 

<br><br>
