### PR TITLE
feat: 토큰 인증 및 인가 구현

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/support/AuthenticationPrincipal.java
+++ b/backend/src/main/java/com/pickpick/auth/support/AuthenticationPrincipal.java
@@ -1,0 +1,11 @@
+package com.pickpick.auth.support;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface AuthenticationPrincipal {
+}

--- a/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
@@ -37,13 +37,13 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String getPayload(String token) {
+    public String getPayload(final String token) {
         return parseClaims(token)
                 .getBody()
                 .getSubject();
     }
 
-    public void validateToken(String token) {
+    public void validateToken(final String token) {
         try {
             parseClaims(token);
         } catch (ExpiredJwtException e) {

--- a/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
@@ -32,4 +32,13 @@ public class JwtTokenProvider {
                 .signWith(secretKey, SignatureAlgorithm.HS256)
                 .compact();
     }
+
+    public String getPayload(String token) {
+        return Jwts.parserBuilder()
+                .setSigningKey(secretKey)
+                .build()
+                .parseClaimsJws(token)
+                .getBody()
+                .getSubject();
+    }
 }

--- a/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
@@ -1,5 +1,9 @@
 package com.pickpick.auth.support;
 
+import com.pickpick.exception.InvalidTokenException;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.Jws;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
@@ -34,11 +38,25 @@ public class JwtTokenProvider {
     }
 
     public String getPayload(String token) {
+        return parseClaims(token)
+                .getBody()
+                .getSubject();
+    }
+
+    public void validateToken(String token) {
+        try {
+            parseClaims(token);
+        } catch (ExpiredJwtException e) {
+            throw new InvalidTokenException("만료된 토큰입니다.");
+        } catch (Exception e) {
+            throw new InvalidTokenException("유효하지 않은 토큰입니다.");
+        }
+    }
+
+    private Jws<Claims> parseClaims(final String token) {
         return Jwts.parserBuilder()
                 .setSigningKey(secretKey)
                 .build()
-                .parseClaimsJws(token)
-                .getBody()
-                .getSubject();
+                .parseClaimsJws(token);
     }
 }

--- a/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
@@ -37,12 +37,6 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String getPayload(final String token) {
-        return parseClaims(token)
-                .getBody()
-                .getSubject();
-    }
-
     public void validateToken(final String token) {
         try {
             parseClaims(token);
@@ -51,6 +45,12 @@ public class JwtTokenProvider {
         } catch (Exception e) {
             throw new InvalidTokenException("유효하지 않은 토큰입니다.");
         }
+    }
+
+    public String getPayload(final String token) {
+        return parseClaims(token)
+                .getBody()
+                .getSubject();
     }
 
     private Jws<Claims> parseClaims(final String token) {

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationInterceptor.java
@@ -11,12 +11,13 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthenticationInterceptor(JwtTokenProvider jwtTokenProvider) {
+    public AuthenticationInterceptor(final JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Override
-    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response,
+                             final Object handler) {
         if (CorsUtils.isCorsRequest(request)) {
             return true;
         }

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationInterceptor.java
@@ -1,0 +1,28 @@
+package com.pickpick.auth.ui;
+
+import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.utils.AuthorizationExtractor;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.springframework.web.cors.CorsUtils;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+public class AuthenticationInterceptor implements HandlerInterceptor {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthenticationInterceptor(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        if (CorsUtils.isCorsRequest(request)) {
+            return true;
+        }
+
+        String token = AuthorizationExtractor.extract(request);
+        jwtTokenProvider.validateToken(token);
+        return true;
+    }
+}

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -14,24 +14,24 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthenticationPrincipalArgumentResolver(JwtTokenProvider jwtTokenProvider) {
+    public AuthenticationPrincipalArgumentResolver(final JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Override
-    public boolean supportsParameter(MethodParameter parameter) {
+    public boolean supportsParameter(final MethodParameter parameter) {
         return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
     }
 
     @Override
-    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
-                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+    public Object resolveArgument(final MethodParameter parameter, final ModelAndViewContainer mavContainer,
+                                  final NativeWebRequest webRequest, final WebDataBinderFactory binderFactory) {
         String token = AuthorizationExtractor.extract(toHttpServletRequest(webRequest));
         jwtTokenProvider.validateToken(token);
         return Long.valueOf(jwtTokenProvider.getPayload(token));
     }
 
-    private HttpServletRequest toHttpServletRequest(NativeWebRequest webRequest) {
+    private HttpServletRequest toHttpServletRequest(final NativeWebRequest webRequest) {
         return webRequest.getNativeRequest(HttpServletRequest.class);
     }
 }

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -27,6 +27,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
                                   NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         String token = AuthorizationExtractor.extract(toHttpServletRequest(webRequest));
+        jwtTokenProvider.validateToken(token);
         return Long.valueOf(jwtTokenProvider.getPayload(token));
     }
 

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -1,0 +1,37 @@
+package com.pickpick.auth.ui;
+
+import com.pickpick.auth.support.AuthenticationPrincipal;
+import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.utils.AuthorizationExtractor;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthenticationPrincipalArgumentResolver(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+                                  NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        String token = AuthorizationExtractor.extract(toHttpServletRequest(webRequest));
+        return Long.valueOf(jwtTokenProvider.getPayload(token));
+    }
+
+    private HttpServletRequest toHttpServletRequest(NativeWebRequest webRequest) {
+        return webRequest.getNativeRequest(HttpServletRequest.class);
+    }
+}
+

--- a/backend/src/main/java/com/pickpick/channel/ui/ChannelController.java
+++ b/backend/src/main/java/com/pickpick/channel/ui/ChannelController.java
@@ -1,9 +1,8 @@
 package com.pickpick.channel.ui;
 
+import com.pickpick.auth.support.AuthenticationPrincipal;
 import com.pickpick.channel.application.ChannelSubscriptionService;
 import com.pickpick.channel.ui.dto.ChannelResponses;
-import com.pickpick.utils.AuthorizationExtractor;
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -19,8 +18,7 @@ public class ChannelController {
     }
 
     @GetMapping
-    public ChannelResponses findAllChannels(HttpServletRequest request) {
-        String memberId = AuthorizationExtractor.extract(request);
-        return new ChannelResponses(channelSubscriptionService.findAll(Long.valueOf(memberId)));
+    public ChannelResponses findAllChannels(final @AuthenticationPrincipal Long memberId) {
+        return new ChannelResponses(channelSubscriptionService.findAll(memberId));
     }
 }

--- a/backend/src/main/java/com/pickpick/channel/ui/ChannelSubscriptionController.java
+++ b/backend/src/main/java/com/pickpick/channel/ui/ChannelSubscriptionController.java
@@ -1,14 +1,13 @@
 package com.pickpick.channel.ui;
 
+import com.pickpick.auth.support.AuthenticationPrincipal;
 import com.pickpick.channel.application.ChannelSubscriptionService;
 import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponses;
-import com.pickpick.utils.AuthorizationExtractor;
 import java.util.List;
 import java.util.stream.Collectors;
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -29,31 +28,29 @@ public class ChannelSubscriptionController {
     }
 
     @GetMapping
-    public ChannelSubscriptionResponses getAllChannels(HttpServletRequest request) {
-        String memberId = AuthorizationExtractor.extract(request);
+    public ChannelSubscriptionResponses getAllChannels(final @AuthenticationPrincipal Long memberId) {
         return new ChannelSubscriptionResponses(
-                channelSubscriptionService.findAllOrderByViewOrder(Long.parseLong(memberId))
+                channelSubscriptionService.findAllOrderByViewOrder(memberId)
                         .stream()
                         .map(ChannelSubscriptionResponse::from)
                         .collect(Collectors.toList()));
     }
 
     @PostMapping
-    public void subscribeChannel(HttpServletRequest request,
-                                 @RequestBody ChannelSubscriptionRequest subscriptionRequest) {
-        String memberId = AuthorizationExtractor.extract(request);
-        channelSubscriptionService.save(subscriptionRequest, Long.parseLong(memberId));
+    public void subscribeChannel(final @AuthenticationPrincipal Long memberId,
+                                 final @RequestBody ChannelSubscriptionRequest subscriptionRequest) {
+        channelSubscriptionService.save(subscriptionRequest, memberId);
     }
 
     @PutMapping
-    public void updateViewOrders(HttpServletRequest request, @RequestBody List<ChannelOrderRequest> orderRequests) {
-        String memberId = AuthorizationExtractor.extract(request);
-        channelSubscriptionService.updateOrders(orderRequests, Long.parseLong(memberId));
+    public void updateViewOrders(final @AuthenticationPrincipal Long memberId,
+                                 final @RequestBody List<ChannelOrderRequest> orderRequests) {
+        channelSubscriptionService.updateOrders(orderRequests, memberId);
     }
 
     @DeleteMapping
-    public void unsubscribeChannel(HttpServletRequest request, @RequestParam Long channelId) {
-        String memberId = AuthorizationExtractor.extract(request);
-        channelSubscriptionService.delete(channelId, Long.parseLong(memberId));
+    public void unsubscribeChannel(final @AuthenticationPrincipal Long memberId,
+                                   final @RequestParam Long channelId) {
+        channelSubscriptionService.delete(channelId, memberId);
     }
 }

--- a/backend/src/main/java/com/pickpick/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/pickpick/config/AuthenticationPrincipalConfig.java
@@ -1,10 +1,12 @@
 package com.pickpick.config;
 
 import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.auth.ui.AuthenticationInterceptor;
 import com.pickpick.auth.ui.AuthenticationPrincipalArgumentResolver;
 import java.util.List;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
@@ -19,5 +21,12 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(new AuthenticationPrincipalArgumentResolver(jwtTokenProvider));
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(new AuthenticationInterceptor(jwtTokenProvider))
+                .addPathPatterns("/api/**")
+                .excludePathPatterns("/api/event", "/api/slack-login");
     }
 }

--- a/backend/src/main/java/com/pickpick/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/pickpick/config/AuthenticationPrincipalConfig.java
@@ -14,17 +14,17 @@ public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
 
     private final JwtTokenProvider jwtTokenProvider;
 
-    public AuthenticationPrincipalConfig(JwtTokenProvider jwtTokenProvider) {
+    public AuthenticationPrincipalConfig(final JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;
     }
 
     @Override
-    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+    public void addArgumentResolvers(final List<HandlerMethodArgumentResolver> argumentResolvers) {
         argumentResolvers.add(new AuthenticationPrincipalArgumentResolver(jwtTokenProvider));
     }
 
     @Override
-    public void addInterceptors(InterceptorRegistry registry) {
+    public void addInterceptors(final InterceptorRegistry registry) {
         registry.addInterceptor(new AuthenticationInterceptor(jwtTokenProvider))
                 .addPathPatterns("/api/**")
                 .excludePathPatterns("/api/event", "/api/slack-login");

--- a/backend/src/main/java/com/pickpick/config/AuthenticationPrincipalConfig.java
+++ b/backend/src/main/java/com/pickpick/config/AuthenticationPrincipalConfig.java
@@ -1,0 +1,23 @@
+package com.pickpick.config;
+
+import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.auth.ui.AuthenticationPrincipalArgumentResolver;
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class AuthenticationPrincipalConfig implements WebMvcConfigurer {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AuthenticationPrincipalConfig(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new AuthenticationPrincipalArgumentResolver(jwtTokenProvider));
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/InvalidTokenException.java
+++ b/backend/src/main/java/com/pickpick/exception/InvalidTokenException.java
@@ -1,0 +1,8 @@
+package com.pickpick.exception;
+
+public class InvalidTokenException extends BadRequestException {
+
+    public InvalidTokenException(final String message) {
+        super(message);
+    }
+}

--- a/backend/src/main/java/com/pickpick/message/ui/BookmarkController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/BookmarkController.java
@@ -1,10 +1,9 @@
 package com.pickpick.message.ui;
 
+import com.pickpick.auth.support.AuthenticationPrincipal;
 import com.pickpick.message.application.BookmarkService;
 import com.pickpick.message.ui.dto.BookmarkRequest;
 import com.pickpick.message.ui.dto.BookmarkResponses;
-import com.pickpick.utils.AuthorizationExtractor;
-import javax.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -28,24 +27,21 @@ public class BookmarkController {
 
     @PostMapping
     @ResponseStatus(value = HttpStatus.CREATED)
-    public void save(final HttpServletRequest request,
+    public void save(final @AuthenticationPrincipal Long memberId,
                      final @RequestBody BookmarkRequest bookmarkRequest) {
-        String memberId = AuthorizationExtractor.extract(request);
-        bookmarkService.save(Long.parseLong(memberId), bookmarkRequest);
+        bookmarkService.save(memberId, bookmarkRequest);
     }
 
     @GetMapping
-    public BookmarkResponses find(final HttpServletRequest request,
+    public BookmarkResponses find(final @AuthenticationPrincipal Long memberId,
                                   final @RequestParam(required = false) Long bookmarkId) {
-        String memberId = AuthorizationExtractor.extract(request);
-        return bookmarkService.find(bookmarkId, Long.parseLong(memberId));
+        return bookmarkService.find(bookmarkId, memberId);
     }
 
     @DeleteMapping("/{bookmarkId}")
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void delete(final HttpServletRequest request,
+    public void delete(final @AuthenticationPrincipal Long memberId,
                        final @PathVariable Long bookmarkId) {
-        String memberId = AuthorizationExtractor.extract(request);
-        bookmarkService.delete(bookmarkId, Long.parseLong(memberId));
+        bookmarkService.delete(bookmarkId, memberId);
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/MessageController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/MessageController.java
@@ -1,10 +1,9 @@
 package com.pickpick.message.ui;
 
+import com.pickpick.auth.support.AuthenticationPrincipal;
 import com.pickpick.message.application.MessageService;
 import com.pickpick.message.ui.dto.MessageRequest;
 import com.pickpick.message.ui.dto.MessageResponses;
-import com.pickpick.utils.AuthorizationExtractor;
-import javax.servlet.http.HttpServletRequest;
 import javax.validation.Valid;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,11 +20,8 @@ public class MessageController {
     }
 
     @GetMapping
-    public MessageResponses findSlackMessages(HttpServletRequest httpServletRequest,
-                                              @Valid MessageRequest messageRequest) {
-
-        String memberId = AuthorizationExtractor.extract(httpServletRequest);
-
-        return messageService.find(Long.parseLong(memberId), messageRequest);
+    public MessageResponses findSlackMessages(final @AuthenticationPrincipal Long memberId,
+                                              final @Valid MessageRequest messageRequest) {
+        return messageService.find(memberId, messageRequest);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -2,6 +2,7 @@ package com.pickpick.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.pickpick.auth.support.JwtTokenProvider;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -9,6 +10,7 @@ import java.util.Map;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
@@ -26,6 +28,9 @@ class AcceptanceTest {
         RestAssured.port = port;
     }
 
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
     ExtractableResponse<Response> post(final String uri, final Object object) {
         return RestAssured.given().log().all()
                 .body(object)
@@ -36,9 +41,11 @@ class AcceptanceTest {
                 .extract();
     }
 
-    ExtractableResponse<Response> postWithAuth(final String uri, final Object object, final Long memberId) {
+    ExtractableResponse<Response> postWithCreateToken(final String uri, final Object object, final Long memberId) {
+        String token = createToken(memberId);
+
         return RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + memberId)
+                .header("Authorization", "Bearer " + token)
                 .body(object)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
@@ -65,41 +72,35 @@ class AcceptanceTest {
                 .extract();
     }
 
-    ExtractableResponse<Response> getWithAuth(final String uri, final Long memberId,
-                                              final Map<String, Object> queryParams) {
+    ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId) {
+        String token = createToken(memberId);
+
         return RestAssured.given().log().all()
-                .queryParams(queryParams)
-                .header("Authorization", "Bearer " + memberId)
+                .header("Authorization", "Bearer " + token)
                 .when()
                 .get(uri)
                 .then().log().all()
                 .extract();
     }
 
-    ExtractableResponse<Response> getWithAuth(final String uri, final Long memberId) {
+    ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId,
+                                                     final Map<String, Object> request) {
+        String token = createToken(memberId);
+
         return RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + memberId)
+                .queryParams(request)
+                .header("Authorization", "Bearer " + token)
                 .when()
                 .get(uri)
                 .then().log().all()
                 .extract();
     }
 
-    ExtractableResponse<Response> getWithAuthAndParams(final String uri, final Long memberId,
-                                                       final Map<String, Object> params) {
-        return RestAssured.given()
-                .log().all()
-                .header("Authorization", "Bearer " + memberId)
-                .queryParams(params)
-                .when()
-                .get(uri)
-                .then().log().all()
-                .extract();
-    }
+    ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object, final Long memberId) {
+        String token = createToken(memberId);
 
-    ExtractableResponse<Response> putWithAuth(final String uri, final Object object, final Long memberId) {
         return RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + memberId)
+                .header("Authorization", "Bearer " + token)
                 .body(object)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .when()
@@ -108,13 +109,19 @@ class AcceptanceTest {
                 .extract();
     }
 
-    ExtractableResponse<Response> deleteWithAuth(final String uri, final Long memberId) {
+    ExtractableResponse<Response> deleteWithCreateToken(final String uri, final Long memberId) {
+        String token = createToken(memberId);
+
         return RestAssured.given().log().all()
-                .header("Authorization", "Bearer " + memberId)
+                .header("Authorization", "Bearer " + token)
                 .when()
                 .delete(uri)
                 .then().log().all()
                 .extract();
+    }
+
+    private String createToken(final Long memberId) {
+        return jwtTokenProvider.createToken(String.valueOf(memberId));
     }
 
     void 상태코드_200_확인(final ExtractableResponse<Response> response) {

--- a/backend/src/test/java/com/pickpick/acceptance/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AuthAcceptanceTest.java
@@ -2,7 +2,7 @@ package com.pickpick.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
@@ -35,10 +35,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 정상_로그인() throws SlackApiException, IOException {
         // given
-        when(slackClient.oauthV2Access(any(OAuthV2AccessRequest.class)))
-                .thenReturn(generateOAuthV2AccessResponse());
-        when(slackClient.usersIdentity(any(UsersIdentityRequest.class)))
-                .thenReturn(generateUsersIdentityResponse(MEMBER_SLACK_ID));
+        given(slackClient.oauthV2Access(any(OAuthV2AccessRequest.class)))
+                .willReturn(generateOAuthV2AccessResponse());
+        given(slackClient.usersIdentity(any(UsersIdentityRequest.class)))
+                .willReturn(generateUsersIdentityResponse(MEMBER_SLACK_ID));
 
         // when
         ExtractableResponse<Response> response = get(API_URL, Map.of("code", "1234"));

--- a/backend/src/test/java/com/pickpick/acceptance/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/BookmarkAcceptanceTest.java
@@ -24,7 +24,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
     @Test
     void 북마크_생성() {
         // given & when
-        ExtractableResponse<Response> response = postWithAuth(API_BOOKMARK, Map.of("messageId", 1), 1L);
+        ExtractableResponse<Response> response = postWithCreateToken(API_BOOKMARK, Map.of("messageId", 1), 1L);
 
         // then
         상태코드_확인(response, HttpStatus.CREATED);
@@ -38,7 +38,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         boolean expectedIsLast = true;
 
         // when
-        ExtractableResponse<Response> response = getWithAuth(API_BOOKMARK, 2L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(API_BOOKMARK, 2L, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -57,7 +57,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         boolean expectedIsLast = false;
 
         // when
-        ExtractableResponse<Response> response = getWithAuth(API_BOOKMARK, 1L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(API_BOOKMARK, 1L, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -80,7 +80,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long bookmarkId = 2L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithAuth(API_BOOKMARK + "/" + bookmarkId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(API_BOOKMARK + "/" + bookmarkId, 1L);
 
         // then
         상태코드_확인(response, HttpStatus.NO_CONTENT);
@@ -92,7 +92,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long bookmarkId = 1L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithAuth(API_BOOKMARK + "/" + bookmarkId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(API_BOOKMARK + "/" + bookmarkId, 1L);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelAcceptanceTest.java
@@ -57,7 +57,7 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
     }
 
     protected ExtractableResponse<Response> 유저_전체_채널_목록_조회_요청() {
-        return getWithAuth("/api/channels", 2L);
+        return getWithCreateToken("/api/channels", 2L);
     }
 
     protected List<Long> 구독중이_아닌_채널_id_목록_추출(ExtractableResponse<Response> response) {
@@ -71,11 +71,11 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
 
     protected ExtractableResponse<Response> 구독_요청(final Long channelId) {
         ChannelSubscriptionRequest channelSubscriptionRequest = new ChannelSubscriptionRequest(channelId);
-        return postWithAuth(API_CHANNEL_SUBSCRIPTION, channelSubscriptionRequest, 2L);
+        return postWithCreateToken(API_CHANNEL_SUBSCRIPTION, channelSubscriptionRequest, 2L);
     }
 
     protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return deleteWithAuth(API_CHANNEL_SUBSCRIPTION + "?channelId=" + channelId, 2L);
+        return deleteWithCreateToken(API_CHANNEL_SUBSCRIPTION + "?channelId=" + channelId, 2L);
     }
 
     private void 채널_구독_완료_확인(final Long channelIdToSubscribe) {

--- a/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/ChannelSubscriptionAcceptanceTest.java
@@ -120,7 +120,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
 
     private ExtractableResponse<Response> 유저_구독_채널_목록_조회_요청() {
-        return getWithAuth(API_CHANNEL_SUBSCRIPTION, 2L);
+        return getWithCreateToken(API_CHANNEL_SUBSCRIPTION, 2L);
     }
 
     private void 구독이_올바른_순서로_조회됨(
@@ -141,7 +141,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
     }
 
     private ExtractableResponse<Response> 구독_채널_순서_변경_요청(final List<ChannelOrderRequest> request) {
-        return putWithAuth(API_CHANNEL_SUBSCRIPTION, request, 2L);
+        return putWithCreateToken(API_CHANNEL_SUBSCRIPTION, request, 2L);
     }
 
     private ExtractableResponse<Response> 올바른_구독_채널_순서_변경_요청() {

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -109,7 +109,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
                     final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
         // when
-        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(API_URL, MEMBER_ID, request);
 
         // then
         MessageResponses messageResponses = response.as(MessageResponses.class);
@@ -128,7 +128,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @ParameterizedTest
     void 메시지_조회_시_needPastMessage_true_응답_확인(final String needPastMessage) {
         Map request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
-        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(API_URL, MEMBER_ID, request);
 
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
@@ -138,7 +138,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @Test
     void 메시지_조회_시_needPastMessage가_False일_경우_응답_확인() {
         Map request = createQueryParams("jupjup", "", "5", "false", "", "");
-        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(API_URL, MEMBER_ID, request);
 
         MessageResponses messageResponses = response.as(MessageResponses.class);
 

--- a/backend/src/test/java/com/pickpick/auth/support/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/pickpick/auth/support/JwtTokenProviderTest.java
@@ -1,7 +1,9 @@
 package com.pickpick.auth.support;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.pickpick.exception.InvalidTokenException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -13,7 +15,7 @@ class JwtTokenProviderTest {
 
     @DisplayName("토큰 생성 후 값 추출")
     @Test
-    void createToken() {
+    void getPayload() {
         // given
         long memberId = 1L;
         String token = jwtTokenProvider.createToken(String.valueOf(memberId));
@@ -23,5 +25,46 @@ class JwtTokenProviderTest {
 
         // then
         assertThat(Long.parseLong(actual)).isEqualTo(memberId);
+    }
+
+    @DisplayName("토큰 유효 시간 검증")
+    @Test
+    void validateExpiredToken() {
+        // given
+        long memberId = 1L;
+        JwtTokenProvider expiredTokenProvider = new JwtTokenProvider("eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno",
+                0);
+        String token = expiredTokenProvider.createToken(String.valueOf(memberId));
+
+        // when & then
+        assertThatThrownBy(() -> expiredTokenProvider.validateToken(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("만료된 토큰입니다.");
+    }
+
+    @DisplayName("유효하지 않은 토큰 검증")
+    @Test
+    void validateInvalidToken() {
+        // given
+        String token = "fake_token";
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("유효하지 않은 토큰입니다.");
+    }
+
+    @DisplayName("다른 시그니쳐로 생성된 토큰 검증")
+    @Test
+    void validateInvalidSignature() {
+        // given
+        JwtTokenProvider otherJwtTokenProvider = new JwtTokenProvider("secretKey12345678912356714252637", 60000);
+        Long memberId = 1L;
+        String token = otherJwtTokenProvider.createToken(String.valueOf(memberId));
+
+        // when & then
+        assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
+                .isInstanceOf(InvalidTokenException.class)
+                .hasMessageContaining("유효하지 않은 토큰입니다.");
     }
 }

--- a/backend/src/test/java/com/pickpick/auth/support/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/pickpick/auth/support/JwtTokenProviderTest.java
@@ -1,0 +1,27 @@
+package com.pickpick.auth.support;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(
+            "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIiLCJuYW1lIjoiSm9obiBEb2UiLCJpYXQiOjE1MTYyMzkwMjJ9.ih1aovtQShabQ7l0cINw4k1fagApg3qLWiB8Kt59Lno",
+            60000);
+
+    @DisplayName("토큰 생성 후 값 추출")
+    @Test
+    void createToken() {
+        // given
+        long memberId = 1L;
+        String token = jwtTokenProvider.createToken(String.valueOf(memberId));
+
+        // when
+        String actual = jwtTokenProvider.getPayload(token);
+
+        // then
+        assertThat(Long.parseLong(actual)).isEqualTo(memberId);
+    }
+}

--- a/backend/src/test/java/com/pickpick/controller/ChannelControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/ChannelControllerTest.java
@@ -1,20 +1,34 @@
 package com.pickpick.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.pickpick.auth.support.JwtTokenProvider;
 import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/truncate.sql", "/channel.sql", "/channel-subscription.sql"})
 class ChannelControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setup() {
+        given(jwtTokenProvider.getPayload(any(String.class)))
+                .willReturn("2");
+    }
 
     @DisplayName("구독 여부를 포함하여 채널을 조회한다.")
     @Test

--- a/backend/src/test/java/com/pickpick/controller/ChannelSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/ChannelSubscriptionControllerTest.java
@@ -1,6 +1,8 @@
 package com.pickpick.controller;
 
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -10,12 +12,15 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import java.util.List;
 import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -24,6 +29,15 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 @Sql({"/truncate.sql", "/channel.sql", "/channel-subscription.sql"})
 class ChannelSubscriptionControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setup() {
+        given(jwtTokenProvider.getPayload(any(String.class)))
+                .willReturn("2");
+    }
 
     @DisplayName("멤버의 구독 중인 채널을 조회한다.")
     @Test

--- a/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
@@ -1,5 +1,7 @@
 package com.pickpick.controller;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
@@ -8,9 +10,12 @@ import static org.springframework.restdocs.request.RequestDocumentation.paramete
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+import com.pickpick.auth.support.JwtTokenProvider;
 import org.apache.http.HttpHeaders;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -20,6 +25,15 @@ import org.springframework.util.MultiValueMap;
 
 @Sql({"/truncate.sql", "/message.sql"})
 class MessageControllerTest extends RestDocsTestSupport {
+
+    @MockBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setup() {
+        given(jwtTokenProvider.getPayload(any(String.class)))
+                .willReturn("2");
+    }
 
     @DisplayName("메시지를 조회한다.")
     @Test
@@ -34,8 +48,8 @@ class MessageControllerTest extends RestDocsTestSupport {
 
         mockMvc.perform(MockMvcRequestBuilders
                         .get("/api/messages")
-                        .params(requestParam)
                         .header(HttpHeaders.AUTHORIZATION, "Bearer 2")
+                        .params(requestParam)
                 )
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(


### PR DESCRIPTION
## 요약

토큰 인증 및 인가 구현

<br>

## 작업 내용

- slack OAuth에서 사용자 토큰 받아 정보 확인 후 새로운 토큰 발급 
- ArgumentResolver로 토큰 값 이용  
- 토큰 유효성 검증  

<br>

## 참고 사항

아직 intercepter를 적용하지 않아 draft로 올립니다  

<br>

## 관련 이슈

- Close #234 

<br><br>
