### PR TITLE
feat: 채널명 변경 이벤트 및 채널 삭제 이벤트 적용

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -13,12 +13,11 @@ import com.pickpick.exception.SubscriptionDuplicateException;
 import com.pickpick.exception.SubscriptionNotExistException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
-
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Transactional(readOnly = true)
 @Service

--- a/backend/src/main/java/com/pickpick/channel/domain/Channel.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/Channel.java
@@ -1,5 +1,6 @@
 package com.pickpick.channel.domain;
 
+import com.pickpick.exception.SlackBadRequestException;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.GeneratedValue;
@@ -7,6 +8,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 import javax.persistence.Table;
 import lombok.Getter;
+import org.springframework.util.StringUtils;
 
 @Getter
 @Table(name = "channel")
@@ -32,6 +34,13 @@ public class Channel {
     }
 
     public void changeName(final String name) {
+        validateName(name);
         this.name = name;
+    }
+
+    private void validateName(final String name) {
+        if (!StringUtils.hasText(name)) {
+            throw new SlackBadRequestException(String.format("채널명 변경 - 채널 이름이 유효하지 않습니다. %s", name));
+        }
     }
 }

--- a/backend/src/main/java/com/pickpick/channel/domain/Channel.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/Channel.java
@@ -1,8 +1,12 @@
 package com.pickpick.channel.domain;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
 import lombok.Getter;
-
-import javax.persistence.*;
 
 @Getter
 @Table(name = "channel")

--- a/backend/src/main/java/com/pickpick/channel/domain/Channel.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/Channel.java
@@ -1,12 +1,8 @@
 package com.pickpick.channel.domain;
 
-import javax.persistence.Column;
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
-import javax.persistence.Table;
 import lombok.Getter;
+
+import javax.persistence.*;
 
 @Getter
 @Table(name = "channel")
@@ -28,6 +24,10 @@ public class Channel {
 
     public Channel(final String slackId, final String name) {
         this.slackId = slackId;
+        this.name = name;
+    }
+
+    public void changeName(final String name) {
         this.name = name;
     }
 }

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
@@ -1,9 +1,8 @@
 package com.pickpick.channel.domain;
 
