### PR TITLE
feat: 메시지 조회 시 needPastMessage 함께 응답하도록 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -39,7 +39,7 @@ public class MessageService {
         List<Message> messages = findMessages(messageRequest);
         boolean isLast = isLast(messageRequest, messages);
 
-        return toSlackMessageResponse(messages, isLast);
+        return toSlackMessageResponse(messages, isLast, messageRequest.isNeedPastMessage());
     }
 
     private List<Message> findMessages(final MessageRequest messageRequest) {
@@ -172,8 +172,9 @@ public class MessageService {
         return QMessage.message.postedDate.after(targetPostDate);
     }
 
-    private MessageResponses toSlackMessageResponse(final List<Message> messages, final boolean isLast) {
-        return new MessageResponses(toSlackMessageResponses(messages), isLast);
+    private MessageResponses toSlackMessageResponse(final List<Message> messages, final boolean isLast,
+                                                    final boolean needPastMessage) {
+        return new MessageResponses(toSlackMessageResponses(messages), isLast, needPastMessage);
     }
 
     private List<MessageResponse> toSlackMessageResponses(final List<Message> messages) {

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
@@ -12,11 +12,15 @@ public class MessageResponses {
     @JsonProperty(value = "isLast")
     private boolean last;
 
+    @JsonProperty(value = "isNeedPastMessage")
+    private boolean needPastMessage;
+
     private MessageResponses() {
     }
 
-    public MessageResponses(final List<MessageResponse> messages, final boolean last) {
+    public MessageResponses(final List<MessageResponse> messages, final boolean last, final boolean needPastMessage) {
         this.messages = messages;
         this.last = last;
+        this.needPastMessage = needPastMessage;
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -42,37 +42,44 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         "channelIds가 5이면, 5번 채널의 가장 최근 메시지 20개가 응답되어야 한다.",
                         createQueryParams("", "", "5", "", "", ""),
                         false,
-                        createExpectedMessageIds(38L, 19L)),
+                        createExpectedMessageIds(38L, 19L),
+                        true),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 true이고 date가 존재할 경우, 5번 채널의 해당 날짜 보다 과거 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "2022-07-13T19:21:55", "5", "true", "", ""),
                         true,
-                        createExpectedMessageIds(6L, 1L)),
+                        createExpectedMessageIds(6L, 1L),
+                        true),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 해당 메시지 보다 과거 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "5", "true", "6", ""),
                         true,
-                        createExpectedMessageIds(5L, 1L)),
+                        createExpectedMessageIds(5L, 1L),
+                        true),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 false이고 messageId가 존재할 경우, 5번 채널의 해당 메시지 보다 미래 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "5", "false", "6", ""),
                         false,
-                        createExpectedMessageIds(26L, 7L)),
+                        createExpectedMessageIds(26L, 7L),
+                        false),
                 Arguments.of(
                         "channelIds가 5이고, keyword가 '줍'일 경우, 5번 채널의 메시지 중 '줍'이 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("줍", "", "5", "", "", ""),
                         true,
-                        createExpectedMessageIds(28L, 23L)),
+                        createExpectedMessageIds(28L, 23L),
+                        true),
                 Arguments.of(
                         "channelIds가 5이고, keyword가 '호'이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 '호'가 포함된 메시지 중, 전달된 메시지 ID의 메시지보다 더 과거 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("호", "", "5", "", "13", ""),
                         true,
-                        createExpectedMessageIds(7L, 4L)),
+                        createExpectedMessageIds(7L, 4L),
+                        true),
                 Arguments.of(
                         "channelIds가 5이고, keyword가 'jupjup'일 경우, 5번 채널의 메시지 중 'jupjup'이 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("jupjup", "", "5", "", "", ""),
                         true,
-                        createExpectedMessageIds(18L, 14L))
+                        createExpectedMessageIds(18L, 14L),
+                        true)
         );
     }
 
@@ -93,7 +100,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{0}")
     void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
