### PR TITLE
fix: 변경된 북마크 API 반영

### DIFF
--- a/frontend/src/api/bookmarks.ts
+++ b/frontend/src/api/bookmarks.ts
@@ -29,8 +29,8 @@ export const postBookmark = async (messageId: string) => {
   );
 };
 
-export const deleteBookmark = async (bookmarkId: string) => {
-  await fetcher.delete(`${API_ENDPOINT.BOOKMARKS}/${bookmarkId}`, {
+export const deleteBookmark = async (messageId: string) => {
+  await fetcher.delete(`${API_ENDPOINT.BOOKMARKS}?messageId=${messageId}`, {
     headers: { ...getPrivateHeaders() },
   });
 };


### PR DESCRIPTION
## 요약

백엔드에서 변경된 API 명세 반영했습니다.
이제 Feed Page 에서도 북마크 토글 잘 될거예요.
조회 관련 바뀐 부분은, 프론트엔드에서 적용할 부분이 없었습니다. 

## 작업 내용

```
북마크 삭제 API 

- 이전
/api/bookmarks/bookmarkId
- 현재 
/api/bookmarks?messageId=:messageId
```

## 참고 사항

- https://github.com/woowacourse-teams/2022-pickpick/pull/355

## 관련 이슈

- Close #359 

<br><br>
