### PR TITLE
feat: 로그인 시 최초 로그인 여부 응답

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
@@ -22,8 +22,7 @@ public class AuthController {
 
     @GetMapping("/slack-login")
     public LoginResponse login(@RequestParam @NotEmpty final String code) {
-        String token = authService.login(code);
-        return new LoginResponse(token);
+        return authService.login(code);
     }
 
     @GetMapping("/certification")

--- a/backend/src/main/java/com/pickpick/auth/ui/dto/LoginResponse.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/dto/LoginResponse.java
@@ -1,5 +1,7 @@
 package com.pickpick.auth.ui.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
 import lombok.Getter;
 
 @Getter
@@ -7,7 +9,12 @@ public class LoginResponse {
 
     private String token;
 
-    public LoginResponse(final String token) {
+    @JsonProperty("isFirstLogin")
+    private boolean firstLogin;
+
+    @Builder
+    public LoginResponse(final String token, final boolean firstLogin) {
         this.token = token;
+        this.firstLogin = firstLogin;
     }
 }

--- a/backend/src/main/java/com/pickpick/member/domain/Member.java
+++ b/backend/src/main/java/com/pickpick/member/domain/Member.java
@@ -29,6 +29,9 @@ public class Member {
     @Column(name = "thumbnail_url", length = 2048, nullable = false)
     private String thumbnailUrl;
 
+    @Column(name = "first_login", nullable = false)
+    private boolean firstLogin = true;
+
     protected Member() {
     }
 
@@ -36,6 +39,10 @@ public class Member {
         this.slackId = slackId;
         this.username = username;
         this.thumbnailUrl = thumbnailUrl;
+    }
+
+    public void markLoggedIn() {
+        this.firstLogin = false;
     }
 
     public void update(final String username, final String thumbnailUrl) {

--- a/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
@@ -2,11 +2,13 @@ package com.pickpick.auth.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.auth.ui.dto.LoginResponse;
 import com.pickpick.exception.InvalidTokenException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -48,7 +50,7 @@ class AuthServiceTest {
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;
 
-    @DisplayName("로그인")
+    @DisplayName("최초 로그인 시 토큰과 isFirstLogin true, 두번째 이후부턴 토큰과 false가 반환되어야 한다")
     @Test
     void login() throws SlackApiException, IOException {
         // given
@@ -61,10 +63,16 @@ class AuthServiceTest {
                 .willReturn(generateUsersIdentityResponse(member.getSlackId()));
 
         // when
-        String jupjupToken = authService.login("1234");
+        LoginResponse firstLoginResponse = authService.login("1234");
+        LoginResponse secondLoginResponse = authService.login("1234");
 
         // then
-        assertThat(jupjupToken).isNotBlank();
+        assertAll(
+                () -> assertThat(firstLoginResponse.getToken()).isNotEmpty(),
+                () -> assertThat(firstLoginResponse.isFirstLogin()).isTrue(),
+                () -> assertThat(secondLoginResponse.getToken()).isNotEmpty(),
+                () -> assertThat(secondLoginResponse.isFirstLogin()).isFalse()
+        );
     }
 
     private OAuthV2AccessResponse generateOAuthV2AccessResponse() {


### PR DESCRIPTION
## 요약

로그인 시, 응답 body에 최초 로그인 여부를 함께 응답하도록 구성

<br><br>

## 작업 내용

- Member 엔티티 내 최초 로그인 여부를 구분할 boolean 필드 추가
- AuthService 내 로그인 시, Member 조회하여 최초 로그인 여부 변수 할당 후, markLoggedIn 메서드로 최초 로그인 여부 false 할당

<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #300 

<br><br>
