### PR TITLE
fix: TimeZone UTC+9 설정

### DIFF
--- a/backend/src/main/java/com/pickpick/config/TimeConfig.java
+++ b/backend/src/main/java/com/pickpick/config/TimeConfig.java
@@ -1,0 +1,14 @@
+package com.pickpick.config;
+
+import java.util.TimeZone;
+import javax.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TimeConfig {
+
+    @PostConstruct
+    public void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/backend/src/main/java/com/pickpick/config/TimeZoneConfig.java
+++ b/backend/src/main/java/com/pickpick/config/TimeZoneConfig.java
@@ -5,7 +5,7 @@ import javax.annotation.PostConstruct;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
-public class TimeConfig {
+public class TimeZoneConfig {
 
     @PostConstruct
     public void setTimeZone() {


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용

- 배포 시점에 디폴트 타임존을 UTC+9 로 설정