### PR TITLE
refactor: 검색어로 메시지 조회시 대소문자 무시하도록 개선, 테스트 픽스처 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -76,7 +76,7 @@ public class MessageService {
 
     private BooleanExpression textContains(final String keyword) {
         if (StringUtils.hasText(keyword)) {
-            return QMessage.message.text.contains(keyword);
+            return QMessage.message.text.containsIgnoreCase(keyword);
         }
 
         return null;

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -68,13 +68,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         false,
                         createExpectedMessageIds(26L, 7L)),
                 Arguments.of(
-                        "channelIds가 5이고, keyword가 A일 경우, 5번 채널의 메시지 중 A가 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
-                        createQueryParams("A", "", "5", "", "", ""),
+                        "channelIds가 5이고, keyword가 text A일 경우, 5번 채널의 메시지 중 text A가 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
+                        createQueryParams("text A", "", "5", "", "", ""),
                         false,
                         createExpectedMessageIds(32L, 13L)),
                 Arguments.of(
-                        "channelIds가 5이고, keyword가 A이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 A가 포함된 메시지 중, 전달된 메시지 ID의 메시지보다 더 과거 메시지 20개를 시간 내림차순으로 응답해야 한다.",
-                        createQueryParams("A", "", "5", "", "13", ""),
+                        "channelIds가 5이고, keyword가 text A이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 text A가 포함된 메시지 중, 전달된 메시지 ID의 메시지보다 더 과거 메시지 20개를 시간 내림차순으로 응답해야 한다.",
+                        createQueryParams("text A", "", "5", "", "13", ""),
                         true,
                         createExpectedMessageIds(12L, 8L))
         );


### PR DESCRIPTION
## 요약

- 메시지 검색어로 조회 시 대소문자 무시하도록 개선
- 테스트 픽스처 일부 수정

<br><br>

## 작업 내용

- QMessage.message.text.contains -> QMessage.message.text.containsIgnoreCase
- SlackMessageRequest.keyword=A -> SlackMessageRequest.keyword=text A

<br><br>

## 참고 사항

Github Actions 으로 빌드 및 테스트를 테스트해보고 있었는데,
두 가지 케이스가 반복적으로 실패가 되고 있어서 확인해보니 실제로 테스트가 깨지고 있었습니다

그로 인해 이번 이슈 및 PR을 생성해 작업을 진행하였고,
해당 작업이 진행될 경우 정상 빌드됨을 확인했습니다

![image](https://user-images.githubusercontent.com/62681566/180836503-1c34a15e-94f6-4b94-aeba-ca8b87c5e030.png)
![image](https://user-images.githubusercontent.com/62681566/180836525-029b942a-843e-4f2a-b31e-1fecc929fcf0.png)


<br><br>

## 관련 이슈

- Close #177 

<br><br>
