### PR TITLE
hotfix: TimeUtils 변환 로직 수정, 백엔드 CI 테스트 스크립트 타임존 설정 추가

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -36,6 +36,11 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
+      - name: TimeZone을 Asia/Seoul로 설정합니다
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Asia/Seoul
+
       - name: Gradle 명령 실행을 위한 권한을 부여합니다
         run: chmod +x gradlew
 

--- a/backend/src/main/java/com/pickpick/utils/TimeUtils.java
+++ b/backend/src/main/java/com/pickpick/utils/TimeUtils.java
@@ -6,6 +6,7 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 
 public class TimeUtils {
+
     private TimeUtils() {
     }
 
@@ -14,6 +15,6 @@ public class TimeUtils {
     }
 
     private static LocalDateTime toLocalDateTime(final long unixTime) {
-        return LocalDateTime.ofInstant(Instant.ofEpochSecond(unixTime), ZoneId.systemDefault());
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(unixTime), ZoneId.of("Asia/Seoul"));
     }
 }


### PR DESCRIPTION
## 요약

- 메시지 조회 테스트가 실패하는 원인이 타임존 설정으로 예상하여 작업을 진행하였습니다

<br><br>

## 작업 내용

- TimeUtils 내 toLocalDateTime 메서드에서 변환 시점에 systemDefault 존으로 변환하고 있던 것을 수정했습니다
  - 현재는 systemDefault 에서 Zone.of("Asia/Seoul") 으로 변경되었습니다.
- 백엔드 CI 테스트 자동화 스크립트에서 TimeZone 설정을 step을 추가했습니다.

<br><br>
