### PR TITLE
refactor: 구독 생성, 삭제 API 스펙 변경

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -13,11 +13,12 @@ import com.pickpick.exception.SubscriptionDuplicateException;
 import com.pickpick.exception.SubscriptionNotExistException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @Service
@@ -65,7 +66,7 @@ public class ChannelSubscriptionService {
 
     @Transactional
     public void save(final ChannelSubscriptionRequest subscriptionRequest, final Long memberId) {
-        Long channelId = subscriptionRequest.getId();
+        Long channelId = subscriptionRequest.getChannelId();
         Channel channel = channels.findById(channelId)
                 .orElseThrow(() -> new ChannelNotFoundException(channelId));
 

--- a/backend/src/main/java/com/pickpick/channel/ui/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/channel/ui/ChannelSubscriptionController.java
@@ -6,17 +6,11 @@ import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponses;
 import com.pickpick.utils.AuthorizationExtractor;
+import org.springframework.web.bind.annotation.*;
+
+import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/channel-subscription")
@@ -51,8 +45,8 @@ public class ChannelSubscriptionController {
         channelSubscriptionService.updateOrders(orderRequests, Long.parseLong(memberId));
     }
 
-    @DeleteMapping("/{channelId}")
-    public void unsubscribeChannel(HttpServletRequest request, @PathVariable Long channelId) {
+    @DeleteMapping
+    public void unsubscribeChannel(HttpServletRequest request, @RequestParam Long channelId) {
         String memberId = AuthorizationExtractor.extract(request);
         channelSubscriptionService.delete(channelId, Long.parseLong(memberId));
     }

--- a/backend/src/main/java/com/pickpick/channel/ui/dto/ChannelSubscriptionRequest.java
+++ b/backend/src/main/java/com/pickpick/channel/ui/dto/ChannelSubscriptionRequest.java
@@ -5,12 +5,12 @@ import lombok.Getter;
 @Getter
 public class ChannelSubscriptionRequest {
 
-    private Long id;
+    private Long channelId;
 
     private ChannelSubscriptionRequest() {
     }
 
-    public ChannelSubscriptionRequest(Long id) {
-        this.id = id;
+    public ChannelSubscriptionRequest(Long channelId) {
+        this.channelId = channelId;
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
@@ -1,16 +1,17 @@
 package com.pickpick.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.pickpick.channel.ui.dto.ChannelResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql({"/truncate.sql", "/channel.sql"})
 @DisplayName("채널 기능")
@@ -75,7 +76,7 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
     }
 
     protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return deleteWithAuth(API_CHANNEL_SUBSCRIPTION + "/" + channelId, 2L);
+        return deleteWithAuth(API_CHANNEL_SUBSCRIPTION + "?channelId=" + channelId, 2L);
     }
 
     private void 채널_구독_완료_확인(final Long channelIdToSubscribe) {


### PR DESCRIPTION
## 요약

구독 생성, 삭제 API 스펙 변경
<br><br>

## 작업 내용

**- 구독시**
POST /api/channel-subscription

{
   "channelId": 1
}

**-구독 해제 시**
DELETE /api/channel-subscription?channelId={channelId}



<br><br>

## 관련 이슈

- Close #181 

<br><br>