-                    final List<Long> expectedMessageIds) {
+                    final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
         // when
         ExtractableResponse<Response> response = get(API_URL, request);
 
@@ -103,6 +110,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
         assertAll(
                 () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
                 () -> assertThat(messageResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
                         .extracting("id")
                         .isEqualTo(expectedMessageIds)
@@ -111,7 +119,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
     @ValueSource(strings = {"", "true"})
     @ParameterizedTest
-    void 메시지_조회_시_needPastMessage_true_응답_확인(String needPastMessage) {
+    void 메시지_조회_시_needPastMessage_true_응답_확인(final String needPastMessage) {
         Map request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
         ExtractableResponse<Response> response = get(API_URL, request);
 

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -13,9 +13,11 @@ import java.util.stream.Collectors;
 import java.util.stream.LongStream;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -105,5 +107,26 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         .extracting("id")
                         .isEqualTo(expectedMessageIds)
         );
+    }
+
+    @ValueSource(strings = {"", "true"})
+    @ParameterizedTest
+    void 메시지_조회_시_needPastMessage_true_응답_확인(String needPastMessage) {
+        Map request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
+        ExtractableResponse<Response> response = get(API_URL, request);
+
+        MessageResponses messageResponses = response.as(MessageResponses.class);
+
+        assertThat(messageResponses.isNeedPastMessage()).isTrue();
+    }
+
+    @Test
+    void 메시지_조회_시_needPastMessage가_False일_경우_응답_확인() {
+        Map request = createQueryParams("jupjup", "", "5", "false", "", "");
+        ExtractableResponse<Response> response = get(API_URL, request);
+
+        MessageResponses messageResponses = response.as(MessageResponses.class);
+
+        assertThat(messageResponses.isNeedPastMessage()).isFalse();
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/MessageAcceptanceTest.java
@@ -30,25 +30,6 @@ class MessageAcceptanceTest extends AcceptanceTest {
     private static final String API_URL = "/api/messages";
     private static final long MEMBER_ID = 1L;
 
-    @MethodSource("methodSource")
-    @ParameterizedTest(name = "{0}")
-    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
-                    final List<Long> expectedMessageIds) {
-        // when
-        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
-
-        // then
-        MessageResponses messageResponses = response.as(MessageResponses.class);
-
-        assertAll(
-                () -> assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value()),
-                () -> assertThat(messageResponses.isLast()).isEqualTo(expectedIsLast),
-                () -> assertThat(messageResponses.getMessages())
-                        .extracting("id")
-                        .isEqualTo(expectedMessageIds)
-        );
-    }
-
     private static Stream<Arguments> methodSource() {
         return Stream.of(
                 Arguments.of(
@@ -97,7 +78,8 @@ class MessageAcceptanceTest extends AcceptanceTest {
                         "쿼리 파라미터가 전혀 전달되지 않았을 경우, 회원의 채널 정렬 상 첫번째 채널의 최신 20개 메시지를 작성시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "", "", "", ""),
                         false,
-                        createExpectedMessageIds(38L, 19L))
+                        createExpectedMessageIds(38L, 19L),
+                        true)
         );
     }
 
@@ -120,12 +102,14 @@ class MessageAcceptanceTest extends AcceptanceTest {
                 .boxed()
                 .sorted(Comparator.reverseOrder())
                 .collect(Collectors.toList());
+    }
+
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{0}")
     void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
                     final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
         // when
-        ExtractableResponse<Response> response = get(API_URL, request);
+        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
 
         // then
         MessageResponses messageResponses = response.as(MessageResponses.class);
@@ -144,7 +128,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @ParameterizedTest
     void 메시지_조회_시_needPastMessage_true_응답_확인(final String needPastMessage) {
         Map request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
-        ExtractableResponse<Response> response = get(API_URL, request);
+        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
 
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
@@ -154,7 +138,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @Test
     void 메시지_조회_시_needPastMessage가_False일_경우_응답_확인() {
         Map request = createQueryParams("jupjup", "", "5", "false", "", "");
-        ExtractableResponse<Response> response = get(API_URL, request);
+        ExtractableResponse<Response> response = getWithAuthAndParams(API_URL, MEMBER_ID, request);
 
         MessageResponses messageResponses = response.as(MessageResponses.class);
 

--- a/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/controller/MessageControllerTest.java
@@ -58,7 +58,9 @@ class MessageControllerTest extends RestDocsTestSupport {
                                                 .description("메시지 게시 날짜"),
                                         fieldWithPath("messages.[].modifiedDate").type(JsonFieldType.STRING)
                                                 .description("메시지 수정 날짜"),
-                                        fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부")
+                                        fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부"),
+                                        fieldWithPath("isNeedPastMessage").type(JsonFieldType.BOOLEAN)
+                                                .description("위/아래 스크롤 방향")
                                 )
                         )
                 );


### PR DESCRIPTION
## 요약

메시지 조회 시 needPastMessage 함께 응답하도록 수정
<br><br>

## 작업 내용

- 요청으로 들어온 needPastMessage 그대로 응답에 추가
- 관련 코드 수정 및 테스트코드 보강

<br><br>

## 참고 사항

@kkojae91 응답에 요청으로 들어온 needPastMessage를 그대로 다시 넘겨주도록 수정했어요.
 수정한거 공유하려고 리뷰어로 추가한거고, 아래 이미지처럼 응답이 갈 예정입니다.
혹시 생각하던 방향이 아니라면 말씀주세요!!
<img width="1001" alt="image" src="https://user-images.githubusercontent.com/55357130/182652584-032607d0-4c23-461d-87e3-16c9104a0804.png">

<br><br>

## 관련 이슈

- Close #265 

<br><br>
