### PR TITLE
feat: 예외 클래스별 클라이언트 메시지 및 해당 메시지 조회 메서드 추가

### DIFF
--- a/backend/src/main/java/com/pickpick/exception/BadRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/BadRequestException.java
@@ -2,7 +2,13 @@ package com.pickpick.exception;
 
 public class BadRequestException extends RuntimeException {
 
+    private static final String CLIENT_MESSAGE = "요청 값이 잘못되었습니다.";
+
     public BadRequestException(final String message) {
         super(message);
+    }
+
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/NotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/NotFoundException.java
@@ -2,7 +2,13 @@ package com.pickpick.exception;
 
 public class NotFoundException extends RuntimeException {
 
+    private static final String CLIENT_MESSAGE = "해당 정보를 조회하지 못했습니다.";
+
     public NotFoundException(final String message) {
         super(message);
+    }
+
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/ChannelInvalidNameException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/ChannelInvalidNameException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class ChannelInvalidNameException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 채널 이름입니다.";
+    private static final String DEFAULT_MESSAGE = "유효하지 않은 채널 이름";
+    private static final String CLIENT_MESSAGE = "유효하지 않은 채널 이름입니다.";
 
     public ChannelInvalidNameException(final String name) {
         super(String.format("%s -> channel name: %s", DEFAULT_MESSAGE, name));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/ChannelNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/ChannelNotFoundException.java
@@ -4,7 +4,8 @@ import com.pickpick.exception.NotFoundException;
 
 public class ChannelNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "채널을 찾지 못했습니다";
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 채널 조회";
+    private static final String CLIENT_MESSAGE = "채널을 찾지 못했습니다.";
 
     public ChannelNotFoundException(final Long id) {
         super(String.format("%s -> channel id: %d", DEFAULT_MESSAGE, id));
@@ -12,5 +13,10 @@ public class ChannelNotFoundException extends NotFoundException {
 
     public ChannelNotFoundException(final String slackId) {
         super(String.format("%s -> channel slack id: %s", DEFAULT_MESSAGE, slackId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
@@ -7,8 +7,8 @@ public class SubscriptionDuplicateException extends BadRequestException {
     private static final String DEFAULT_MESSAGE = "구독 중인 채널 중복 구독 시도";
     private static final String CLIENT_MESSAGE = "이미 구독 중인 채널입니다.";
 
-    public SubscriptionDuplicateException(final Long id) {
-        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, id));
+    public SubscriptionDuplicateException(final Long channelId) {
+        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, channelId));
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionDuplicateException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "이미 구독 중인 채널입니다.";
+    private static final String DEFAULT_MESSAGE = "구독 중인 채널 중복 구독 시도";
+    private static final String CLIENT_MESSAGE = "이미 구독 중인 채널입니다.";
 
     public SubscriptionDuplicateException(final Long id) {
-        super(String.format("%s -> subscription id: %d", DEFAULT_MESSAGE, id));
+        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, id));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionInvalidOrderException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionInvalidOrderException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionInvalidOrderException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "구독 순서는 1 이상이여야합니다.";
+    private static final String DEFAULT_MESSAGE = "구독 순서에 0 이하의 수 입력";
+    private static final String CLIENT_MESSAGE = "구독 순서는 1 이상이여야합니다.";
 
     public SubscriptionInvalidOrderException() {
         super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
@@ -7,8 +7,8 @@ public class SubscriptionNotExistException extends BadRequestException {
     private static final String DEFAULT_MESSAGE = "구독 중이 아닌 채널을 구독 조회";
     private static final String CLIENT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
 
-    public SubscriptionNotExistException(final Long id) {
-        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, id));
+    public SubscriptionNotExistException(final Long channelId) {
+        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, channelId));
     }
 
     public SubscriptionNotExistException(final String message) {

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
@@ -4,13 +4,19 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionNotExistException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
+    private static final String DEFAULT_MESSAGE = "구독 중이 아닌 채널을 구독 조회";
+    private static final String CLIENT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
 
     public SubscriptionNotExistException(final Long id) {
-        super(String.format("%s -> subscription id: %d", DEFAULT_MESSAGE, id));
+        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, id));
     }
 
     public SubscriptionNotExistException(final String message) {
         super(message);
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.NotFoundException;
 
 public class SubscriptionNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "해당 멤버가 구독 중인 채널이 없습니다.";
+    private static final String DEFAULT_MESSAGE = "채널 구독이 0개인 멤버로 구독 목록 조회";
+    private static final String CLIENT_MESSAGE = "해당 멤버가 구독 중인 채널이 없습니다.";
 
     public SubscriptionNotFoundException(final Long memberId) {
         super(String.format("%s -> member id: %d", DEFAULT_MESSAGE, memberId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
@@ -8,7 +8,7 @@ public class SubscriptionNotFoundException extends NotFoundException {
     private static final String CLIENT_MESSAGE = "해당 멤버가 구독 중인 채널이 없습니다.";
 
     public SubscriptionNotFoundException(final Long memberId) {
-        super(String.format("%s -> member id: %d", DEFAULT_MESSAGE, memberId));
+        super(String.format("%s -> subscription member id: %d", DEFAULT_MESSAGE, memberId));
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionOrderDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionOrderDuplicateException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionOrderDuplicateException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "요청한 구독 순서 내부에 중복이 존재합니다.";
+    private static final String DEFAULT_MESSAGE = "중복된 구독 순서 요청";
+    private static final String CLIENT_MESSAGE = "요청한 구독 순서 내부에 중복이 존재합니다.";
 
     public SubscriptionOrderDuplicateException() {
         super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/member/MemberInvalidThumbnailUrlException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberInvalidThumbnailUrlException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class MemberInvalidThumbnailUrlException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 이미지 주소입니다.";
+    private static final String DEFAULT_MESSAGE = "유효하지 않은 이미지 주소";
+    private static final String CLIENT_MESSAGE = "유효하지 않은 이미지 주소입니다.";
 
     public MemberInvalidThumbnailUrlException(final String thumbnailUrl) {
         super(String.format("%s -> member thumbnail url: %s", DEFAULT_MESSAGE, thumbnailUrl));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/member/MemberInvalidUsernameException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberInvalidUsernameException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class MemberInvalidUsernameException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 사용자 이름입니다.";
+    private static final String DEFAULT_MESSAGE = "유효하지 않은 사용자 이름";
+    private static final String CLIENT_MESSAGE = "유효하지 않은 사용자 이름입니다.";
 
     public MemberInvalidUsernameException(final String username) {
         super(String.format("%s -> member username: %s", DEFAULT_MESSAGE, username));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/member/MemberNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberNotFoundException.java
@@ -4,13 +4,19 @@ import com.pickpick.exception.NotFoundException;
 
 public class MemberNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "사용자를 찾지 못했습니다";
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 멤버 조회";
+    private static final String CLIENT_MESSAGE = "사용자를 찾지 못했습니다.";
 
     public MemberNotFoundException(final Long id) {
         super(String.format("%s -> member id: %d", DEFAULT_MESSAGE, id));
     }
 
     public MemberNotFoundException(final String slackId) {
-        super(String.format("%s -> member id: %s", DEFAULT_MESSAGE, slackId));
+        super(String.format("%s -> member slack id: %s", DEFAULT_MESSAGE, slackId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class BookmarkDeleteFailureException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "해당 북마크를 삭제할 수 없습니다";
+    private static final String DEFAULT_MESSAGE = "외래키가 일치하는 북마크가 없어 삭제 목적 조회 실패";
+    private static final String CLIENT_MESSAGE = "해당 북마크를 삭제할 수 없습니다.";
 
     public BookmarkDeleteFailureException(final Long id, final Long memberId) {
-        super(String.format("%s -> bookmark id: %d, member id: %d", DEFAULT_MESSAGE, id, memberId));
+        super(String.format("%s -> bookmark message id: %d, member id: %d", DEFAULT_MESSAGE, id, memberId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
@@ -7,8 +7,8 @@ public class BookmarkDeleteFailureException extends BadRequestException {
     private static final String DEFAULT_MESSAGE = "외래키가 일치하는 북마크가 없어 삭제 목적 조회 실패";
     private static final String CLIENT_MESSAGE = "해당 북마크를 삭제할 수 없습니다.";
 
-    public BookmarkDeleteFailureException(final Long id, final Long memberId) {
-        super(String.format("%s -> bookmark message id: %d, member id: %d", DEFAULT_MESSAGE, id, memberId));
+    public BookmarkDeleteFailureException(final Long messageId, final Long memberId) {
+        super(String.format("%s -> bookmark message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkNotFoundException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.NotFoundException;
 
 public class BookmarkNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "북마크를 찾지 못했습니다";
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 북마크 조회";
+    private static final String CLIENT_MESSAGE = "북마크를 찾지 못했습니다.";
 
     public BookmarkNotFoundException(final Long id) {
         super(String.format("%s -> bookmark id: %d", DEFAULT_MESSAGE, id));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/MessageNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/MessageNotFoundException.java
@@ -4,7 +4,8 @@ import com.pickpick.exception.NotFoundException;
 
 public class MessageNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "메시지를 찾지 못했습니다";
+    private static final String DEFAULT_MESSAGE = "존재하지 않는 메시지 조회";
+    private static final String CLIENT_MESSAGE = "메시지를 찾지 못했습니다.";
 
     public MessageNotFoundException(final Long id) {
         super(String.format("%s -> message id: %d", DEFAULT_MESSAGE, id));
@@ -12,5 +13,10 @@ public class MessageNotFoundException extends NotFoundException {
 
     public MessageNotFoundException(final String slackId) {
         super(String.format("%s -> message slack id: %s", DEFAULT_MESSAGE, slackId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventNotFoundException.java
@@ -4,9 +4,15 @@ import com.pickpick.exception.NotFoundException;
 
 public class SlackEventNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "지원하지 않는 Slack Event 입니다";
+    private static final String DEFAULT_MESSAGE = "대응하는 enum 값이 없는 Slack Event 요청";
+    private static final String CLIENT_MESSAGE = "지원하지 않는 Slack Event 입니다.";
 
     public SlackEventNotFoundException(final String type, final String subtype) {
         super(String.format("%s -> type: %s, subtype: %s", DEFAULT_MESSAGE, type, subtype));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventServiceNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventServiceNotFoundException.java
@@ -5,10 +5,15 @@ import com.pickpick.slackevent.application.SlackEvent;
 
 public class SlackEventServiceNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "Service를 지원하지 않는 SlackEvent입니다.";
+    private static final String DEFAULT_MESSAGE = "대응하는 Service 클래스가 없는 Slack Event 요청";;
+    private static final String CLIENT_MESSAGE = "지원하지 않는 SlackEvent입니다.";
 
     public SlackEventServiceNotFoundException(final SlackEvent slackEvent) {
         super(String.format("%s -> type: %s, subtype: %s", DEFAULT_MESSAGE, slackEvent.getType(),
                 slackEvent.getSubtype()));
+    }
+
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }


### PR DESCRIPTION
## 요약

예외 클래스별 클라이언트 메시지 및 해당 메시지 조회 메서드 추가

<br>

## 작업 내용

이어서 작업할 `InvalidTokenException`을 제외한 커스텀 예외 클래스에 클라이언트 메시지를 추가했습니다  
메시지 추가 외에 변경된 사안입니다  

1.  상속 대상인 `BadRequestException`, `NotFoundException`에 `getClientMessage()`를 정의하고 `override` 하는 구조로 추가했습니다  
원래 각 클래스에서만 추가하려고 했는데, 그렇게 하니 `controllerAdvice`에서 `BadRequestException`, `NotFoundException`로 예외를 캐치하고 있어서 개별 메서드의 `getClientMessage()`를 호출할 수 없었어요 🥲  
그래서 임의로 이런 구조로 추가했는데 더 나은 방안이 떠오르신다면 알려주세요  

2. 예외 클래스가 사용되는 맥락에 따라서 디폴트/클라이언트 메시지를 임의로 수정/작성했습니다  

3. 기존 `String.format~`에 받는 값과 로깅 형식이 일치하지 않는 부분이 있어서 수정했습니다  

예외 메시지 제가 임의로 손댄 게 많아서 되돌리고 싶은 부분, 변경 필요한 부분 있으면 얼마든지 남겨주세요!!  

<br>

## 관련 이슈

- Close #363 

<br>
