### PR TITLE
feat: Jacoco 플러그인 설정 추가

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -60,6 +60,16 @@ jobs:
           report_paths: '**/build/test-results/test/TEST-*.xml'
           token: ${{ github.token }}
 
+      - name: 테스트 커버리지를 PR에 코멘트로 등록합니다
+        id: jacoco
+        uses: madrapps/jacoco-report@v1.2
+        with:
+          title: 📝 테스트 커버리지 리포트입니다
+          paths: ${{ github.workspace }}/backend/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 50
+          min-coverage-changed-files: 50
+
       - name: build 실패 시 Slack으로 알립니다
         uses: 8398a7/action-slack@v3
         with:

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id 'jacoco'
 }
 
 group = 'com.pickpick'
@@ -54,6 +55,7 @@ ext {
 test {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy jacocoTestReport
 }
 
 asciidoctor {
@@ -100,4 +102,16 @@ sourceSets {
 }
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
+}
+
+jacoco {
+    toolVersion = "0.8.8"
+}
+
+jacocoTestReport {
+    dependsOn test
+    reports {
+        xml.enabled true
+        html.enabled true
+    }
 }


### PR DESCRIPTION
## 요약

정적 분석 리포트 중 하나인 코드 커버리지 분석 툴, Jacoco를 연동했습니다

<br><br>

## 작업 내용

- build.gradle 에 Jacoco 관련 설정을 추가했습니다
- 백엔드 Github Action 파일에 Jacoco 코멘트 기능을 추가했습니다

<br><br>

## 참고 사항

- 예시 이미지입니다

<img src="https://user-images.githubusercontent.com/62681566/183315501-700c0c4e-2522-49b3-9230-6f4b9b043bcd.png" width="300px">

<br><br>

- 관련 문서를 노션에 작성했습니다

https://www.notion.so/richard7/4-Jacoco-with-Github-Action-c23c4269218841728df09f8554984111

<br><br>

## 관련 이슈

- Close #341 

<br><br>
