### PR TITLE
refactor: react-query queryKey 상수화

### DIFF
--- a/frontend/src/@constants/index.ts
+++ b/frontend/src/@constants/index.ts
@@ -5,3 +5,9 @@ export const PATH_NAME = {
   BOOKMARK: "/bookmark",
   ADD_CHANNEL: "/addChannel",
 };
+
+export const QUERY_KEY = {
+  ALL_CHANNELS: "allChannels",
+  ALL_MESSAGES: "allMessages",
+  SPECIFIC_DATE_MESSAGES: "specificDateMessages",
+};

--- a/frontend/src/pages/AddChannel/index.tsx
+++ b/frontend/src/pages/AddChannel/index.tsx
@@ -9,9 +9,10 @@ import {
   subscribeChannel,
   unsubscribeChannel,
 } from "@src/api/channels";
+import { QUERY_KEY } from "@src/@constants";
 
 function AddChannel() {
-  const { data, refetch } = useQuery("channels", getChannels);
+  const { data, refetch } = useQuery(QUERY_KEY.ALL_CHANNELS, getChannels);
   const { mutate: subscribe } = useMutation(subscribeChannel, {
     onSettled: () => {
       refetch();

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -12,12 +12,13 @@ import { extractResponseMessages } from "@src/@utils";
 import useMessageDate from "@src/hooks/useMessageDate";
 import DateDropDown from "@src/components/DateDropdown";
 import { nextMessagesCallback } from "@src/api/utils";
+import { QUERY_KEY } from "@src/@constants";
 
 function Feed() {
   const { initializeDateArray, isRenderDate } = useMessageDate();
 
   const { data, isLoading, isError, fetchNextPage, hasNextPage } =
-    useInfiniteQuery<ResponseMessages>(["messages"], getMessages(), {
+    useInfiniteQuery<ResponseMessages>(QUERY_KEY.ALL_MESSAGES, getMessages(), {
       getNextPageParam: nextMessagesCallback,
       onSettled: initializeDateArray,
     });

--- a/frontend/src/pages/SpecificDateFeed/index.tsx
+++ b/frontend/src/pages/SpecificDateFeed/index.tsx
@@ -14,6 +14,7 @@ import useMessageDate from "@src/hooks/useMessageDate";
 import DateDropDown from "@src/components/DateDropdown";
 import MessagesLoadingStatus from "@src/components/MessagesLoadingStatus";
 import { extractResponseMessages } from "@src/@utils";
+import { QUERY_KEY } from "@src/@constants";
 
 function SpecificDateFeed() {
   const { key: queryKey } = useLocation();
@@ -28,7 +29,7 @@ function SpecificDateFeed() {
     fetchNextPage,
     hasNextPage,
   } = useInfiniteQuery<ResponseMessages>(
-    ["dateMessages", queryKey],
+    [QUERY_KEY.SPECIFIC_DATE_MESSAGES, queryKey],
     getMessages({
       date,
     }),


### PR DESCRIPTION
## 요약
react-query queryKey 상수화


## 작업 내용

- React Query 에서 사용되는 Query Key 상수화 하여 관리 
- AllChannels, AllMessages, SpecificDateMessgaes 쿼리키 상수화 

추후에 쿼리키가 중복되면 문제 생길 것 같아서 상수로 관리 했습니다.



## 관련 이슈

- Close #185

<br><br>
