### PR TITLE
refactor: 북마크 조회, 삭제 api 변경

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
+++ b/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
@@ -117,10 +117,10 @@ public class BookmarkService {
     }
 
     @Transactional
-    public void delete(final Long bookmarkId, final Long memberId) {
-        bookmarks.findByIdAndMemberId(bookmarkId, memberId)
-                .orElseThrow(() -> new BookmarkDeleteFailureException(bookmarkId, memberId));
+    public void delete(final Long messageId, final Long memberId) {
+        Bookmark bookmark = bookmarks.findByMessageIdAndMemberId(messageId, memberId)
+                .orElseThrow(() -> new BookmarkDeleteFailureException(messageId, memberId));
 
-        bookmarks.deleteById(bookmarkId);
+        bookmarks.deleteById(bookmark.getId());
     }
 }

--- a/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
@@ -9,8 +9,6 @@ public interface BookmarkRepository extends Repository<Bookmark, Long> {
 
     Optional<Bookmark> findById(Long id);
 
-    Optional<Bookmark> findByIdAndMemberId(Long id, Long memberId);
-
     Optional<Bookmark> findByMessageIdAndMemberId(Long messageId, Long memberId);
 
     void deleteById(Long id);

--- a/backend/src/main/java/com/pickpick/message/ui/BookmarkController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/BookmarkController.java
@@ -7,7 +7,6 @@ import com.pickpick.message.ui.dto.BookmarkResponses;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -38,10 +37,10 @@ public class BookmarkController {
         return bookmarkService.find(bookmarkId, memberId);
     }
 
-    @DeleteMapping("/{bookmarkId}")
+    @DeleteMapping
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void delete(final @AuthenticationPrincipal Long memberId,
-                       final @PathVariable Long bookmarkId) {
-        bookmarkService.delete(bookmarkId, memberId);
+                       final @RequestParam Long messageId) {
+        bookmarkService.delete(messageId, memberId);
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponse.java
@@ -41,7 +41,7 @@ public class BookmarkResponse {
         Message message = bookmark.getMessage();
 
         return BookmarkResponse.builder()
-                .id(bookmark.getId())
+                .id(message.getId())
                 .memberId(message.getMember().getId())
                 .username(message.getMember().getUsername())
                 .userThumbnail(message.getMember().getThumbnailUrl())

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -78,22 +78,22 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
     @Test
     void 북마크_정상_삭제() {
         // given
-        long bookmarkId = 2L;
+        long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "/" + bookmarkId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId, 1L);
 
         // then
         상태코드_확인(response, HttpStatus.NO_CONTENT);
     }
 
     @Test
-    void 다른_사용자의_북마크_삭제() {
+    void 사용자에게_존재하지_않는_북마크_삭제() {
         // given
-        long bookmarkId = 1L;
+        long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "/" + bookmarkId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId, 1L);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -122,7 +122,7 @@ class BookmarkServiceTest {
         bookmarks.save(bookmark);
 
         // when
-        bookmarkService.delete(bookmark.getId(), member.getId());
+        bookmarkService.delete(message.getId(), member.getId());
 
         // then
         Optional<Bookmark> actual = bookmarks.findById(bookmark.getId());


### PR DESCRIPTION
## 요약

북마크 조회, 삭제 api 변경  

<br>

## 작업 내용  

### 북마크 조회  

메세지 조회와 포맷이 동일해졌습니다  
**여기의 `id`는 메세지의 `id`입니다**  
다른 점은 배열이 `messages`로 감싸져 있느냐, `bookmarks`로 감싸져 있느냐네요   

GET /api/bookmarks  
authorization: Bearer "token"  
response 200 ok  

```json
{
    "bookmarks": [
        {
            "id" : 23,
	    "memberId" : 1,
	    "username" : "써머",
	    "userThumbnail" : "https://summer.png",
	    "text" : "Sample Text A",
	    "postedDate" : "2022-07-17T13:21:55",
	    "modifiedDate" : "2022-07-17T13:21:55"
        }, 
        {
            "id" : 23,
	    "memberId" : 1,
	    "username" : "써머",
	    "userThumbnail" : "https://summer.png",
	    "text" : "Sample Text A",
	    "postedDate" : "2022-07-17T13:21:55",
	    "modifiedDate" : "2022-07-17T13:21:55"
        },
    ],
    "isLast": false
}
```

<br>

#### 북마크 삭제  

DELETE /api/bookmarks?messageId=:messageId  
authroization: Bearer "token"  
response 204 no-content  

쿼리 파라미터 `messageId`에 메세지 `id`가 들어갑니다  

<br>

## 관련 이슈

- Close #345   

<br><br>
