### PR TITLE
hotfix: 빌드 명령어에 --info 옵션 추가

### DIFF
--- a/backend/Jenkinsfile
+++ b/backend/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 sh '''
                 cd ./backend
                 chmod +x ./gradlew
-                ./gradlew clean bootJar
+                ./gradlew clean bootJar --info
                 cd ..
                 '''
             }


### PR DESCRIPTION
## 요약

젠킨스 빌드 명령어에 --info 옵션 추가

<br> 

## 작업 내용

젠킨스 빌드 명령어에 디버깅을 위한 --info 옵션 추가

<br>
