### PR TITLE
refactor: 메시지 조회 API 동적 쿼리 생성 로직 리팩터링

### DIFF
--- a/backend/src/main/java/com/pickpick/config/QuerydslConfig.java
+++ b/backend/src/main/java/com/pickpick/config/QuerydslConfig.java
@@ -1,0 +1,19 @@
+package com.pickpick.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/backend/src/main/java/com/pickpick/service/MessageService.java
+++ b/backend/src/main/java/com/pickpick/service/MessageService.java
@@ -16,7 +16,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-import javax.persistence.EntityManager;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -25,21 +24,18 @@ import org.springframework.util.StringUtils;
 @Service
 public class MessageService {
 
-    protected static final int FIRST_INDEX = 0;
-    protected static final int ONE_TO_GET_LAST_INDEX = 1;
-    
-    private final EntityManager entityManager;
-    private final MessageRepository messageRepository;
-    private JPAQueryFactory jpaQueryFactory;
+    private static final int FIRST_INDEX = 0;
+    private static final int ONE_TO_GET_LAST_INDEX = 1;
 
-    public MessageService(final EntityManager entityManager, final MessageRepository messageRepository) {
-        this.entityManager = entityManager;
+    private final MessageRepository messageRepository;
+    private final JPAQueryFactory jpaQueryFactory;
+
+    public MessageService(final MessageRepository messageRepository, final JPAQueryFactory jpaQueryFactory) {
         this.messageRepository = messageRepository;
+        this.jpaQueryFactory = jpaQueryFactory;
     }
 
     public SlackMessageResponses find(final SlackMessageRequest slackMessageRequest) {
-        jpaQueryFactory = new JPAQueryFactory(entityManager);
-
         List<Message> messages = findMessages(slackMessageRequest);
         boolean isLast = isLast(slackMessageRequest, messages);
 

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -56,7 +56,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         "channelIds가 5이고, needPastMessage가 true이고 date가 존재할 경우, 5번 채널의 해당 날짜 보다 과거 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "2022-07-13T19:21:55", "5", "true", "", ""),
                         true,
-                        createExpectedMessageIds(5L, 1L)),
+                        createExpectedMessageIds(6L, 1L)),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 해당 메시지 보다 과거 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "5", "true", "6", ""),


### PR DESCRIPTION
## 요약

- 메시지 조회 API 동적 검색 조건 생성 로직 리팩터링

<br><br>

## 작업 내용

- MessageService 클래스 내 where 절에 들어가던 내용을 리팩터링했습니다
  - 기존 BooleanBuilder를 이용해 하나의 메서드에서 모든 로직 생성하던 부분을 분리해냈습니다
  - BooleanExpression 으로 개별 검증 단위마다 메서드로 분리하여 이를 조합하도록 구현했습니다
  - isLastExpression도 함께 리팩터링 진행했습니다
- 테스트 픽스처 하나 수정했습니다
  - 시간으로 조회할 경우 전달된 시간을 포함하여 검색해야하기 때문에 픽스처를 수정했습니다
  - 가령 7월 1일로 이동하면, 7월1일23시59분59초를 전달하는데, 이때 이 시간도 포함해서 검색해야 하기 때문입니다.
- JpaQueryFactory 를 어디서든 생성자 주입 받을 수 있게 설정을 추가하였습니다

<br><br>

## 참고 사항

- https://jojoldu.tistory.com/372
- https://youtu.be/zMAX7g6rO_Y?t=176

<br><br>

## 관련 이슈

- Close #157 

<br><br>