-import org.springframework.data.repository.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
 public interface ChannelRepository extends Repository<Channel, Long> {
 

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
@@ -1,8 +1,9 @@
 package com.pickpick.channel.domain;
 
+import org.springframework.data.repository.Repository;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.repository.Repository;
 
 public interface ChannelRepository extends Repository<Channel, Long> {
 
@@ -15,4 +16,6 @@ public interface ChannelRepository extends Repository<Channel, Long> {
     Optional<Channel> findBySlackId(String slackId);
 
     Optional<Channel> findById(Long id);
+
+    void deleteBySlackId(String slackId);
 }

--- a/backend/src/main/java/com/pickpick/channel/ui/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/channel/ui/ChannelSubscriptionController.java
@@ -6,11 +6,17 @@ import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponses;
 import com.pickpick.utils.AuthorizationExtractor;
-import org.springframework.web.bind.annotation.*;
-
-import javax.servlet.http.HttpServletRequest;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/channel-subscription")

--- a/backend/src/main/java/com/pickpick/exception/SlackBadRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/SlackBadRequestException.java
@@ -1,0 +1,8 @@
+package com.pickpick.exception;
+
+public class SlackBadRequestException extends BadRequestException {
+
+    public SlackBadRequestException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
+++ b/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
@@ -16,11 +16,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class MemberInitializer {
 
-    @Value("${slack.bot-token}")
-    private String slackBotToken;
-
     private final MethodsClient client = Slack.getInstance().methods();
     private final MemberRepository memberRepository;
+    @Value("${slack.bot-token}")
+    private String slackBotToken;
 
     public MemberInitializer(final MemberRepository memberRepository) {
         this.memberRepository = memberRepository;

--- a/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
@@ -1,8 +1,9 @@
 package com.pickpick.message.domain;
 
+import org.springframework.data.repository.Repository;
+
 import java.util.List;
 import java.util.Optional;
-import org.springframework.data.repository.Repository;
 
 public interface MessageRepository extends Repository<Message, Long> {
 
@@ -15,4 +16,6 @@ public interface MessageRepository extends Repository<Message, Long> {
     Optional<Message> findBySlackId(String slackMessageId);
 
     void deleteBySlackId(String slackId);
+
+    void deleteAllByChannelSlackId(String channelSlackId);
 }

--- a/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
@@ -1,9 +1,8 @@
 package com.pickpick.message.domain;
 
-import org.springframework.data.repository.Repository;
-
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.repository.Repository;
 
 public interface MessageRepository extends Repository<Message, Long> {
 

--- a/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
@@ -1,10 +1,9 @@
 package com.pickpick.slackevent.application;
 
 import com.pickpick.exception.SlackEventNotFoundException;
-import lombok.Getter;
-
 import java.util.Arrays;
 import java.util.Map;
+import lombok.Getter;
 
 @Getter
 public enum SlackEvent {

--- a/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
@@ -12,7 +12,8 @@ public enum SlackEvent {
     MESSAGE_CREATED("message", ""),
     MESSAGE_CHANGED("message", "message_changed"),
     MESSAGE_DELETED("message", "message_deleted"),
-    CHANNEL_RENAME("channel_rename", "");
+    CHANNEL_RENAME("channel_rename", ""),
+    CHANNEL_DELETED("channel_deleted", "");
 
     private final String type;
     private final String subtype;

--- a/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
@@ -1,16 +1,18 @@
 package com.pickpick.slackevent.application;
 
 import com.pickpick.exception.SlackEventNotFoundException;
+import lombok.Getter;
+
 import java.util.Arrays;
 import java.util.Map;
-import lombok.Getter;
 
 @Getter
 public enum SlackEvent {
 
     MESSAGE_CREATED("message", ""),
     MESSAGE_CHANGED("message", "message_changed"),
-    MESSAGE_DELETED("message", "message_deleted");
+    MESSAGE_DELETED("message", "message_deleted"),
+    CHANNEL_RENAME("channel_rename", "");
 
     private final String type;
     private final String subtype;

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
@@ -1,0 +1,46 @@
+package com.pickpick.slackevent.application.channel;
+
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.ChannelNotFoundException;
+import com.pickpick.message.domain.MessageRepository;
+import com.pickpick.slackevent.application.SlackEvent;
+import com.pickpick.slackevent.application.SlackEventService;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Map;
+
+@Transactional
+@Service
+public class ChannelDeletedService implements SlackEventService {
+
+    private static final String CHANNEL_SLACK_ID = "channel";
+
+    private final ChannelRepository channels;
+    private final MessageRepository messages;
+
+    public ChannelDeletedService(ChannelRepository channels, MessageRepository messages) {
+        this.channels = channels;
+        this.messages = messages;
+    }
+
+    @Override
+    public void execute(Map<String, Object> requestBody) {
+        String channelSlackId = extractChannelSlackId(requestBody);
+
+        channels.findBySlackId(channelSlackId)
+                .orElseThrow(() -> new ChannelNotFoundException(channelSlackId));
+
+        messages.deleteAllByChannelSlackId(channelSlackId);
+        channels.deleteBySlackId(channelSlackId);
+    }
+
+    private String extractChannelSlackId(final Map<String, Object> requestBody) {
+        return (String) requestBody.get(CHANNEL_SLACK_ID);
+    }
+
+    @Override
+    public boolean isSameSlackEvent(SlackEvent slackEvent) {
+        return false;
+    }
+}

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
@@ -1,7 +1,6 @@
 package com.pickpick.slackevent.application.channel;
 
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.ChannelNotFoundException;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
@@ -26,9 +25,6 @@ public class ChannelDeletedService implements SlackEventService {
     @Override
     public void execute(final Map<String, Object> requestBody) {
         String channelSlackId = extractChannelSlackId(requestBody);
-
-        channels.findBySlackId(channelSlackId)
-                .orElseThrow(() -> new ChannelNotFoundException(channelSlackId));
 
         messages.deleteAllByChannelSlackId(channelSlackId);
         channels.deleteBySlackId(channelSlackId);

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
@@ -5,10 +5,9 @@ import com.pickpick.exception.ChannelNotFoundException;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.util.Map;
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Service;
 
 @Transactional
 @Service

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
@@ -25,7 +25,7 @@ public class ChannelDeletedService implements SlackEventService {
     }
 
     @Override
-    public void execute(Map<String, Object> requestBody) {
+    public void execute(final Map<String, Object> requestBody) {
         String channelSlackId = extractChannelSlackId(requestBody);
 
         channels.findBySlackId(channelSlackId)
@@ -40,7 +40,7 @@ public class ChannelDeletedService implements SlackEventService {
     }
 
     @Override
-    public boolean isSameSlackEvent(SlackEvent slackEvent) {
-        return false;
+    public boolean isSameSlackEvent(final SlackEvent slackEvent) {
+        return SlackEvent.CHANNEL_DELETED == slackEvent;
     }
 }

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
@@ -24,7 +24,7 @@ public class ChannelRenameService implements SlackEventService {
     }
 
     @Override
-    public void execute(Map<String, Object> requestBody) {
+    public void execute(final Map<String, Object> requestBody) {
         SlackChannelRenameDto slackChannelRenameDto = convert(requestBody);
 
         Channel channel = channels.findBySlackId(slackChannelRenameDto.getSlackId())
@@ -43,7 +43,7 @@ public class ChannelRenameService implements SlackEventService {
     }
 
     @Override
-    public boolean isSameSlackEvent(SlackEvent slackEvent) {
+    public boolean isSameSlackEvent(final SlackEvent slackEvent) {
         return SlackEvent.CHANNEL_RENAME == slackEvent;
     }
 }

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
@@ -1,0 +1,49 @@
+package com.pickpick.slackevent.application.channel;
+
+import com.pickpick.channel.domain.Channel;
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.ChannelNotFoundException;
+import com.pickpick.slackevent.application.SlackEvent;
+import com.pickpick.slackevent.application.SlackEventService;
+import com.pickpick.slackevent.application.channel.dto.SlackChannelRenameDto;
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+import java.util.Map;
+
+@Transactional
+@Service
+public class ChannelRenameService implements SlackEventService {
+
+    private static final String CHANNEL = "channel";
+
+    private final ChannelRepository channels;
+
+    public ChannelRenameService(ChannelRepository channels) {
+        this.channels = channels;
+    }
+
+    @Override
+    public void execute(Map<String, Object> requestBody) {
+        SlackChannelRenameDto slackChannelRenameDto = convert(requestBody);
+
+        Channel channel = channels.findBySlackId(slackChannelRenameDto.getSlackId())
+                .orElseThrow(() -> new ChannelNotFoundException(slackChannelRenameDto.getSlackId()));
+
+        channel.changeName(slackChannelRenameDto.getNewName());
+    }
+
+    private SlackChannelRenameDto convert(final Map<String, Object> requestBody) {
+        Map<String, String> channel = (Map) requestBody.get(CHANNEL);
+
+        return new SlackChannelRenameDto(
+                channel.get("id"),
+                channel.get("name")
+        );
+    }
+
+    @Override
+    public boolean isSameSlackEvent(SlackEvent slackEvent) {
+        return SlackEvent.CHANNEL_RENAME == slackEvent;
+    }
+}

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
@@ -6,10 +6,9 @@ import com.pickpick.exception.ChannelNotFoundException;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
 import com.pickpick.slackevent.application.channel.dto.SlackChannelRenameDto;
-import org.springframework.stereotype.Service;
-
-import javax.transaction.Transactional;
 import java.util.Map;
+import javax.transaction.Transactional;
+import org.springframework.stereotype.Service;
 
 @Transactional
 @Service

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
@@ -15,6 +15,8 @@ import org.springframework.stereotype.Service;
 public class ChannelRenameService implements SlackEventService {
 
     private static final String CHANNEL = "channel";
+    private static final String ID = "id";
+    private static final String NAME = "name";
 
     private final ChannelRepository channels;
 
@@ -36,8 +38,8 @@ public class ChannelRenameService implements SlackEventService {
         Map<String, String> channel = (Map) requestBody.get(CHANNEL);
 
         return new SlackChannelRenameDto(
-                channel.get("id"),
-                channel.get("name")
+                channel.get(ID),
+                channel.get(NAME)
         );
     }
 

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/dto/SlackChannelRenameDto.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/dto/SlackChannelRenameDto.java
@@ -1,0 +1,15 @@
+package com.pickpick.slackevent.application.channel.dto;
+
+import lombok.Getter;
+
+@Getter
+public class SlackChannelRenameDto {
+
+    private String slackId;
+    private String newName;
+
+    public SlackChannelRenameDto(final String slackId, final String newName) {
+        this.slackId = slackId;
+        this.newName = newName;
+    }
+}

--- a/backend/src/main/java/com/pickpick/utils/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/pickpick/utils/AuthorizationExtractor.java
@@ -1,7 +1,7 @@
 package com.pickpick.utils;
 
-import javax.servlet.http.HttpServletRequest;
 import java.util.Enumeration;
+import javax.servlet.http.HttpServletRequest;
 
 public class AuthorizationExtractor {
 

--- a/backend/src/test/java/com/pickpick/PickpickApplicationTests.java
+++ b/backend/src/test/java/com/pickpick/PickpickApplicationTests.java
@@ -6,8 +6,8 @@ import org.springframework.boot.test.context.SpringBootTest;
 @SpringBootTest
 class PickpickApplicationTests {
 
-	@Test
-	void contextLoads() {
-	}
+    @Test
+    void contextLoads() {
+    }
 
 }

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
@@ -1,17 +1,16 @@
 package com.pickpick.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.pickpick.channel.ui.dto.ChannelResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 @Sql({"/truncate.sql", "/channel.sql"})
 @DisplayName("채널 기능")

--- a/backend/src/test/java/com/pickpick/acceptance/EventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/EventAcceptanceTest.java
@@ -19,6 +19,33 @@ class EventAcceptanceTest extends AcceptanceTest {
     private static final String MESSAGE_DELETED = "message_deleted";
     private static final String MESSAGE_CHANGED = "message_changed";
 
+    private static Map<String, Object> createEventRequest(String subtype) {
+        String user = "U03MC231";
+        String timestamp = "1234567890.123456";
+        String text = "메시지 전송!";
+        String slackMessageId = "db8a1f84-8acf-46ab-b93d-85177cee3e97";
+
+        String type = "event_callback";
+        Map<String, Object> event = Map.of(
+                "type", "message",
+                "subtype", subtype,
+                "channel", "ABC1234",
+                "previous_message", Map.of("client_msg_id", slackMessageId),
+                "message", Map.of(
+                        "user", user,
+                        "ts", timestamp,
+                        "text", text,
+                        "client_msg_id", slackMessageId
+                ),
+                "client_msg_id", slackMessageId,
+                "text", text,
+                "user", user,
+                "ts", timestamp
+        );
+
+        return Map.of("type", type, "event", event);
+    }
+
     @Test
     void URL_검증_요청_시_challenge_를_응답한다() {
         // given
@@ -75,32 +102,5 @@ class EventAcceptanceTest extends AcceptanceTest {
 
         // then
         assertThat(messageChangedResponse.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private static Map<String, Object> createEventRequest(String subtype) {
-        String user = "U03MC231";
-        String timestamp = "1234567890.123456";
-        String text = "메시지 전송!";
-        String slackMessageId = "db8a1f84-8acf-46ab-b93d-85177cee3e97";
-
-        String type = "event_callback";
-        Map<String, Object> event = Map.of(
-                "type", "message",
-                "subtype", subtype,
-                "channel", "ABC1234",
-                "previous_message", Map.of("client_msg_id", slackMessageId),
-                "message", Map.of(
-                        "user", user,
-                        "ts", timestamp,
-                        "text", text,
-                        "client_msg_id", slackMessageId
-                ),
-                "client_msg_id", slackMessageId,
-                "text", text,
-                "user", user,
-                "ts", timestamp
-        );
-
-        return Map.of("type", type, "event", event);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -1,17 +1,8 @@
 package com.pickpick.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
 import com.pickpick.message.ui.dto.MessageResponses;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
-import java.util.stream.LongStream;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
@@ -19,31 +10,23 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.LongStream;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 @Sql({"/truncate.sql", "/message.sql"})
+@Sql(value = "/truncate.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @DisplayName("메시지 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class MessageAcceptanceTest extends AcceptanceTest {
 
     private static final String API_URL = "/api/messages";
-
-    @MethodSource("methodSource")
-    @ParameterizedTest(name = "{0}")
-    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
-                    final List<Long> expectedMessageIds) {
-        // when
-        ExtractableResponse<Response> response = get(API_URL, request);
-
-        // then
-        MessageResponses messageResponses = response.as(MessageResponses.class);
-
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(messageResponses.isLast()).isEqualTo(expectedIsLast),
-                () -> assertThat(messageResponses.getMessages())
-                        .extracting("id")
-                        .isEqualTo(expectedMessageIds)
-        );
-    }
 
     private static Stream<Arguments> methodSource() {
         return Stream.of(
@@ -98,6 +81,25 @@ class MessageAcceptanceTest extends AcceptanceTest {
                 "needPastMessage", needPastMessage,
                 "messageId", messageId,
                 "messageCount", messageCount
+        );
+    }
+
+    @MethodSource("methodSource")
+    @ParameterizedTest(name = "{0}")
+    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
+                    final List<Long> expectedMessageIds) {
+        // when
+        ExtractableResponse<Response> response = get(API_URL, request);
+
+        // then
+        MessageResponses messageResponses = response.as(MessageResponses.class);
+
+        assertAll(
+                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
+                () -> assertThat(messageResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(messageResponses.getMessages())
+                        .extracting("id")
+                        .isEqualTo(expectedMessageIds)
         );
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -27,6 +27,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
     private static final String API_URL = "/api/messages";
 
+    private static List<Long> createExpectedMessageIds(final Long endInclusive, final Long startInclusive) {
+        return LongStream.rangeClosed(startInclusive, endInclusive)
+                .boxed()
+                .sorted(Comparator.reverseOrder())
+                .collect(Collectors.toList());
+    }
+
     private static Stream<Arguments> methodSource() {
         return Stream.of(
                 Arguments.of(
@@ -60,13 +67,6 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         true,
                         createExpectedMessageIds(12L, 8L))
         );
-    }
-
-    private static List<Long> createExpectedMessageIds(final Long endInclusive, final Long startInclusive) {
-        return LongStream.rangeClosed(startInclusive, endInclusive)
-                .boxed()
-                .sorted(Comparator.reverseOrder())
-                .collect(Collectors.toList());
     }
 
     private static Map<String, String> createQueryParams(

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -1,24 +1,23 @@
 package com.pickpick.acceptance;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.pickpick.message.ui.dto.MessageResponses;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.context.jdbc.Sql;
-
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/truncate.sql", "/message.sql"})
 @Sql(value = "/truncate.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)

--- a/backend/src/test/java/com/pickpick/channel/domain/ChannelTest.java
+++ b/backend/src/test/java/com/pickpick/channel/domain/ChannelTest.java
@@ -1,0 +1,24 @@
+package com.pickpick.channel.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.pickpick.exception.SlackBadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+
+class ChannelTest {
+
+    @DisplayName("채널 이름은 빈 문자열, 또는 null로 변경할 수 없다")
+    @NullAndEmptySource
+    @ParameterizedTest
+    void changeName(String invalidName) {
+        // given
+        Channel channel = new Channel("slackId", "채널 이름");
+
+        // when & then
+        assertThatThrownBy(() -> channel.changeName(invalidName))
+                .isInstanceOf(SlackBadRequestException.class)
+                .hasMessageContaining("채널 이름이 유효하지 않습니다");
+    }
+}

--- a/backend/src/test/java/com/pickpick/message/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/MessageServiceTest.java
@@ -31,6 +31,20 @@ class MessageServiceTest {
         this.messageService = messageService;
     }
 
+    private static Stream<Arguments> slackMessageRequest() {
+        return Stream.of(
+                Arguments.of(
+                        "5번 채널에서 메시지ID가 1인 메시지 이후에 작성된 메시지 7개 조회",
+                        getSlackMessageRequest(),
+                        List.of(8L, 7L, 6L, 5L, 4L, 3L, 2L),
+                        false)
+        );
+    }
+
+    private static MessageRequest getSlackMessageRequest() {
+        return new MessageRequest("", "", List.of(5L), false, 1L, 7);
+    }
+
     @DisplayName("메시지 조회 요청에 따른 메시지가 응답된다")
     @MethodSource("slackMessageRequest")
     @ParameterizedTest(name = "{0}")
@@ -49,19 +63,5 @@ class MessageServiceTest {
                 () -> assertThat(messages).extracting("id").isEqualTo(expectedMessageIds),
                 () -> assertThat(last).isEqualTo(expectedLast)
         );
-    }
-
-    private static Stream<Arguments> slackMessageRequest() {
-        return Stream.of(
-                Arguments.of(
-                        "5번 채널에서 메시지ID가 1인 메시지 이후에 작성된 메시지 7개 조회",
-                        getSlackMessageRequest(),
-                        List.of(8L, 7L, 6L, 5L, 4L, 3L, 2L),
-                        false)
-        );
-    }
-
-    private static MessageRequest getSlackMessageRequest() {
-        return new MessageRequest("", "", List.of(5L), false, 1L, 7);
     }
 }

--- a/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
@@ -1,18 +1,17 @@
 package com.pickpick.slackevent;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.pickpick.exception.SlackEventNotFoundException;
 import com.pickpick.slackevent.application.SlackEvent;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.Map;
-import java.util.stream.Stream;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SlackEventTest {
 

--- a/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
@@ -1,19 +1,32 @@
 package com.pickpick.slackevent;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
 import com.pickpick.exception.SlackEventNotFoundException;
 import com.pickpick.slackevent.application.SlackEvent;
-import java.util.Map;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 
+import java.util.Map;
+import java.util.stream.Stream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 class SlackEventTest {
+
+    private static Stream<Arguments> methodSource() {
+        return Stream.of(
+                Arguments.of(Map.of("event", Map.of("type", "message")), SlackEvent.MESSAGE_CREATED),
+                Arguments.of(Map.of("event", Map.of("type", "message", "subtype", "message_changed")),
+                        SlackEvent.MESSAGE_CHANGED),
+                Arguments.of(Map.of("event", Map.of("type", "message", "subtype", "message_deleted")),
+                        SlackEvent.MESSAGE_DELETED),
+                Arguments.of(Map.of("event", Map.of("type", "channel_rename")), SlackEvent.CHANNEL_RENAME),
+                Arguments.of(Map.of("event", Map.of("type", "channel_deleted")), SlackEvent.CHANNEL_DELETED)
+        );
+    }
 
     @DisplayName("type과 subtype에 따라 SlackEvent 탐색")
     @ParameterizedTest
@@ -24,16 +37,6 @@ class SlackEventTest {
 
         // then
         assertThat(actual).isEqualTo(expected);
-    }
-
-    private static Stream<Arguments> methodSource() {
-        return Stream.of(
-                Arguments.of(Map.of("event", Map.of("type", "message")), SlackEvent.MESSAGE_CREATED),
-                Arguments.of(Map.of("event", Map.of("type", "message", "subtype", "message_changed")),
-                        SlackEvent.MESSAGE_CHANGED),
-                Arguments.of(Map.of("event", Map.of("type", "message", "subtype", "message_deleted")),
-                        SlackEvent.MESSAGE_DELETED)
-        );
     }
 
     @DisplayName("존재하지 않는 SlackEvent type일 경우 예외 발생")

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -80,7 +80,7 @@ class ChannelDeletedServiceTest {
 
     @DisplayName("채널 삭제 이벤트가 전달되었지만 일치하는 채널 아이디가 존재하지 않으면 예외가 발생한다")
     @Test
-    void exceptionOccursWhenMatchedChannelIdDoesNotExistOnChannelDeletedEvent() {
+    void throwExceptionWhenChannelDoesNotExisted() {
         // given
         channels.save(SAMPLE_CHANNEL);
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -1,12 +1,10 @@
 package com.pickpick.slackevent.application.channel;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.ChannelNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -76,19 +74,5 @@ class ChannelDeletedServiceTest {
                 () -> assertThat(channels.findAll()).isEmpty(),
                 () -> assertThat(messages.findAll()).isEmpty()
         );
-    }
-
-    @DisplayName("채널 삭제 이벤트가 전달되었지만 일치하는 채널 아이디가 존재하지 않으면 예외가 발생한다")
-    @Test
-    void throwExceptionWhenChannelDoesNotExisted() {
-        // given
-        Map<String, Object> request = Map.of(
-                "type", "channel_deleted",
-                "channel", "존재하지 않는 채널 Slack ID"
-        );
-
-        // when & then
-        assertThatThrownBy(() -> channelDeletedService.execute(request))
-                .isInstanceOf(ChannelNotFoundException.class);
     }
 }

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -1,0 +1,98 @@
+package com.pickpick.slackevent.application.channel;
+
+import com.pickpick.channel.domain.Channel;
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.ChannelNotFoundException;
+import com.pickpick.member.domain.Member;
+import com.pickpick.member.domain.MemberRepository;
+import com.pickpick.message.domain.Message;
+import com.pickpick.message.domain.MessageRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Transactional
+@SpringBootTest
+class ChannelDeletedServiceTest {
+
+    private static final Member SAMPLE_MEMBER = new Member("U03MKN0UW", "사용자", "test.png");
+    private static final Channel SAMPLE_CHANNEL = new Channel("ASDFB", "채널");
+    private static final Message SAMPLE_MESSAGE_1 = new Message(
+            "aaaa1f84-8acf-46ab-b93d-85177cee3e97",
+            "첫번째 메시지 전송!",
+            SAMPLE_MEMBER,
+            SAMPLE_CHANNEL,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+    );
+    private static final Message SAMPLE_MESSAGE_2 = new Message(
+            "bbbb1f84-8acf-46ab-b93d-85177cee3e99",
+            "두번째 메시지 전송!",
+            SAMPLE_MEMBER,
+            SAMPLE_CHANNEL,
+            LocalDateTime.now(),
+            LocalDateTime.now()
+    );
+
+    @Autowired
+    private ChannelRepository channels;
+
+    @Autowired
+    private MessageRepository messages;
+
+    @Autowired
+    private MemberRepository members;
+
+    @Autowired
+    private ChannelDeletedService channelDeletedService;
+
+    @DisplayName("채널 삭제 이벤트가 전달되면 채널과 메시지들이 삭제된다")
+    @Test
+    void channelAndMessagesShouldBeDeletedOnChannelDeletedEvent() {
+        // given
+        channels.save(SAMPLE_CHANNEL);
+        members.save(SAMPLE_MEMBER);
+        messages.save(SAMPLE_MESSAGE_1);
+        messages.save(SAMPLE_MESSAGE_2);
+
+        Map<String, Object> request = Map.of(
+                "type", "channel_deleted",
+                "channel", SAMPLE_CHANNEL.getSlackId()
+        );
+
+        // when
+        channelDeletedService.execute(request);
+
+        //then
+        assertAll(
+                () -> assertThat(channels.findAll()).isEmpty(),
+                () -> assertThat(messages.findAll()).isEmpty()
+        );
+    }
+
+    @DisplayName("채널 삭제 이벤트가 전달되었지만 일치하는 채널 아이디가 존재하지 않으면 예외가 발생한다")
+    @Test
+    void exceptionOccursWhenMatchedChannelIdDoesNotExistOnChannelDeletedEvent() {
+        // given
+        channels.save(SAMPLE_CHANNEL);
+
+        String notExistChannelId = "존재하지 않는 채널 Slack ID";
+        Map<String, Object> request = Map.of(
+                "type", "channel_deleted",
+                "channel", notExistChannelId
+        );
+
+        // when & then
+        assertThatThrownBy(() -> channelDeletedService.execute(request))
+                .isInstanceOf(ChannelNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -1,5 +1,9 @@
 package com.pickpick.slackevent.application.channel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
 import com.pickpick.exception.ChannelNotFoundException;
@@ -7,18 +11,13 @@ import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
+import java.time.LocalDateTime;
+import java.util.Map;
+import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import javax.transaction.Transactional;
-import java.time.LocalDateTime;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertAll;
 
 @Transactional
 @SpringBootTest

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -82,12 +82,9 @@ class ChannelDeletedServiceTest {
     @Test
     void throwExceptionWhenChannelDoesNotExisted() {
         // given
-        channels.save(SAMPLE_CHANNEL);
-
-        String notExistChannelId = "존재하지 않는 채널 Slack ID";
         Map<String, Object> request = Map.of(
                 "type", "channel_deleted",
-                "channel", notExistChannelId
+                "channel", "존재하지 않는 채널 Slack ID"
         );
 
         // when & then

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
@@ -1,0 +1,69 @@
+package com.pickpick.slackevent.application.channel;
+
+import com.pickpick.channel.domain.Channel;
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.ChannelNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import javax.transaction.Transactional;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@Transactional
+@SpringBootTest
+class ChannelRenameServiceTest {
+
+    @Autowired
+    private ChannelRepository channels;
+
+    @Autowired
+    private ChannelRenameService channelRenameService;
+
+    @DisplayName("채널 이름 변경 이벤트가 전달되면 채널 이름이 변경된다")
+    @Test
+    void channelNameShouldBeChangedOnChannelRenameEvent() {
+        // given
+        Channel channel = new Channel("slackId", "channelName");
+        channels.save(channel);
+
+        String expectedChannelName = "변경된 채널 이름";
+        Map<String, Object> request = Map.of(
+                "type", "channel_rename",
+                "channel", Map.of(
+                        "id", channel.getSlackId(),
+                        "name", expectedChannelName,
+                        "created", "1234567890")
+        );
+
+        // when
+        channelRenameService.execute(request);
+
+        // then
+        Channel renamedChannel = channels.findById(channel.getId())
+                .orElseThrow(() -> new ChannelNotFoundException(channel.getId()));
+
+        assertThat(renamedChannel.getName()).isEqualTo(expectedChannelName);
+    }
+
+    @DisplayName("채널 이름 변경 이벤트가 전달되었지만 해당 채널이 존재하지 않으면 예외가 발생한다")
+    @Test
+    void exceptionOccursWhenMatchedChannelDoesNotExist() {
+        // given
+        Map<String, Object> request = Map.of(
+                "type", "channel_rename",
+                "channel", Map.of(
+                        "id", "NOT_EXIST_CHANNEL_SLACK_ID",
+                        "name", "NAME CHANGE REQUEST VALUE",
+                        "created", "1234567890")
+        );
+
+        // when & then
+        assertThatThrownBy(() -> channelRenameService.execute(request))
+                .isInstanceOf(ChannelNotFoundException.class);
+    }
+}

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
@@ -1,18 +1,17 @@
 package com.pickpick.slackevent.application.channel;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
 import com.pickpick.exception.ChannelNotFoundException;
+import java.util.Map;
+import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-
-import javax.transaction.Transactional;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
 @SpringBootTest

--- a/backend/src/test/resources/channel.sql
+++ b/backend/src/test/resources/channel.sql
@@ -1,11 +1,10 @@
 INSERT INTO `channel` (`id`, `name`, `slack_id`)
-VALUES
-(1, '백엔드-잡담', 'C03NNNFNY01'),
-(2, '팀-공지', 'C03N6B801S7'),
-(3, 'test-4기-잡담', 'C03MEKY23L7'),
-(4, 'test-4기-공지사항', 'C03N7SSTUMP'),
-(5, 'test-be-4기-공지', 'C03MV690W2X'),
-(6, 'test-fe-4기-공지', 'C03MEKQJBAB');
+VALUES (1, '백엔드-잡담', 'C03NNNFNY01'),
+       (2, '팀-공지', 'C03N6B801S7'),
+       (3, 'test-4기-잡담', 'C03MEKY23L7'),
+       (4, 'test-4기-공지사항', 'C03N7SSTUMP'),
+       (5, 'test-be-4기-공지', 'C03MV690W2X'),
+       (6, 'test-fe-4기-공지', 'C03MEKQJBAB');
 
 insert into member (id, slack_id, thumbnail_url, username)
 values (2, 'U03MC231', 'https://avatars.slack-edge.com/2022-07-02/3764274541009_4d1fa8d13242781486fa_512.png', '써머');


### PR DESCRIPTION
## 요약

채널명 변경 이벤트 및 채널 삭제 이벤트 적용

<br><br>

## 작업 내용

- `ChannelRenameService`
- `ChannelDeletedService`
- `SlackEvent` enum에 이벤트 케이스(`CHANNEL_RENAME`, `CHANNEL_DELETED`) 추가

<br><br>

## 관련 이슈

- Close #186

<br><br>
