### PR TITLE
refactor: 누락된 타입 보강

### DIFF
--- a/frontend/src/@constants/index.ts
+++ b/frontend/src/@constants/index.ts
@@ -4,7 +4,7 @@ export const PATH_NAME = {
   ALARM: "/alarm",
   BOOKMARK: "/bookmark",
   ADD_CHANNEL: "/add-channel",
-};
+} as const;
 
 export const QUERY_KEY = {
   ALL_CHANNELS: "allChannels",
@@ -12,11 +12,11 @@ export const QUERY_KEY = {
   ALL_MESSAGES: "allMessages",
   SPECIFIC_DATE_MESSAGES: "specificDateMessages",
   BOOKMARKS: "bookmarks",
-};
+} as const;
 
 export const API_ENDPOINT = {
   MESSAGES: "/api/messages",
   CHANNEL: "/api/channels",
   CHANNEL_SUBSCRIPTION: "/api/channel-subscription",
   BOOKMARKS: "/api/bookmarks",
-};
+} as const;

--- a/frontend/src/@types/shared.ts
+++ b/frontend/src/@types/shared.ts
@@ -8,10 +8,13 @@ export interface Message {
   postedDate: string;
   text: string;
   userThumbnail: string;
+  isBookmarked?: boolean;
 }
 
