### PR TITLE
feat: TEAM_JOIN 이벤트 구현

### DIFF
--- a/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
@@ -14,6 +14,7 @@ public enum SlackEvent {
     CHANNEL_RENAME("channel_rename", ""),
     CHANNEL_DELETED("channel_deleted", ""),
     MEMBER_CHANGED("user_profile_changed", ""),
+    MEMBER_JOIN("team_join", ""),
     ;
 
     private final String type;

--- a/backend/src/main/java/com/pickpick/slackevent/application/member/MemberJoinService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/member/MemberJoinService.java
@@ -1,0 +1,74 @@
+package com.pickpick.slackevent.application.member;
+
+import com.pickpick.member.domain.Member;
+import com.pickpick.member.domain.MemberRepository;
+import com.pickpick.slackevent.application.SlackEvent;
+import com.pickpick.slackevent.application.SlackEventService;
+import com.pickpick.slackevent.application.member.dto.MemberJoinDto;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+@Transactional
+@Service
+public class MemberJoinService implements SlackEventService {
+
+    private static final String USER = "user";
+    private static final String PROFILE = "profile";
+    private static final String SLACK_ID = "id";
+    private static final String DISPLAY_NAME = "display_name";
+    private static final String IMAGE_URL = "image_512";
+    private static final String REAL_NAME = "real_name";
+    private static final String EVENT = "event";
+
+    private final MemberRepository members;
+
+    public MemberJoinService(final MemberRepository members) {
+        this.members = members;
+    }
+
+    @Override
+    public void execute(final Map<String, Object> requestBody) {
+        MemberJoinDto memberJoinDto = convert(requestBody);
+
+        Member newMember = toMember(memberJoinDto);
+
+        members.save(newMember);
+    }
+
+    private MemberJoinDto convert(final Map<String, Object> requestBody) {
+        Map<String, Object> event = (Map) requestBody.get(EVENT);
+        Map<String, Object> user = (Map) event.get(USER);
+        Map<String, Object> profile = (Map) user.get(PROFILE);
+
+        return MemberJoinDto.builder()
+                .slackId((String) user.get(SLACK_ID))
+                .username(extractUsername(profile))
+                .thumbnailUrl((String) profile.get(IMAGE_URL))
+                .build();
+    }
+
+    private String extractUsername(final Map<String, Object> profile) {
+        String username = (String) profile.get(DISPLAY_NAME);
+
+        if (!StringUtils.hasText(username)) {
+            return (String) profile.get(REAL_NAME);
+        }
+
+        return username;
+    }
+
+    private Member toMember(final MemberJoinDto memberJoinDto) {
+        return new Member(
+                memberJoinDto.getSlackId(),
+                memberJoinDto.getUsername(),
+                memberJoinDto.getThumbnailUrl()
+        );
+    }
+
+    @Override
+    public boolean isSameSlackEvent(final SlackEvent slackEvent) {
+        return SlackEvent.MEMBER_JOIN == slackEvent;
+    }
+}

--- a/backend/src/main/java/com/pickpick/slackevent/application/member/dto/MemberJoinDto.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/member/dto/MemberJoinDto.java
@@ -1,0 +1,19 @@
+package com.pickpick.slackevent.application.member.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class MemberJoinDto {
+
+    private final String slackId;
+    private final String username;
+    private final String thumbnailUrl;
+
+    @Builder
+    public MemberJoinDto(final String slackId, final String username, final String thumbnailUrl) {
+        this.slackId = slackId;
+        this.username = username;
+        this.thumbnailUrl = thumbnailUrl;
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
@@ -1,11 +1,17 @@
 package com.pickpick.acceptance.member;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,15 +20,56 @@ import org.springframework.beans.factory.annotation.Autowired;
 @SuppressWarnings("NonAsciiCharacters")
 public class MemberAcceptanceTest extends AcceptanceTest {
 
+    private static final String SLACK_EVENT_API_URL = "/api/event";
+    private static final String SLACK_ID = "U03MKN0UW";
+
     @Autowired
-    private MemberRepository memberRepository;
+    private MemberRepository members;
 
     @Test
     void 프로젝트_기동_시점에_유저가_저장되어_있어야_한다() {
         // given
-        List<Member> members = memberRepository.findAll();
+        List<Member> members = this.members.findAll();
 
         // when & then
         assertThat(members.isEmpty()).isFalse();
+    }
+
+    @Test
+    void 슬랙_워크스페이스에_신규_멤버가_참여하면_저장되어야_한다() {
+        // given
+        int 신규_참여_전_멤버_수 = members.findAll().size();
+        Map<String, Object> teamJoinEvent = createTeamJoinEvent("진짜이름", "표시이름", "https://somebody.png");
+
+        // when
+        ExtractableResponse<Response> teamJoinEventResponse = post(SLACK_EVENT_API_URL, teamJoinEvent);
+        List<Member> 신규_참여_후_전체_멤버 = members.findAll();
+        int 신규_참여_후_멤버_수 = 신규_참여_후_전체_멤버.size();
+        Optional<Member> 신규_참여_멤버 = 신규_참여_후_전체_멤버.stream()
+                .max(Comparator.comparing(Member::getId));
+
+        // then
+        assertAll(
+                () -> 상태코드_200_확인(teamJoinEventResponse),
+                () -> assertThat(신규_참여_전_멤버_수 + 1).isEqualTo(신규_참여_후_멤버_수),
+                () -> assertThat(신규_참여_멤버).isPresent(),
+                () -> assertThat(신규_참여_멤버.get().getSlackId()).isEqualTo(SLACK_ID)
+        );
+    }
+
+    private Map<String, Object> createTeamJoinEvent(final String realName, final String displayName,
+                                                    final String thumbnailUrl) {
+        return Map.of(
+                "event", Map.of(
+                        "type", "team_join",
+                        "user", Map.of(
+                                "id", SLACK_ID,
+                                "profile", Map.of(
+                                        "real_name", realName,
+                                        "display_name", displayName,
+                                        "image_512", thumbnailUrl
+                                )
+                        )
+                ));
     }
 }

--- a/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
@@ -24,7 +24,8 @@ class SlackEventTest {
                         SlackEvent.MESSAGE_DELETED),
                 Arguments.of(Map.of("event", Map.of("type", "channel_rename")), SlackEvent.CHANNEL_RENAME),
                 Arguments.of(Map.of("event", Map.of("type", "channel_deleted")), SlackEvent.CHANNEL_DELETED),
-                Arguments.of(Map.of("event", Map.of("type", "user_profile_changed")), SlackEvent.MEMBER_CHANGED)
+                Arguments.of(Map.of("event", Map.of("type", "user_profile_changed")), SlackEvent.MEMBER_CHANGED),
+                Arguments.of(Map.of("event", Map.of("type", "team_join")), SlackEvent.MEMBER_JOIN)
         );
     }
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/member/MemberJoinServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/member/MemberJoinServiceTest.java
@@ -1,0 +1,79 @@
+package com.pickpick.slackevent.application.member;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import com.pickpick.member.domain.Member;
+import com.pickpick.member.domain.MemberRepository;
+import com.pickpick.slackevent.application.SlackEvent;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+@DisplayName("MemberJoinService는")
+@Import(MemberJoinService.class)
+@DataJpaTest
+class MemberJoinServiceTest {
+
+    private static final String SLACK_ID = "U03MKN0UW";
+
+    @Autowired
+    private MemberJoinService memberJoinService;
+
+    @Autowired
+    private MemberRepository members;
+
+    @DisplayName("MEMBER_JOIN 타입에 대해서만 true를 반환한다")
+    @CsvSource(value = {"MEMBER_JOIN,true",
+            "MESSAGE_CREATED,false", "MESSAGE_CHANGED,false", "MESSAGE_DELETED,false",
+            "CHANNEL_RENAME,false", "CHANNEL_DELETED,false", "MEMBER_CHANGED,false"})
+    @ParameterizedTest(name = "SlackEvent: {0} - Supports: {1}")
+    void supportsMemberJoinEvent(final SlackEvent slackEvent, final boolean expected) {
+        // given & when
+        boolean isSameSlackEvent = memberJoinService.isSameSlackEvent(slackEvent);
+
+        // then
+        assertThat(isSameSlackEvent).isEqualTo(expected);
+    }
+
+    @DisplayName("MEMBER_JOIN 이벤트가 전달되면, 신규 멤버를 저장한다")
+    @CsvSource(value = {"김진짜, 표시 이름, 표시 이름", "김진짜, '', 김진짜"})
+    @ParameterizedTest(name = "RealName: {0}, DisplayName: {1} -> ExpectedName: {2}")
+    void teamJoinEvent(final String realName, final String displayName, final String expectedName) {
+        // given
+        Optional<Member> memberBeforeSave = members.findBySlackId(SLACK_ID);
+        Map<String, Object> teamJoinEvent = createTeamJoinEvent(realName, displayName, expectedName);
+
+        // when
+        memberJoinService.execute(teamJoinEvent);
+        Optional<Member> memberAfterSave = members.findBySlackId(SLACK_ID);
+
+        // then
+        assertAll(
+                () -> assertThat(memberBeforeSave).isNotPresent(),
+                () -> assertThat(memberAfterSave).isPresent(),
+                () -> assertThat(memberAfterSave.get().getUsername()).isEqualTo(expectedName)
+        );
+    }
+
+    private Map<String, Object> createTeamJoinEvent(final String realName, final String displayName,
+                                                    final String thumbnailUrl) {
+        return Map.of(
+                "event", Map.of(
+                        "type", "team_join",
+                        "user", Map.of(
+                                "id", SLACK_ID,
+                                "profile", Map.of(
+                                        "real_name", realName,
+                                        "display_name", displayName,
+                                        "image_512", thumbnailUrl
+                                )
+                        )
+                ));
+    }
+}

--- a/backend/src/test/java/com/pickpick/slackevent/application/member/MemberJoinServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/member/MemberJoinServiceTest.java
@@ -41,7 +41,7 @@ class MemberJoinServiceTest {
         assertThat(isSameSlackEvent).isEqualTo(expected);
     }
 
-    @DisplayName("MEMBER_JOIN 이벤트가 전달되면, 신규 멤버를 저장한다")
+    @DisplayName("신규 멤버를 저장한다")
     @CsvSource(value = {"김진짜, 표시 이름, 표시 이름", "김진짜, '', 김진짜"})
     @ParameterizedTest(name = "RealName: {0}, DisplayName: {1} -> ExpectedName: {2}")
     void teamJoinEvent(final String realName, final String displayName, final String expectedName) {


### PR DESCRIPTION
## 요약

- 신규 멤버가 워크스페이스에 조인했을 때 회원 등록 처리 구현

<br><br>

## 작업 내용

- Slack Event 유형에 MEMBER_JOIN 추가
- Slack으로부터 전달되는 이벤트 컨텍스트까지는 `team_join`으로 표현
- 줍줍 도메인으로 넘어온 이후에는 `MEMBER_JOIN`으로 표현
- MemberJoinService 구현
- MemberJoinServiceTest 구현
- MemberAcceptanceTest 테스트코드 추가

<br><br>

## 참고 사항

- 워크스페이스에 신규 멤버가 참여했을 때의 이벤트 요청값을 노션에 저장해두었습니다.
- https://www.notion.so/richard7/4-TEAM_JOIN-event-154480a6515e4fbcb4eb9523fc80fb26

<br><br>

## 관련 이슈

- Close #253 

<br><br>
