### PR TITLE
hoxfix: 젠킨스 빌드 시 테스트 실행하도록 스크립트 변경

### DIFF
--- a/backend/Jenkinsfile
+++ b/backend/Jenkinsfile
@@ -16,7 +16,7 @@ pipeline {
                 sh '''
                 cd ./backend
                 chmod +x ./gradlew
-                ./gradlew clean bootJar -x test --info
+                ./gradlew clean bootJar --info
                 cd ..
                 '''
             }


### PR DESCRIPTION
## 요약

젠킨스 빌드 시 테스트 실행하도록 스크립트 변경

<br>

## 작업 내용

젠킨스 빌드 시 테스트 실행하도록 스크립트에서 `-x test` 옵션 제거  

<br>
