### PR TITLE
hotfix: 메시지 본문에 작성자 썸네일 주소가 들어가는 오류 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -236,7 +236,7 @@ public class MessageService {
                 .memberId(member.getId())
                 .username(member.getUsername())
                 .userThumbnail(member.getThumbnailUrl())
-                .text(member.getThumbnailUrl())
+                .text(message.getText())
                 .postedDate(message.getPostedDate())
                 .modifiedDate(message.getModifiedDate())
                 .isBookmarked(isBookmarked)


### PR DESCRIPTION
## 요약

메시지 본문에 작성자 썸네일 주소가 들어가는 오류 수정  

<br>

## 작업 내용

메시지 본문 텍스트에 작성자 썸네일 주소가 들어가고 있었습니다  
정상적으로 메시지 본문을 담도록 수정했어요  

<br>
