### PR TITLE
feat: local, dev 환경에서만 CORS 허용

### DIFF
--- a/backend/src/main/java/com/pickpick/config/CorsConfig.java
+++ b/backend/src/main/java/com/pickpick/config/CorsConfig.java
@@ -1,10 +1,12 @@
 package com.pickpick.config;
 
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
+@Profile({"local", "dev"})
 @Configuration
 public class CorsConfig implements WebMvcConfigurer {
     public static final String ALLOWED_METHOD_NAMES = "GET,HEAD,POST,PUT,DELETE,TRACE,OPTIONS,PATCH";


### PR DESCRIPTION
## 요약

- 운영환경(prod)에선 CORS 설정을 제거합니다
- 로컬, 개발환경에선 CORS 설정을 유지합니다

<br><br>

## 작업 내용

- CorsConfig 클래스에 `@Profile({"local", "dev"})` 애너테이션 추가

<br><br>

## 참고 사항

https://www.youtube.com/watch?v=7GaXw-d4fMs

<br><br>

## 관련 이슈

- Close #318

<br><br>
