### PR TITLE
feat: Github Actions를 이용한 Backend CI 테스트 자동화

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.TOKEN_FOR_SUBMODULE }}
           submodules: recursive
 
       - name: Set up JDK 11

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -1,0 +1,52 @@
+name: Backend Build Test
+
+on:
+  push:
+    branches: [ main ]
+    paths: 'backend/**'
+  pull_request:
+    branches: [ main ]
+    paths: 'backend/**'
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          submodules: recursive
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Set Timezone as Asia/Seoul
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Asia/Seoul
+
+      - name: Grant permission to gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew clean build
+
+      - name: Alert result to Slack
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Github Action Test by Richie
+          fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -1,11 +1,17 @@
-name: Backend Build Test
+name: 줍줍 백엔드 CI 테스트 자동화
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - release/*
+      - develop
     paths: 'backend/**'
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - release/*
+      - develop
     paths: 'backend/**'
 
 defaults:
@@ -18,35 +24,43 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout
+      - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
         with:
-          token: ${{ secrets.TOKEN_FOR_SUBMODULE }}
+          token: ${{ secrets.SUBMODULE_TOKEN }}
           submodules: recursive
 
-      - name: Set up JDK 11
+      - name: JDK 11을 설치합니다
         uses: actions/setup-java@v3
         with:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: Set Timezone as Asia/Seoul
-        uses: zcong1993/setup-timezone@master
-        with:
-          timezone: Asia/Seoul
-
-      - name: Grant permission to gradlew
+      - name: Gradle 명령 실행을 위한 권한을 부여합니다
         run: chmod +x gradlew
 
-      - name: Build with Gradle
-        run: ./gradlew clean build
+      - name: Gradle build를 수행합니다
+        run: ./gradlew build
 
-      - name: Alert result to Slack
+      - name: 테스트 결과를 PR에 코멘트로 등록합니다
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: '**/build/test-results/test/TEST-*.xml'
+
+      - name: 테스트 실패 시, 실패한 코드 라인에 Check 코멘트를 등록합니다
+        uses: mikepenz/action-junit-report@v3
+        if: always()
+        with:
+          report_paths: '**/build/test-results/test/TEST-*.xml'
+          token: ${{ github.token }}
+
+      - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
         with:
           status: ${{ job.status }}
-          author_name: Github Action Test by Richie
+          author_name: 백엔드 빌드 실패 알림
           fields: repo, message, commit, author, action, eventName, ref, workflow, job, took
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-        if: always()
+        if: failure()


### PR DESCRIPTION
## 요약

- .github/workflows/backend-build-test.yml 파일 추가
- 해당 파일 내에 어떤 이벤트 발생 시 어떤 동작을 수행할 지 설정

<br><br>

## 작업 내용

- main 브랜치 내 backend 경로 하위에 merge, push, pr생성, pr 생성 후 코드 추가 이벤트 시 적용
- 수행하는 내용은 clone, jdk 설치, 타임존 설정, gradle build, Slack 알림 으로 구성됨
- woowacourse-teams/2022-pickpick 에 Repository Secret 2개 추가
  - 하나는 서브 모듈 clone을 위한 토큰, 하나는 Slack 메시지 게시를 위한 웹훅 URL 토큰

<br><br>

## 참고 사항

- [Github Action을 이용한 CI 테스트 자동화](https://github.com/woowacourse-teams/2022-pickpick/wiki/Github-Action%EC%9D%84-%EC%9D%B4%EC%9A%A9%ED%95%9C-CI-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EC%9E%90%EB%8F%99%ED%99%94)
- @yeon-06  @JangBomi  마지막에 Approve 하는 분께서 merge 해주셔도 될 것 같습니다!

<br><br>

## 관련 이슈

- Close #179 

<br><br>