+export type Bookmark = Omit<Message, "isBookmarked">;
+
 export interface ResponseBookmarks {
-  bookmarks: Message[];
+  bookmarks: Bookmark[];
   isLast: boolean;
 }
 export interface ResponseMessages {

--- a/frontend/src/@types/shared.ts
+++ b/frontend/src/@types/shared.ts
@@ -2,6 +2,9 @@ import { LIGHT_MODE_THEME } from "@src/@styles/theme";
 
 export type Theme = typeof LIGHT_MODE_THEME;
 
+export interface StyledDefaultProps {
+  theme: Theme;
+}
 export interface Message {
   id: string;
   username: string;

--- a/frontend/src/@utils/index.ts
+++ b/frontend/src/@utils/index.ts
@@ -1,4 +1,5 @@
 import {
+  Bookmark,
   Message,
   ResponseBookmarks,
   ResponseMessages,
@@ -31,7 +32,7 @@ export const extractResponseMessages = (
 
 export const extractResponseBookmarks = (
   data?: InfiniteData<ResponseBookmarks>
-): Message[] => {
+): Bookmark[] => {
   if (!data) return [];
 
   return data.pages.flatMap((arr) => arr.bookmarks);

--- a/frontend/src/api/bookmarks.ts
+++ b/frontend/src/api/bookmarks.ts
@@ -1,13 +1,14 @@
 import { API_ENDPOINT } from "@src/@constants";
 import { ResponseBookmarks } from "@src/@types/shared";
 import { fetcher } from ".";
+import { getAuthorization } from "./utils";
 
 export const getBookmarks = async ({ pageParam = "" }: any) => {
   const { data } = await fetcher.get<ResponseBookmarks>(
     `${API_ENDPOINT.BOOKMARKS}?messageId=${pageParam}`,
     {
       headers: {
-        authorization: "Bearer 1",
+        ...getAuthorization(),
       },
     }
   );
@@ -20,7 +21,7 @@ export const postBookmark = async (messageId: string) => {
     { messageId },
     {
       headers: {
-        authorization: "Bearer 2004",
+        ...getAuthorization(),
       },
     }
   );
@@ -29,7 +30,7 @@ export const postBookmark = async (messageId: string) => {
 export const deleteBookmark = async (messageId: string) => {
   await fetcher.delete(`${API_ENDPOINT.BOOKMARKS}?messageId=${messageId}`, {
     headers: {
-      authorization: "Bearer 2004",
+      ...getAuthorization(),
     },
   });
 };

--- a/frontend/src/api/bookmarks.ts
+++ b/frontend/src/api/bookmarks.ts
@@ -3,7 +3,13 @@ import { ResponseBookmarks } from "@src/@types/shared";
 import { fetcher } from ".";
 import { getAuthorization } from "./utils";
 
-export const getBookmarks = async ({ pageParam = "" }: any) => {
+interface GetBookmarkParam {
+  pageParam?: string;
+}
+
+export const getBookmarks = async (
+  { pageParam }: GetBookmarkParam = { pageParam: "" }
+) => {
   const { data } = await fetcher.get<ResponseBookmarks>(
     `${API_ENDPOINT.BOOKMARKS}?messageId=${pageParam}`,
     {

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -4,11 +4,12 @@ import {
   ResponseSubscribedChannels,
 } from "@src/@types/shared";
 import { fetcher } from ".";
+import { getAuthorization } from "./utils";
 
 export const getChannels = async () => {
   const { data } = await fetcher.get<ResponseChannels>(API_ENDPOINT.CHANNEL, {
     headers: {
-      authorization: "Bearer 2892",
+      ...getAuthorization(),
     },
   });
 
@@ -20,7 +21,7 @@ export const getSubscribedChannels = async () => {
     API_ENDPOINT.CHANNEL_SUBSCRIPTION,
     {
       headers: {
-        authorization: "Bearer 2892",
+        ...getAuthorization(),
       },
     }
   );
@@ -45,7 +46,7 @@ export const unsubscribeChannel = async (channelId: string) => {
     `${API_ENDPOINT.CHANNEL_SUBSCRIPTION}?channelId=${channelId}`,
     {
       headers: {
-        authorization: "Bearer 2892",
+        ...getAuthorization(),
       },
     }
   );

--- a/frontend/src/api/messages.ts
+++ b/frontend/src/api/messages.ts
@@ -2,9 +2,23 @@ import { API_ENDPOINT } from "@src/@constants";
 import { ResponseMessages } from "@src/@types/shared";
 import { fetcher } from ".";
 
+interface PageParam {
+  messageId: string;
+  needPastMessage: boolean;
+  date: string;
+}
+
+interface FirstParam {
+  date?: string;
+}
+
+interface SecondParam {
+  pageParam?: PageParam;
+}
+
 export const getMessages =
-  ({ date = "" } = {}) =>
-  async ({ pageParam }: any) => {
+  ({ date }: FirstParam = { date: "" }) =>
+  async ({ pageParam }: SecondParam) => {
     if (!pageParam) {
       const { data } = await fetcher.get<ResponseMessages>(
         `${

--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -29,3 +29,7 @@ export const nextBookmarksCallback = ({
     return bookmarks[bookmarks.length - 1]?.id;
   }
 };
+
+export const getAuthorization = () => {
+  return { authorization: "Bearer 2892" };
+};

--- a/frontend/src/components/@layouts/Footer/style.ts
+++ b/frontend/src/components/@layouts/Footer/style.ts
@@ -1,14 +1,14 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.footer`
   padding: 20px 20px 77.5px 20px;
-  background-color: ${({ theme }: { theme: Theme }) =>
+  background-color: ${({ theme }: StyledDefaultProps) =>
     theme.COLOR.BACKGROUND.PRIMARY};
 `;
 
 export const Description = styled.p`
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.CAPTION};
     color: ${theme.COLOR.SECONDARY.DEFAULT};
   `}

--- a/frontend/src/components/@layouts/Header/style.ts
+++ b/frontend/src/components/@layouts/Header/style.ts
@@ -1,12 +1,12 @@
 import styled, { css } from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.header`
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  background-color: ${({ theme }: { theme: Theme }) =>
+  background-color: ${({ theme }: StyledDefaultProps) =>
     theme.COLOR.BACKGROUND.SECONDARY};
   padding: 20px;
   display: flex;
@@ -15,7 +15,7 @@ export const Container = styled.header`
 `;
 
 export const Title = styled.h1`
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.TITLE};
     font-family: ${theme.FONT.SECONDARY};
     color: ${theme.COLOR.TEXT.DEFAULT};

--- a/frontend/src/components/@layouts/LayoutContainer/index.tsx
+++ b/frontend/src/components/@layouts/LayoutContainer/index.tsx
@@ -11,14 +11,14 @@ function LayoutContainer() {
   const hasHeader = () => pathname === "/" || pathname === "/addChannel";
 
   return (
-    <Styled.Container>
+    <div>
       {hasHeader() && <Header />}
       <Styled.Main hasMarginTop={hasHeader()}>
         <Outlet />
       </Styled.Main>
       <Footer />
       <Navigation />
-    </Styled.Container>
+    </div>
   );
 }
 

--- a/frontend/src/components/@layouts/LayoutContainer/style.ts
+++ b/frontend/src/components/@layouts/LayoutContainer/style.ts
@@ -1,7 +1,9 @@
 import styled, { css } from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 
-export const Container = styled.div``;
+interface StyledProps extends StyledDefaultProps {
+  hasMarginTop: boolean;
+}
 
 export const Main = styled.main`
   display: flex;
@@ -10,7 +12,7 @@ export const Main = styled.main`
   align-items: center;
   height: auto;
 
-  ${({ theme, hasMarginTop }: { theme: Theme; hasMarginTop: boolean }) => css`
+  ${({ theme, hasMarginTop }: StyledProps) => css`
     background-color: ${theme.COLOR.BACKGROUND.PRIMARY};
     margin-top: ${hasMarginTop ? "74.5px" : 0};
   `}

--- a/frontend/src/components/@layouts/Navigation/style.ts
+++ b/frontend/src/components/@layouts/Navigation/style.ts
@@ -1,5 +1,5 @@
 import styled from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.nav`
   position: fixed;
@@ -10,6 +10,6 @@ export const Container = styled.nav`
   justify-content: space-around;
   padding: 5px;
   z-index: 1;
-  background-color: ${({ theme }: { theme: Theme }) =>
+  background-color: ${({ theme }: StyledDefaultProps) =>
     `${theme.COLOR.BACKGROUND.SECONDARY}`};
 `;

--- a/frontend/src/components/@shared/Button/style.ts
+++ b/frontend/src/components/@shared/Button/style.ts
@@ -1,14 +1,14 @@
 import styled, { css, CSSProp } from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps, Theme } from "@src/@types/shared";
 import { Props, Size } from ".";
 
 const sizeTable: Record<Size, CSSProp<Theme>> = {
   medium: css`
-    font-size: ${({ theme }: { theme: Theme }) => theme.FONT_SIZE.BODY};
+    font-size: ${({ theme }: StyledDefaultProps) => theme.FONT_SIZE.BODY};
     padding: 0.5rem 1.25rem;
   `,
   large: css`
-    font-size: ${({ theme }: { theme: Theme }) => theme.FONT_SIZE.LARGE_BODY};
+    font-size: ${({ theme }: StyledDefaultProps) => theme.FONT_SIZE.LARGE_BODY};
     padding: 0.75rem 5.875rem;
   `,
 };
@@ -16,15 +16,17 @@ const sizeTable: Record<Size, CSSProp<Theme>> = {
 const colorTable = {
   active: css`
     font-weight: 600;
-    color: ${({ theme }: { theme: Theme }) => theme.COLOR.TEXT.WHITE};
-    background-color: ${({ theme }: { theme: Theme }) =>
-      theme.COLOR.PRIMARY.DEFAULT};
+    ${({ theme }: StyledDefaultProps) => css`
+      color: ${theme.COLOR.TEXT.WHITE};
+      background-color: ${theme.COLOR.PRIMARY.DEFAULT};
+    `}
   `,
   inactive: css`
     font-weight: 400;
-    color: ${({ theme }: { theme: Theme }) => theme.COLOR.TEXT.DEFAULT};
-    background-color: ${({ theme }: { theme: Theme }) =>
-      theme.COLOR.BACKGROUND.TERTIARY};
+    ${({ theme }: StyledDefaultProps) => css`
+    color: ${theme.COLOR.TEXT.DEFAULT};
+    background-color: ${theme.COLOR.BACKGROUND.TERTIARY}};
+  `}
   `,
 };
 

--- a/frontend/src/components/@shared/Dimmer/style.ts
+++ b/frontend/src/components/@shared/Dimmer/style.ts
@@ -1,6 +1,10 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 import { Props } from ".";
+
+interface StyledProps extends StyledDefaultProps {
+  hasBackgroundColor: boolean;
+}
 
 export const Container = styled.div<Props>`
   position: fixed;
@@ -9,13 +13,7 @@ export const Container = styled.div<Props>`
   right: 0;
   bottom: 0;
 
-  ${({
-    theme,
-    hasBackgroundColor,
-  }: {
-    theme: Theme;
-    hasBackgroundColor: boolean;
-  }) => css`
+  ${({ theme, hasBackgroundColor }: StyledProps) => css`
     background-color: ${hasBackgroundColor
       ? theme.COLOR.DIMMER
       : "transparent"};

--- a/frontend/src/components/@shared/IconButton/style.ts
+++ b/frontend/src/components/@shared/IconButton/style.ts
@@ -1,24 +1,24 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 import { Props } from ".";
 
 const iconColorTable = {
   remove: css`
-    background-color: ${({ theme }: { theme: Theme }) =>
+    background-color: ${({ theme }: StyledDefaultProps) =>
       theme.COLOR.CONTAINER.LIGHT_RED};
   `,
   alarm: css`
-    background-color: ${({ theme }: { theme: Theme }) =>
+    background-color: ${({ theme }: StyledDefaultProps) =>
       theme.COLOR.CONTAINER.LIGHT_BLUE};
   `,
   star: css`
-    background-color: ${({ theme }: { theme: Theme }) =>
+    background-color: ${({ theme }: StyledDefaultProps) =>
       theme.COLOR.CONTAINER.LIGHT_ORANGE};
   `,
 };
 
-const backgroundColorGary = css`
-  background-color: ${({ theme }: { theme: Theme }) =>
+const inactiveStyle = css`
+  background-color: ${({ theme }: StyledDefaultProps) =>
     theme.COLOR.BACKGROUND.TERTIARY};
 `;
 
@@ -29,6 +29,6 @@ export const Container = styled.button`
   cursor: pointer;
 
   ${({ icon, isActive }: Pick<Props, "icon" | "isActive">) => css`
-    ${isActive ? iconColorTable[icon] : backgroundColorGary}
+    ${isActive ? iconColorTable[icon] : inactiveStyle}
   `};
 `;

--- a/frontend/src/components/Drawer/style.ts
+++ b/frontend/src/components/Drawer/style.ts
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   position: fixed;
@@ -10,7 +10,7 @@ export const Container = styled.div`
   padding: 20px 0;
   border-radius: 0 4px 4px 0;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.CONTAINER.DEFAULT};
   `}
 `;
@@ -18,7 +18,7 @@ export const Container = styled.div`
 export const Hr = styled.hr`
   padding: 0 10px;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.BORDER};
     height: 1px;
     border: 0;

--- a/frontend/src/components/DropdownMenu/style.ts
+++ b/frontend/src/components/DropdownMenu/style.ts
@@ -1,5 +1,5 @@
 import styled, { css } from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.ul`
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
@@ -10,13 +10,13 @@ export const Container = styled.ul`
   top: 22px;
   left: 0;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.CONTAINER.DEFAULT};
   `}
 `;
 
 export const Option = styled.li`
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.BODY};
   `}
 

--- a/frontend/src/components/DropdownToggle/style.ts
+++ b/frontend/src/components/DropdownToggle/style.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.button`
@@ -7,7 +7,7 @@ export const Container = styled.button`
   border: none;
   padding: 4px 12px;
   width: fit-content;
-  background-color: ${({ theme }: { theme: Theme }) =>
+  background-color: ${({ theme }: StyledDefaultProps) =>
     theme.COLOR.BACKGROUND.SECONDARY};
   border-radius: 50px;
   cursor: pointer;
@@ -15,7 +15,7 @@ export const Container = styled.button`
 `;
 
 export const Text = styled.p`
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.CAPTION};
     color: ${theme.COLOR.TEXT.DEFAULT};
   `}

--- a/frontend/src/components/Loader/style.ts
+++ b/frontend/src/components/Loader/style.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.div`
@@ -19,7 +19,7 @@ export const LeftCircle = styled.div`
 
   animation: moveLeft 2s linear infinite;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.PRIMARY.DEFAULT};
   `}
 
@@ -44,7 +44,7 @@ export const RightCircle = styled.div`
 
   animation: moveRight 2s linear infinite;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.CONTAINER.LIGHT_ORANGE};
   `}
 

--- a/frontend/src/components/MessageCard/style.ts
+++ b/frontend/src/components/MessageCard/style.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.div`
@@ -12,7 +12,7 @@ export const Container = styled.div`
   border-radius: 4px;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.CONTAINER.WHITE};
   `}
 `;
@@ -20,11 +20,11 @@ export const Container = styled.div`
 export const Writer = styled.p`
   text-overflow: ellipsis;
   font-weight: 600;
-  font-size: ${({ theme }: { theme: Theme }) => theme.FONT_SIZE.LARGE_BODY};
+  font-size: ${({ theme }: StyledDefaultProps) => theme.FONT_SIZE.LARGE_BODY};
 `;
 
 export const Date = styled.p`
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.CAPTION};
     color: ${theme.COLOR.TEXT.PLACEHOLDER};
   `}
@@ -35,14 +35,14 @@ export const Message = styled.p`
   white-space: pre-wrap;
   word-break: break-all;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.BODY};
     color: ${theme.COLOR.TEXT.DEFAULT};
   `}
 `;
 
 export const ButtonText = styled.p`
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.CAPTION};
     color: ${theme.COLOR.TEXT.WHITE};
   `}

--- a/frontend/src/components/MessageCardSkeleton/style.ts
+++ b/frontend/src/components/MessageCardSkeleton/style.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { keyframes, css } from "styled-components";
 
 const refresh = keyframes`
@@ -22,7 +22,7 @@ export const Container = styled.div`
   border-radius: 4px;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.CONTAINER.DEFAULT};
   `}
 `;

--- a/frontend/src/components/SearchInput/style.ts
+++ b/frontend/src/components/SearchInput/style.ts
@@ -1,12 +1,12 @@
 import styled, { css } from "styled-components";
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   display: flex;
   align-items: center;
   gap: 6px;
   padding: 10px 14px;
-  background-color: ${({ theme }: { theme: Theme }) =>
+  background-color: ${({ theme }: StyledDefaultProps) =>
     theme.COLOR.BACKGROUND.SECONDARY};
   width: 100%;
   border-radius: 4px;
@@ -17,13 +17,13 @@ export const Input = styled.input`
   outline: none;
   border: none;
   width: 100%;
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     color: ${theme.COLOR.TEXT.DEFAULT};
     font-size: ${theme.FONT_SIZE.PLACEHOLDER};
   `}
 
   &::placeholder {
-    ${({ theme }: { theme: Theme }) => css`
+    ${({ theme }: StyledDefaultProps) => css`
       color: ${theme.COLOR.TEXT.PLACEHOLDER};
       font-size: ${theme.FONT_SIZE.PLACEHOLDER};
     `}

--- a/frontend/src/components/Snackbar/style.ts
+++ b/frontend/src/components/Snackbar/style.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.div`
@@ -15,7 +15,7 @@ export const Container = styled.div`
   justify-content: center;
   z-index: 1;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     color: ${theme.COLOR.TEXT.WHITE};
     background-color: ${theme.COLOR.CONTAINER.LIGHT_RED};
   `}

--- a/frontend/src/hooks/useBookmark.ts
+++ b/frontend/src/hooks/useBookmark.ts
@@ -5,7 +5,14 @@ interface Props {
   handleSettle: () => void;
 }
 
-function useBookmark({ handleSettle }: Props) {
+type Handler = (messageId: string) => () => void;
+
+interface ReturnType {
+  handleAddBookmark: Handler;
+  handleRemoveBookmark: Handler;
+}
+
+function useBookmark({ handleSettle }: Props): ReturnType {
   const { mutate: addBookmark } = useMutation(postBookmark, {
     onSettled: () => {
       handleSettle();

--- a/frontend/src/hooks/useIntersectionObserver.ts
+++ b/frontend/src/hooks/useIntersectionObserver.ts
@@ -1,9 +1,17 @@
-import { useEffect, useRef } from "react";
+import { RefObject, useEffect, useRef } from "react";
 import { Props as InfiniteScrollProps } from "@src/components/@shared/InfiniteScroll";
 
 type Props = Omit<InfiniteScrollProps, "children">;
 
-function useIntersectionObserver({ callback, threshold, endPoint }: Props) {
+interface ReturnType {
+  targetRef: RefObject<HTMLDivElement>;
+}
+
+function useIntersectionObserver({
+  callback,
+  threshold,
+  endPoint,
+}: Props): ReturnType {
   const targetRef = useRef<HTMLDivElement>(null);
   const observer = useRef(
     new IntersectionObserver(onIntersect, {

--- a/frontend/src/hooks/useMessageDate.ts
+++ b/frontend/src/hooks/useMessageDate.ts
@@ -1,6 +1,11 @@
 import { useRef } from "react";
 
-const useMessageDate = () => {
+interface ReturnType {
+  initializeDateArray: () => void;
+  isRenderDate: (postedDate: string) => boolean;
+}
+
+function useMessageDate(): ReturnType {
   const dateArrayRef = useRef<string[]>([]);
 
   const initializeDateArray = () => {
@@ -18,6 +23,6 @@ const useMessageDate = () => {
     initializeDateArray,
     isRenderDate,
   };
-};
+}
 
 export default useMessageDate;

--- a/frontend/src/hooks/useSnackbar.ts
+++ b/frontend/src/hooks/useSnackbar.ts
@@ -1,7 +1,11 @@
 import { snackbarState } from "@src/@atoms";
 import { useRecoilState } from "recoil";
 
-function useSnackbar() {
+interface ReturnType {
+  openSnackbar: (message: string) => void;
+}
+
+function useSnackbar(): ReturnType {
   const [_, setState] = useRecoilState(snackbarState);
 
   const openSnackbar = (message: string) => {

--- a/frontend/src/hooks/useTopScreenEventHandlers.ts
+++ b/frontend/src/hooks/useTopScreenEventHandlers.ts
@@ -8,13 +8,19 @@ interface Props {
   wheelDistanceCriterion: number;
 }
 
+interface ReturnType {
+  onWheel: (event: React.WheelEvent<HTMLDivElement>) => void;
+  onTouchStart: (event: React.TouchEvent<HTMLDivElement>) => void;
+  onTouchEnd: (event: React.TouchEvent<HTMLDivElement>) => void;
+}
+
 function useTopScreenEventHandler({
   isCallable,
   callback,
   scrollOffset,
   touchDistanceCriterion,
   wheelDistanceCriterion,
-}: Props) {
+}: Props): ReturnType {
   const wheelPosition = useRef({ default: 0, move: 0, scroll: 0 });
   const touchPosition = useRef({ start: 0, end: 0 });
   const scrollPosition = useRef({ default: 0 });

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -24,7 +24,7 @@ function Feed() {
       onSettled: initializeDateArray,
     });
 
-  const { handleAddBookmark, handleRemoveBookmark } = useBookmark({
+  const { handleAddBookmark } = useBookmark({
     handleSettle: refetch,
   });
 

--- a/frontend/src/pages/Home/style.ts
+++ b/frontend/src/pages/Home/style.ts
@@ -1,4 +1,4 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.div`
@@ -22,7 +22,7 @@ export const UsageContainer = styled.section`
   align-items: center;
   gap: 40px;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.BACKGROUND.SECONDARY};
   `}
 `;

--- a/frontend/src/pages/NotFound/style.ts
+++ b/frontend/src/pages/NotFound/style.ts
@@ -1,10 +1,10 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Title = styled.h1`
   text-align: center;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.TITLE};
   `}
 `;
@@ -12,7 +12,7 @@ export const Title = styled.h1`
 export const Description = styled.p`
   text-align: center;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.X_LARGE_BODY};
   `}
 `;

--- a/frontend/src/pages/SpecificDateFeed/index.tsx
+++ b/frontend/src/pages/SpecificDateFeed/index.tsx
@@ -49,7 +49,7 @@ function SpecificDateFeed() {
     wheelDistanceCriterion: -10,
   });
 
-  const { handleAddBookmark, handleRemoveBookmark } = useBookmark({
+  const { handleAddBookmark } = useBookmark({
     handleSettle: refetch,
   });
 

--- a/frontend/src/pages/UnexpectedError/style.ts
+++ b/frontend/src/pages/UnexpectedError/style.ts
@@ -1,10 +1,10 @@
-import { Theme } from "@src/@types/shared";
+import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Title = styled.h1`
   text-align: center;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.TITLE};
   `}
 `;
@@ -12,7 +12,7 @@ export const Title = styled.h1`
 export const Description = styled.p`
   text-align: center;
 
-  ${({ theme }: { theme: Theme }) => css`
+  ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.X_LARGE_BODY};
   `}
 `;


### PR DESCRIPTION
## 요약

타입스크립트 누락된 타입 보강

## 작업 내용

원래 커스텀훅 리턴타입만 정의해주려다가, 최대한 보이는대로 타입스크립트 타입 보강했어요.
(옆에 커밋 링크 타고가면 커밋별 확인 가능)

1. 커스텀 훅 리턴 타입 정의 896d80f5f7dda09469711f8902f90ebcb3b6d9c7
2. 상수에 누락된 as const 추가 6b5a0e24ecfe69944b90d190c737c363062527c1
3. getMessages API 요청함수 파라미터 타입 정의 ac7c4eaf61e3a49cc6495579474785ce75d14923
4. getBookmarks API 요청함수 파라미터 타입 정의 7c7d4dbe75841325fe8557e79ec02f33334748c4
5. Styled Component 에서 매번 Theme 이 포함된 타입을 사용처에서 정의해줘야했던 문제 해결 7ec3ccf19d37badcf74ff664d6cb916fc7bb27ec
 ```tsx
### 이전
{theme} : {theme: Theme} 

### 변경 후
{theme} : StyledDefaultProps

- 추가되어야하는 프로퍼티가 있는 경우는 extends 하도록 함 
```

### 그외
1. accessToken Bearer 수동으로 추가해줘야하는것 util 함수로 분리 464a11ad061994ec35324895323da32a9164539b

<br><br>

## 참고 사항
https://ui.toast.com/weekly-pick/ko_20210521

<br><br>

## 관련 이슈

- Close #193 

<br><br>
