### PR TITLE
feat: Slack 관련 프로퍼티 객체로 관리하도록 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -23,6 +23,7 @@ repositories {
 }
 
 dependencies {
+    implementation 'org.springframework.boot:spring-boot-configuration-processor'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
@@ -34,6 +35,7 @@ dependencies {
     compileOnly 'org.projectlombok:lombok'
 
     annotationProcessor 'org.projectlombok:lombok'
+    annotationProcessor "org.springframework.boot:spring-boot-configuration-processor"
 
     runtimeOnly 'com.h2database:h2'
     runtimeOnly 'mysql:mysql-connector-java'

--- a/backend/src/main/java/com/pickpick/PickpickApplication.java
+++ b/backend/src/main/java/com/pickpick/PickpickApplication.java
@@ -2,7 +2,9 @@ package com.pickpick;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 
+@ConfigurationPropertiesScan
 @SpringBootApplication
 public class PickpickApplication {
 

--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -2,6 +2,7 @@ package com.pickpick.auth.application;
 
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.auth.ui.dto.LoginResponse;
+import com.pickpick.config.SlackProperties;
 import com.pickpick.exception.SlackClientException;
 import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
@@ -12,33 +13,23 @@ import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.slack.api.methods.request.users.UsersIdentityRequest;
 import java.io.IOException;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Slf4j
 @Service
 public class AuthService {
 
-    private final String clientId;
-    private final String clientSecret;
-    private final String redirectUrl;
-
     private final MemberRepository members;
     private final MethodsClient slackClient;
     private final JwtTokenProvider jwtTokenProvider;
+    private final SlackProperties slackProperties;
 
-    public AuthService(@Value("${slack.client-id}") final String clientId,
-                       @Value("${slack.client-secret}") final String clientSecret,
-                       @Value("${slack.redirect-url}") final String redirectUrl,
-                       final MemberRepository members,
-                       final MethodsClient slackClient,
-                       final JwtTokenProvider jwtTokenProvider) {
-        this.clientId = clientId;
-        this.clientSecret = clientSecret;
-        this.redirectUrl = redirectUrl;
+    public AuthService(final MemberRepository members, final MethodsClient slackClient,
+                       final JwtTokenProvider jwtTokenProvider, final SlackProperties slackProperties) {
         this.members = members;
         this.slackClient = slackClient;
         this.jwtTokenProvider = jwtTokenProvider;
+        this.slackProperties = slackProperties;
     }
 
     public LoginResponse login(final String code) {
@@ -63,9 +54,9 @@ public class AuthService {
 
     private String requestSlackToken(final String code) throws IOException, SlackApiException {
         OAuthV2AccessRequest request = OAuthV2AccessRequest.builder()
-                .clientId(clientId)
-                .clientSecret(clientSecret)
-                .redirectUri(redirectUrl)
+                .clientId(slackProperties.getClientId())
+                .clientSecret(slackProperties.getClientSecret())
+                .redirectUri(slackProperties.getRedirectUrl())
                 .code(code)
                 .build();
 

--- a/backend/src/main/java/com/pickpick/config/SlackConfig.java
+++ b/backend/src/main/java/com/pickpick/config/SlackConfig.java
@@ -2,18 +2,22 @@ package com.pickpick.config;
 
 import com.slack.api.Slack;
 import com.slack.api.methods.MethodsClient;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 @Configuration
 public class SlackConfig {
 
-    @Value("${slack.bot-token}")
-    private String token;
+    private final SlackProperties slackProperties;
+
+    public SlackConfig(final SlackProperties slackProperties) {
+        this.slackProperties = slackProperties;
+    }
 
     @Bean
     public MethodsClient methodsClient() {
-        return Slack.getInstance().methods(token);
+        String botToken = slackProperties.getBotToken();
+
+        return Slack.getInstance().methods(botToken);
     }
 }

--- a/backend/src/main/java/com/pickpick/config/SlackProperties.java
+++ b/backend/src/main/java/com/pickpick/config/SlackProperties.java
@@ -1,0 +1,32 @@
+package com.pickpick.config;
+
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.ConstructorBinding;
+
+@Getter
+@ConstructorBinding
+@ConfigurationProperties(prefix = "slack")
+public class SlackProperties {
+
+    @NotBlank
+    private final String botToken;
+
+    @NotBlank
+    private final String clientId;
+
+    @NotBlank
+    private final String clientSecret;
+
+    @NotBlank
+    private final String redirectUrl;
+
+    public SlackProperties(final String botToken, final String clientId, final String clientSecret,
+                           final String redirectUrl) {
+        this.botToken = botToken;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        this.redirectUrl = redirectUrl;
+    }
+}


### PR DESCRIPTION
## 요약

- Slack 관련 정보 객체로 관리

<br><br>

## 작업 내용

- SlackProperties 객체에서 yaml내 Slack 관련 정보를 주입받아 Bean으로 관리되도록 설정
- Slack 관련 yaml을 직접 Value로 가져가던 코드들을 SlackProperties 객체를 의존하도록 변경

<br><br>

## 관련 이슈

- Close #320

<br><br>
