### PR TITLE
feat: 메시지 조회 API 에 channelId가 전달되지 않을 경우 로직 수정

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -59,4 +59,4 @@ operation::channel-subscription-controller-test/update-order-of-subscribed-chann
 
 자세한 예시는 https://github.com/woowacourse-teams/2022-pickpick/wiki/메시지-조회-API-사용법에서 확인
 
-operation::message-controller-test/find-all-message-with-condition[snippets='http-request,request-parameters,http-response,response-fields']
+operation::message-controller-test/find-all-message-with-condition[snippets='http-request,request-headers,request-parameters,http-response,response-fields']

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -17,6 +17,8 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderDesc(Long memberId);
 
+    Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderAsc(Long memberId);
+
     boolean existsByChannelAndMember(Channel channel, Member member);
 
     void deleteAllByMemberId(Long memberId);

--- a/backend/src/main/java/com/pickpick/exception/SubscriptionNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/SubscriptionNotFoundException.java
@@ -1,0 +1,10 @@
+package com.pickpick.exception;
+
+public class SubscriptionNotFoundException extends NotFoundException {
+
+    private static final String DEFAULT_MESSAGE = "해당 멤버가 구독 중인 채널이 없습니다.";
+
+    public SubscriptionNotFoundException(final Long memberId) {
+        super(String.format("%s -> member id: %d", DEFAULT_MESSAGE, memberId));
+    }
+}

--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -1,6 +1,9 @@
 package com.pickpick.message.application;
 
+import com.pickpick.channel.domain.ChannelSubscription;
+import com.pickpick.channel.domain.ChannelSubscriptionRepository;
 import com.pickpick.exception.MessageNotFoundException;
