### PR TITLE
hotfix: ChannelDeletedServiceTest 테스트 격리 처리

### DIFF
--- a/backend/src/test/java/com/pickpick/controller/ChannelControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/ChannelControllerTest.java
@@ -1,17 +1,17 @@
 package com.pickpick.controller;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
-
-import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
-import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Sql({"/truncate.sql", "/channel.sql", "/channel-subscription.sql"})
 class ChannelControllerTest extends RestDocsTestSupport {
@@ -30,7 +30,8 @@ class ChannelControllerTest extends RestDocsTestSupport {
                         responseFields(
                                 fieldWithPath("channels.[].id").type(JsonFieldType.NUMBER).description("채널 아이디"),
                                 fieldWithPath("channels.[].name").type(JsonFieldType.STRING).description("채널 이름"),
-                                fieldWithPath("channels.[].isSubscribed").type(JsonFieldType.BOOLEAN).description("채널 구독 여부")
+                                fieldWithPath("channels.[].isSubscribed").type(JsonFieldType.BOOLEAN)
+                                        .description("채널 구독 여부")
                         )
                 ));
     }

--- a/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
@@ -1,5 +1,11 @@
 package com.pickpick.controller;
 
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -7,12 +13,6 @@ import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
-
-import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 
 @Sql({"/truncate.sql", "/message.sql"})
@@ -44,13 +44,20 @@ class MessageControllerTest extends RestDocsTestSupport {
                                         parameterWithName("messageCount").optional().description("한 번에 불러올 메시지 개수(default:20)")
                                 ),
                                 responseFields(
-                                        fieldWithPath("messages.[].id").type(JsonFieldType.NUMBER).description("메시지 아이디"),
-                                        fieldWithPath("messages.[].memberId").type(JsonFieldType.NUMBER).description("유저 아이디"),
-                                        fieldWithPath("messages.[].username").type(JsonFieldType.STRING).description("유저 이름"),
-                                        fieldWithPath("messages.[].userThumbnail").type(JsonFieldType.STRING).description("유저 프로필 사진"),
-                                        fieldWithPath("messages.[].text").type(JsonFieldType.STRING).description("메시지 내용"),
-                                        fieldWithPath("messages.[].postedDate").type(JsonFieldType.STRING).description("메시지 게시 날짜"),
-                                        fieldWithPath("messages.[].modifiedDate").type(JsonFieldType.STRING).description("메시지 수정 날짜"),
+                                        fieldWithPath("messages.[].id").type(JsonFieldType.NUMBER)
+                                                .description("메시지 아이디"),
+                                        fieldWithPath("messages.[].memberId").type(JsonFieldType.NUMBER)
+                                                .description("유저 아이디"),
+                                        fieldWithPath("messages.[].username").type(JsonFieldType.STRING)
+                                                .description("유저 이름"),
+                                        fieldWithPath("messages.[].userThumbnail").type(JsonFieldType.STRING)
+                                                .description("유저 프로필 사진"),
+                                        fieldWithPath("messages.[].text").type(JsonFieldType.STRING)
+                                                .description("메시지 내용"),
+                                        fieldWithPath("messages.[].postedDate").type(JsonFieldType.STRING)
+                                                .description("메시지 게시 날짜"),
+                                        fieldWithPath("messages.[].modifiedDate").type(JsonFieldType.STRING)
+                                                .description("메시지 수정 날짜"),
                                         fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부")
                                 )
                         )

--- a/backend/src/test/java/com/pickpick/controller/RestDocsTestSupport.java
+++ b/backend/src/test/java/com/pickpick/controller/RestDocsTestSupport.java
@@ -1,6 +1,9 @@
 package com.pickpick.controller;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,10 +19,6 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
-
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @AutoConfigureMockMvc

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -16,7 +16,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.jdbc.Sql;
 
+@Sql("/truncate.sql")
 @Transactional
 @SpringBootTest
 class ChannelDeletedServiceTest {


### PR DESCRIPTION
## 요약

이전 테스트에서 수행한 테스트 데이터가 남아있어서 테스트가 실패하고 있었습니다.

<br><br>

## 작업 내용

ChannelDeletedServiceTest 클래스에 @Sql 애너테이션을 이용해 truncate 수행하도록 처리

<br><br>
