### PR TITLE
refactor: MemberInitializer에 빈 주입 및 테스트에서 비활성화  

### DIFF
--- a/backend/src/main/java/com/pickpick/config/SlackConfig.java
+++ b/backend/src/main/java/com/pickpick/config/SlackConfig.java
@@ -2,14 +2,18 @@ package com.pickpick.config;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SlackConfig {
 
+    @Value("${slack.bot-token}")
+    private String token;
+
     @Bean
     public MethodsClient methodsClient() {
-        return Slack.getInstance().methods();
+        return Slack.getInstance().methods(token);
     }
 }

--- a/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
+++ b/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
@@ -27,7 +27,7 @@ public class MemberInitializer {
     @PostConstruct
     void setupMember() throws SlackApiException, IOException {
         List<String> savedSlackIds = findSavedSlackIds();
-        List<Member> currentWorkspaceMembers = getCurrentWorkspaceMembers();
+        List<Member> currentWorkspaceMembers = fetchWorkspaceMembers();
         List<Member> membersToSave = filterMembersToSave(savedSlackIds, currentWorkspaceMembers);
 
         memberRepository.saveAll(membersToSave);
@@ -40,7 +40,7 @@ public class MemberInitializer {
                 .collect(Collectors.toList());
     }
 
-    private List<Member> getCurrentWorkspaceMembers() throws IOException, SlackApiException {
+    private List<Member> fetchWorkspaceMembers() throws IOException, SlackApiException {
         return toMembers(slackClient.usersList(request -> request)
                 .getMembers());
     }

--- a/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
+++ b/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
@@ -42,7 +42,7 @@ public class MemberInitializer {
 
     private List<Member> getCurrentWorkspaceMembers() throws IOException, SlackApiException {
         return toMembers(slackClient.usersList(request -> request)
-                        .getMembers());
+                .getMembers());
     }
 
     private List<Member> filterMembersToSave(final List<String> savedSlackIds,

--- a/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
+++ b/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
@@ -2,7 +2,6 @@ package com.pickpick.member.application;
 
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
-import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.model.User;
@@ -10,18 +9,18 @@ import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import javax.annotation.PostConstruct;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
+@Profile("prod")
 @Component
 public class MemberInitializer {
 
-    private final MethodsClient client = Slack.getInstance().methods();
+    private final MethodsClient slackClient;
     private final MemberRepository memberRepository;
-    @Value("${slack.bot-token}")
-    private String slackBotToken;
 
-    public MemberInitializer(final MemberRepository memberRepository) {
+    public MemberInitializer(final MethodsClient slackClient, final MemberRepository memberRepository) {
+        this.slackClient = slackClient;
         this.memberRepository = memberRepository;
     }
 
@@ -42,8 +41,7 @@ public class MemberInitializer {
     }
 
     private List<Member> getCurrentWorkspaceMembers() throws IOException, SlackApiException {
-        return toMembers(
-                client.usersList(request -> request.token(slackBotToken))
+        return toMembers(slackClient.usersList(request -> request)
                         .getMembers());
     }
 

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
@@ -15,7 +15,6 @@ import com.slack.api.methods.SlackApiException;
 import com.slack.api.model.Conversation;
 import java.io.IOException;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,9 +28,6 @@ public class MessageCreatedService implements SlackEventService {
     private static final String TEXT = "text";
     private static final String CLIENT_MSG_ID = "client_msg_id";
     private static final String CHANNEL = "channel";
-
-    @Value("${slack.bot-token}")
-    private String slackBotToken;
 
     private final MessageRepository messages;
     private final MemberRepository members;
@@ -65,7 +61,7 @@ public class MessageCreatedService implements SlackEventService {
     private Channel createChannel(final String channelSlackId) {
         try {
             Conversation conversation = slackClient.conversationsInfo(
-                    request -> request.token(slackBotToken).channel(channelSlackId)
+                    request -> request.channel(channelSlackId)
             ).getChannel();
 
             Channel channel = toChannel(conversation);


### PR DESCRIPTION
## 요약

- MemberInitailizer를 프로덕션에서만 활성화  
- MethodsClient 빈을 MemberInitailizer에 주입  

<br>

## 작업 내용

- MemberInitailizer를 프로덕션에서만 활성화하도록 `@Profile` 어노테이션 적용  
- MethodsClient 빈을 MemberInitailizer에 주입  
- MethodsClient 주입 받는 곳에서 봇 토큰 설정하던 것을, 애초에 빈 생성할 때 설정하도록 개선  

<br>

## 참고 사항

**[서브모듈 레포 PR](https://github.com/2022-pickpick/security/pull/4) 이 머지 된 이후 머지되어야 합니다!!**

<br>  

## 관련 이슈

- Close #244 #214 

<br>  
