### PR TITLE
feat: logback maxHistory 수정. 5 -> 2

### DIFF
--- a/backend/src/main/resources/appenders/async-file-appender-info.xml
+++ b/backend/src/main/resources/appenders/async-file-appender-info.xml
@@ -16,7 +16,7 @@
         <rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
             <fileNamePattern>${FILE_PATH}/%d{yyyy-MM-dd}/info/info_%i.log</fileNamePattern>
             <maxFileSize>5MB</maxFileSize>
-            <maxHistory>5</maxHistory>
+            <maxHistory>2</maxHistory>
             <totalSizeCap>30MB</totalSizeCap>
         </rollingPolicy>
 


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용

로그백 maxHistory 설정을 5에서 2로 변경합니다.

<br><br>

## 참고 사항

3차 데모데이 발표시에 사용될 로그 설정 관련 자료 확인차 작업합니다.
기존 5일로 설정했는데 5일 이상 된 파일이 삭제되지 않고 있어서 진행합니다.

<br><br>
