### PR TITLE
hotfix: 북마크 메시지의 유저가 본인으로 보이는 오류 정정

### DIFF
--- a/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponse.java
@@ -1,6 +1,5 @@
 package com.pickpick.message.ui.dto;
 
-import com.pickpick.member.domain.Member;
 import com.pickpick.message.domain.Bookmark;
 import com.pickpick.message.domain.Message;
 import java.time.LocalDateTime;
@@ -39,14 +38,13 @@ public class BookmarkResponse {
     }
 
     public static BookmarkResponse from(final Bookmark bookmark) {
-        Member member = bookmark.getMember();
         Message message = bookmark.getMessage();
 
         return BookmarkResponse.builder()
                 .id(bookmark.getId())
-                .memberId(member.getId())
-                .username(member.getUsername())
-                .userThumbnail(member.getThumbnailUrl())
+                .memberId(message.getMember().getId())
+                .username(message.getMember().getUsername())
+                .userThumbnail(message.getMember().getThumbnailUrl())
                 .text(message.getText())
                 .postedDate(message.getPostedDate())
                 .modifiedDate(message.getModifiedDate())


### PR DESCRIPTION
## 요약

북마크 메시지의 유저가 본인으로 보이는 오류 정정

<br>

## 작업 내용

북마크 메시지의 작성자 본인으로 보이는 오류 정정
북마크를 한 유저의 정보를 담고 있었습니다 😅

<br>

