### PR TITLE
fix: isFirstLogin이 항상 true로 반환되던 오류 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -12,6 +12,7 @@ import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.slack.api.methods.request.users.UsersIdentityRequest;
 import java.io.IOException;
+import javax.transaction.Transactional;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +33,11 @@ public class AuthService {
         this.slackProperties = slackProperties;
     }
 
+    public void verifyToken(final String token) {
+        jwtTokenProvider.validateToken(token);
+    }
+
+    @Transactional
     public LoginResponse login(final String code) {
         try {
             String token = requestSlackToken(code);
@@ -73,9 +79,5 @@ public class AuthService {
         return slackClient.usersIdentity(request)
                 .getUser()
                 .getId();
-    }
-
-    public void verifyToken(final String token) {
-        jwtTokenProvider.validateToken(token);
     }
 }

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
@@ -20,14 +20,14 @@ public class AuthController {
         this.authService = authService;
     }
 
-    @GetMapping("/slack-login")
-    public LoginResponse login(@RequestParam @NotEmpty final String code) {
-        return authService.login(code);
-    }
-
     @GetMapping("/certification")
     public void verifyToken(final HttpServletRequest request) {
         String token = AuthorizationExtractor.extract(request);
         authService.verifyToken(token);
+    }
+
+    @GetMapping("/slack-login")
+    public LoginResponse login(@RequestParam @NotEmpty final String code) {
+        return authService.login(code);
     }
 }

--- a/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
@@ -28,10 +28,8 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
 @AutoConfigureMockMvc
-@Transactional
 @SpringBootTest
 class AuthServiceTest {
 


### PR DESCRIPTION
## 요약

isFirstLogin 응답 오류 수정

<br><br>

## 작업 내용

첫 로그인 여부를 나타내는 로그인 응답값 필드 `isFirstLogin` 이 항상 true로 반환되던 오류 수정

<br><br>

## 참고 사항

- https://javabom.tistory.com/103
- 테스트코드에만 Transactional 애너테이션 적용, 프로덕션에선 놓침
- SpringBootTest에서는 Transactional 애너테이션을 제거하고, DatabaseCleaner를 서둘러 도입하면 좋을 것 같습니다
- 연로그가 원인에 대해 미리 알려줘서 수월하게 작업할 수 있었습니다. 그래서 공동작업자로 추가하였습니다
- 커밋이 이상하게 자꾸 추가되어 푸시가 되는데 원인을 잘 모르겠네요 먼저 올라온 PR들 머지되고 나서 다시 살펴보겠습니다

<br><br>

## 관련 이슈

- #321  과 충돌날 것 같아요. #321을 먼저 merge 해주시면 그 뒤에 이 PR을 수정해서 Ready for review로 바꾸겠습니다
- Close #332

<br><br>
