### PR TITLE
feat: 사용자 인증 관련 API 연동 및 실제 토큰 삽입

### DIFF
--- a/frontend/src/@constants/index.ts
+++ b/frontend/src/@constants/index.ts
@@ -22,7 +22,7 @@ export const API_ENDPOINT = {
   CHANNEL: "/api/channels",
   CHANNEL_SUBSCRIPTION: "/api/channel-subscription",
   BOOKMARKS: "/api/bookmarks",
-  AUTHENTICATION: "/api/auth",
+  CERTIFICATION: "/api/certification",
   SLACK_LOGIN: "/api/slack-login",
 } as const;
 

--- a/frontend/src/@utils/index.ts
+++ b/frontend/src/@utils/index.ts
@@ -54,7 +54,7 @@ export const setCookie = (key: string, value: string) => {
 export const getCookie = (key: string) => {
   const regex = new RegExp(`(?<=${key}=)[^;]*`); // key(좌항)에 해당하는 우항을 가져온다. 세미콜론은 제외한다.
   const matches = document.cookie.match(regex);
-  return matches ? matches[0] : undefined;
+  return matches ? matches[0] : "";
 };
 
 export const deleteCookie = (key: string) => {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,8 +1,8 @@
 import { API_ENDPOINT } from "@src/@constants";
 import { privateFetcher, publicFetcher } from ".";
 
-export const isAuthenticated = async () => {
-  const data = await privateFetcher.get("/api/auth");
+export const isCertificated = async () => {
+  const data = await privateFetcher.get(API_ENDPOINT.CERTIFICATION);
   return data;
 };
 

--- a/frontend/src/api/index.ts
+++ b/frontend/src/api/index.ts
@@ -1,4 +1,6 @@
 import axios from "axios";
+import { ACCESS_TOKEN_KEY } from "@src/@constants";
+import { getCookie } from "@src/@utils";
 
 export const publicFetcher = axios.create({
   baseURL: process.env.API_URL,
@@ -11,6 +13,6 @@ export const privateFetcher = axios.create({
   baseURL: process.env.API_URL,
   headers: {
     "Access-Control-Allow-Origin": "*",
-    authorization: `Bearer 172`,
+    authorization: `Bearer ${getCookie(ACCESS_TOKEN_KEY)}`,
   },
 });

--- a/frontend/src/api/utils.ts
+++ b/frontend/src/api/utils.ts
@@ -1,13 +1,4 @@
-import { ACCESS_TOKEN_KEY } from "@src/@constants";
 import { ResponseMessages, ResponseBookmarks } from "@src/@types/shared";
-import { getCookie } from "@src/@utils";
-
-export const getHeaders = () => {
-  return {
-    "Access-Control-Allow-Origin": "*",
-    authorization: `Bearer ${getCookie(ACCESS_TOKEN_KEY)}`,
-  };
-};
 
 export const previousMessagesCallback = ({
   isLast,

--- a/frontend/src/components/PrivateRouter/index.tsx
+++ b/frontend/src/components/PrivateRouter/index.tsx
@@ -1,5 +1,5 @@
 import { PATH_NAME, QUERY_KEY, ERROR_MESSAGES } from "@src/@constants";
-import { isAuthenticated } from "@src/api/auth";
+import { isCertificated } from "@src/api/auth";
 import useSnackbar from "@src/hooks/useSnackbar";
 import { useEffect } from "react";
 import { useQuery } from "react-query";
@@ -16,7 +16,7 @@ function PrivateRouter({ children }: Props) {
 
   const { isLoading, isError } = useQuery(
     QUERY_KEY.AUTHENTICATION,
-    isAuthenticated,
+    isCertificated,
     {
       useErrorBoundary: false,
       retry: false,

--- a/frontend/src/components/PublicRouter/index.tsx
+++ b/frontend/src/components/PublicRouter/index.tsx
@@ -1,5 +1,5 @@
 import { PATH_NAME, QUERY_KEY } from "@src/@constants";
-import { isAuthenticated } from "@src/api/auth";
+import { isCertificated } from "@src/api/auth";
 import { useEffect } from "react";
 import { useQuery } from "react-query";
 import { useNavigate } from "react-router-dom";
@@ -14,7 +14,7 @@ function PublicRouter({ children }: Props) {
 
   const { isLoading, isSuccess } = useQuery(
     QUERY_KEY.AUTHENTICATION,
-    isAuthenticated,
+    isCertificated,
     {
       useErrorBoundary: false,
       retry: false,

--- a/frontend/src/mocks/handlers/auth.ts
+++ b/frontend/src/mocks/handlers/auth.ts
@@ -1,7 +1,7 @@
 import { rest } from "msw";
 
 const handlers = [
-  rest.get("/api/auth", (req, res, ctx) => {
+  rest.get("/api/certification", (req, res, ctx) => {
     return res(ctx.status(200), ctx.delay(500));
   }),
 ];


### PR DESCRIPTION
## 요약

사용자 인증 관련 API 연동 및 요청시 실제 토큰 삽입하도록 수정

## 작업 내용

- 사용자 인증 관련 API 연동  `/api/certification` 연동
- 임시토큰 -> 실제 토큰으로 수정 


## 관련 이슈

- Close #266 

<br><br>
