### PR TITLE
feat: 로그인 요청값에 error: access_denied 포함 시 예외 처리

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
@@ -1,11 +1,10 @@
 package com.pickpick.auth.ui;
 
 import com.pickpick.auth.application.AuthService;
+import com.pickpick.auth.ui.dto.LoginRequest;
 import com.pickpick.auth.ui.dto.LoginResponse;
-import javax.validation.constraints.NotEmpty;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -19,8 +18,8 @@ public class AuthController {
     }
 
     @GetMapping
-    public LoginResponse login(@RequestParam @NotEmpty final String code) {
-        String token = authService.login(code);
+    public LoginResponse login(final LoginRequest loginRequest) {
+        String token = authService.login(loginRequest);
         return new LoginResponse(token);
     }
 }

--- a/backend/src/main/java/com/pickpick/auth/ui/dto/LoginRequest.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/dto/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.pickpick.auth.ui.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class LoginRequest {
+
+    private String error;
+    private String code;
+
+    public LoginRequest(final String error, final String code) {
+        this.error = error;
+        this.code = code;
+    }
+}

--- a/backend/src/main/java/com/pickpick/config/ControllerAdvice.java
+++ b/backend/src/main/java/com/pickpick/config/ControllerAdvice.java
@@ -2,6 +2,7 @@ package com.pickpick.config;
 
 import com.pickpick.exception.BadRequestException;
 import com.pickpick.exception.NotFoundException;
+import com.pickpick.exception.UnauthorizedException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -15,6 +16,12 @@ public class ControllerAdvice {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler
     public void handleBadRequestException(final BadRequestException e) {
+        log.error("예외 발생: ", e);
+    }
+
+    @ResponseStatus(HttpStatus.UNAUTHORIZED)
+    @ExceptionHandler
+    public void handleUnauthorizedException(final UnauthorizedException e) {
         log.error("예외 발생: ", e);
     }
 

--- a/backend/src/main/java/com/pickpick/exception/PermissionDeniedException.java
+++ b/backend/src/main/java/com/pickpick/exception/PermissionDeniedException.java
@@ -1,0 +1,10 @@
+package com.pickpick.exception;
+
+public class PermissionDeniedException extends UnauthorizedException {
+
+    private static final String DEFAULT_MESSAGE = "엑세스 권한 요청이 거부되었습니다.";
+
+    public PermissionDeniedException() {
+        super(DEFAULT_MESSAGE);
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/UnauthorizedException.java
+++ b/backend/src/main/java/com/pickpick/exception/UnauthorizedException.java
@@ -1,0 +1,8 @@
+package com.pickpick.exception;
+
+public class UnauthorizedException extends RuntimeException {
+
+    public UnauthorizedException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AuthAcceptanceTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/truncate.sql", "/member.sql"})
@@ -46,6 +47,21 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         // then
         상태코드_200_확인(response);
         응답_바디에_토큰_존재(response);
+    }
+
+    @Test
+    void 사용자가_액세스_권한_요청을_거부하는_경우_로그인_실패() throws SlackApiException, IOException {
+        // given
+        when(slackClient.oauthV2Access(any(OAuthV2AccessRequest.class)))
+                .thenReturn(generateOAuthV2AccessResponse());
+        when(slackClient.usersIdentity(any(UsersIdentityRequest.class)))
+                .thenReturn(generateUsersIdentityResponse(MEMBER_SLACK_ID));
+
+        // when
+        ExtractableResponse<Response> response = get(API_URL, Map.of("error", "access_denied"));
+
+        // then
+        상태코드_확인(response, HttpStatus.UNAUTHORIZED);
     }
 
     private OAuthV2AccessResponse generateOAuthV2AccessResponse() {


### PR DESCRIPTION
## 요약

슬랙 액세스 요청 창에서 취소 선택 시 예외 처리 

<br>

## 작업 내용

로그인 요청값에 error: access_denied 가 포함 될 경우 상태코드 `Unauthorized` 응답  

<br>

## 관련 이슈

- Close #259 

<br><br>