+import com.pickpick.exception.SubscriptionNotFoundException;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.message.domain.QMessage;
@@ -28,21 +31,38 @@ public class MessageService {
     private static final int ONE_TO_GET_LAST_INDEX = 1;
 
     private final MessageRepository messageRepository;
+    private final ChannelSubscriptionRepository channelSubscriptions;
     private final JPAQueryFactory jpaQueryFactory;
 
-    public MessageService(final MessageRepository messageRepository, final JPAQueryFactory jpaQueryFactory) {
+    public MessageService(final MessageRepository messageRepository,
+                          final ChannelSubscriptionRepository channelSubscriptions,
+                          final JPAQueryFactory jpaQueryFactory) {
         this.messageRepository = messageRepository;
+        this.channelSubscriptions = channelSubscriptions;
         this.jpaQueryFactory = jpaQueryFactory;
     }
 
-    public MessageResponses find(final MessageRequest messageRequest) {
-        List<Message> messages = findMessages(messageRequest);
-        boolean isLast = isLast(messageRequest, messages);
+    public MessageResponses find(final Long memberId, final MessageRequest messageRequest) {
+        List<Long> channelIds = findChannelId(memberId, messageRequest);
+
+        List<Message> messages = findMessages(channelIds, messageRequest);
+        boolean isLast = isLast(channelIds, messageRequest, messages);
 
         return toSlackMessageResponse(messages, isLast);
     }
 
-    private List<Message> findMessages(final MessageRequest messageRequest) {
+    private List<Long> findChannelId(final Long memberId, final MessageRequest messageRequest) {
+        if (Objects.nonNull(messageRequest.getChannelIds()) && !messageRequest.getChannelIds().isEmpty()) {
+            return messageRequest.getChannelIds();
+        }
+
+        ChannelSubscription firstSubscription = channelSubscriptions.findFirstByMemberIdOrderByViewOrderAsc(memberId)
+                .orElseThrow(() -> new SubscriptionNotFoundException(memberId));
+
+        return List.of(firstSubscription.getChannelId());
+    }
+
+    private List<Message> findMessages(final List<Long> channelIds, final MessageRequest messageRequest) {
         boolean needPastMessage = messageRequest.isNeedPastMessage();
         int messageCount = messageRequest.getMessageCount();
 
@@ -50,7 +70,7 @@ public class MessageService {
                 .selectFrom(QMessage.message)
                 .leftJoin(QMessage.message.member)
                 .fetchJoin()
-                .where(meetAllConditions(messageRequest))
+                .where(meetAllConditions(channelIds, messageRequest))
                 .orderBy(arrangeDateByNeedPastMessage(needPastMessage))
                 .limit(messageCount)
                 .fetch();
@@ -64,8 +84,8 @@ public class MessageService {
                 .collect(Collectors.toList());
     }
 
-    private BooleanExpression meetAllConditions(final MessageRequest request) {
-        return channelIdsIn(request.getChannelIds())
+    private BooleanExpression meetAllConditions(final List<Long> channelIds, final MessageRequest request) {
+        return channelIdsIn(channelIds)
                 .and(textContains(request.getKeyword()))
                 .and(messageHasText())
                 .and(decideMessageIdOrDate(request.getMessageId(), request.getDate(), request.isNeedPastMessage()));
@@ -134,7 +154,8 @@ public class MessageService {
         return QMessage.message.postedDate.asc();
     }
 
-    private boolean isLast(final MessageRequest messageRequest, final List<Message> messages) {
+    private boolean isLast(final List<Long> channelIds, final MessageRequest messageRequest,
+                           final List<Message> messages) {
         if (messages.isEmpty()) {
             return true;
         }
@@ -142,16 +163,17 @@ public class MessageService {
         Integer result = jpaQueryFactory
                 .selectOne()
                 .from(QMessage.message)
-                .where(meetAllIsLastCondition(messageRequest, messages))
+                .where(meetAllIsLastCondition(channelIds, messageRequest, messages))
                 .fetchFirst();
 
         return Objects.isNull(result);
     }
 
-    private BooleanExpression meetAllIsLastCondition(final MessageRequest request, final List<Message> messages) {
+    private BooleanExpression meetAllIsLastCondition(final List<Long> channelIds, final MessageRequest request,
+                                                     final List<Message> messages) {
         Message targetMessage = findTargetMessage(messages, request.isNeedPastMessage());
 
-        return channelIdsIn(request.getChannelIds())
+        return channelIdsIn(channelIds)
                 .and(textContains(request.getKeyword()))
                 .and(isBeforeOrAfterTarget(targetMessage.getPostedDate(), request.isNeedPastMessage()));
     }

--- a/backend/src/main/java/com/pickpick/message/ui/MessageController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/MessageController.java
@@ -3,6 +3,8 @@ package com.pickpick.message.ui;
 import com.pickpick.message.application.MessageService;
 import com.pickpick.message.ui.dto.MessageRequest;
 import com.pickpick.message.ui.dto.MessageResponses;
+import com.pickpick.utils.AuthorizationExtractor;
+import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,7 +21,11 @@ public class MessageController {
     }
 
     @GetMapping
-    public MessageResponses findSlackMessages(@Valid MessageRequest messageRequest) {
-        return messageService.find(messageRequest);
+    public MessageResponses findSlackMessages(HttpServletRequest httpServletRequest,
+                                              @Valid MessageRequest messageRequest) {
+
+        String memberId = AuthorizationExtractor.extract(httpServletRequest);
+
+        return messageService.find(Long.parseLong(memberId), messageRequest);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -55,19 +55,21 @@ class AcceptanceTest {
                 .extract();
     }
 
-    ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
-        return RestAssured.given()
-                .queryParams(queryParams)
-                .log().all()
+    ExtractableResponse<Response> getWithAuth(final String uri, final Long memberId) {
+        return RestAssured.given().log().all()
+                .header("Authorization", "Bearer " + memberId)
                 .when()
                 .get(uri)
                 .then().log().all()
                 .extract();
     }
 
-    ExtractableResponse<Response> getWithAuth(final String uri, final Long memberId) {
-        return RestAssured.given().log().all()
+    ExtractableResponse<Response> getWithAuthAndParams(final String uri, final Long memberId,
+                                                       final Map<String, Object> params) {
+        return RestAssured.given()
+                .log().all()
                 .header("Authorization", "Bearer " + memberId)
+                .queryParams(params)
                 .when()
                 .get(uri)
                 .then().log().all()

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -55,6 +55,16 @@ class AcceptanceTest {
                 .extract();
     }
 
+    ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
+        return RestAssured.given()
+                .queryParams(queryParams)
+                .log().all()
+                .when()
+                .get(uri)
+                .then().log().all()
+                .extract();
+    }
+
     ExtractableResponse<Response> getWithAuth(final String uri, final Long memberId) {
         return RestAssured.given().log().all()
                 .header("Authorization", "Bearer " + memberId)

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -83,7 +83,12 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         "channelIds가 5이고, keyword가 'jupjup'일 경우, 5번 채널의 메시지 중 'jupjup'이 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("jupjup", "", "5", "", "", ""),
                         true,
-                        createExpectedMessageIds(18L, 14L))
+                        createExpectedMessageIds(18L, 14L)),
+                Arguments.of(
+                        "쿼리 파라미터가 전혀 전달되지 않았을 경우, 회원의 채널 정렬 상 첫번째 채널의 최신 20개 메시지를 작성시간 내림차순으로 응답해야 한다.",
+                        createQueryParams("", "", "", "", "", ""),
+                        false,
+                        createExpectedMessageIds(38L, 19L))
         );
     }
 
@@ -101,8 +106,8 @@ class MessageAcceptanceTest extends AcceptanceTest {
         );
     }
 
-    private static List<Long> createExpectedMessageIds(final Long endInclusive, final Long startInclusive) {
-        return LongStream.rangeClosed(startInclusive, endInclusive)
+    private static List<Long> createExpectedMessageIds(final Long startInclusive, final Long endInclusive) {
+        return LongStream.rangeClosed(endInclusive, startInclusive)
                 .boxed()
                 .sorted(Comparator.reverseOrder())
                 .collect(Collectors.toList());

--- a/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
@@ -1,11 +1,14 @@
 package com.pickpick.controller;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -32,9 +35,13 @@ class MessageControllerTest extends RestDocsTestSupport {
         mockMvc.perform(MockMvcRequestBuilders
                         .get("/api/messages")
                         .params(requestParam)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer 2")
                 )
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(
+                                requestHeaders(
+                                        headerWithName(HttpHeaders.AUTHORIZATION).description("유저 식별 토큰(Bearer)")
+                                ),
                                 requestParameters(
                                         parameterWithName("keyword").optional().description("검색할 키워드"),
                                         parameterWithName("date").optional().description("검색 기준 날짜"),

--- a/backend/src/test/resources/message.sql
+++ b/backend/src/test/resources/message.sql
@@ -1,8 +1,13 @@
 insert into channel (id, name, slack_id)
-values (5, '임시 채널', 'ABC1234');
+values (5, '임시 채널', 'ABC1234'),
+       (3, '공지사항 채널', 'DEF5678');
 
 insert into member (id, slack_id, thumbnail_url, username)
 values (1, 'U03MC231', 'https://summer.png', '써머');
+
+insert into channel_subscription(id, view_order, channel_id, member_id)
+values (1, 2, 3, 1),
+       (2, 1, 5, 1);
 
 insert into message (id, modified_date, posted_date, text, member_id, channel_id, slack_message_id)
 values (1, '2022-07-12 14:21:55', '2022-07-12 14:21:55', 'Sample Text', 1, 5, 'ABC1231'),


### PR DESCRIPTION
## 요약
 
메시지 조회 API에 channelId가 전달되지 않을 경우 로직 수정

<br><br>

## 작업 내용

channelId가 전달되지 않을 경우 memberId로 구독중인 채널들을 조회합니다.
구독 순서 상 최상위의 채널을 기준으로 메시지를 조회합니다.

<br><br>

## 관련 이슈

- Close #255 

<br><br>
