### PR TITLE
feat: 만료된 토큰 예외 처리 클래스 분리  

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
+++ b/backend/src/main/java/com/pickpick/auth/support/JwtTokenProvider.java
@@ -1,5 +1,6 @@
 package com.pickpick.auth.support;
 
+import com.pickpick.exception.auth.ExpiredTokenException;
 import com.pickpick.exception.auth.InvalidTokenException;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -41,9 +42,9 @@ public class JwtTokenProvider {
         try {
             parseClaims(token);
         } catch (ExpiredJwtException e) {
-            throw new InvalidTokenException("만료된 토큰입니다.");
+            throw new ExpiredTokenException();
         } catch (Exception e) {
-            throw new InvalidTokenException("유효하지 않은 토큰입니다.");
+            throw new InvalidTokenException();
         }
     }
 

--- a/backend/src/main/java/com/pickpick/exception/auth/ExpiredTokenException.java
+++ b/backend/src/main/java/com/pickpick/exception/auth/ExpiredTokenException.java
@@ -1,0 +1,18 @@
+package com.pickpick.exception.auth;
+
+import com.pickpick.exception.BadRequestException;
+
+public class ExpiredTokenException extends BadRequestException {
+
+    private static final String DEFAULT_MESSAGE = "만료된 토큰으로 요청";
+    private static final String CLIENT_MESSAGE = "만료된 토큰입니다.";
+
+    public ExpiredTokenException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/auth/InvalidTokenException.java
+++ b/backend/src/main/java/com/pickpick/exception/auth/InvalidTokenException.java
@@ -4,7 +4,15 @@ import com.pickpick.exception.BadRequestException;
 
 public class InvalidTokenException extends BadRequestException {
 
-    public InvalidTokenException(final String message) {
-        super(message);
+    private static final String DEFAULT_MESSAGE = "유효하지 않은 토큰으로 요청";
+    private static final String CLIENT_MESSAGE = "유효하지 않은 토큰입니다.";
+
+    public InvalidTokenException() {
+        super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
     }
 }

--- a/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.auth.ui.dto.LoginResponse;
+import com.pickpick.exception.auth.ExpiredTokenException;
 import com.pickpick.exception.auth.InvalidTokenException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -107,8 +108,7 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.verifyToken(token))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessageContaining("유효하지 않은 토큰입니다.");
+                .isInstanceOf(InvalidTokenException.class);
     }
 
     @DisplayName("만료된 토큰을 검증한다.")
@@ -120,8 +120,7 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.verifyToken(token))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessageContaining("만료된 토큰입니다.");
+                .isInstanceOf(ExpiredTokenException.class);
     }
 
     @DisplayName("시그니처가 다른 토큰을 검증한다.")
@@ -133,7 +132,6 @@ class AuthServiceTest {
 
         // when & then
         assertThatThrownBy(() -> authService.verifyToken(token))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessageContaining("유효하지 않은 토큰입니다.");
+                .isInstanceOf(InvalidTokenException.class);
     }
 }

--- a/backend/src/test/java/com/pickpick/auth/support/JwtTokenProviderTest.java
+++ b/backend/src/test/java/com/pickpick/auth/support/JwtTokenProviderTest.java
@@ -3,6 +3,7 @@ package com.pickpick.auth.support;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.pickpick.exception.auth.ExpiredTokenException;
 import com.pickpick.exception.auth.InvalidTokenException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,8 +40,7 @@ class JwtTokenProviderTest {
 
         // when & then
         assertThatThrownBy(() -> expiredTokenProvider.validateToken(token))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessageContaining("만료된 토큰입니다.");
+                .isInstanceOf(ExpiredTokenException.class);
     }
 
     @DisplayName("유효하지 않은 토큰 검증")
@@ -51,8 +51,7 @@ class JwtTokenProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessageContaining("유효하지 않은 토큰입니다.");
+                .isInstanceOf(InvalidTokenException.class);
     }
 
     @DisplayName("다른 시그니쳐로 생성된 토큰 검증")
@@ -65,7 +64,6 @@ class JwtTokenProviderTest {
 
         // when & then
         assertThatThrownBy(() -> jwtTokenProvider.validateToken(token))
-                .isInstanceOf(InvalidTokenException.class)
-                .hasMessageContaining("유효하지 않은 토큰입니다.");
+                .isInstanceOf(InvalidTokenException.class);
     }
 }


### PR DESCRIPTION
## 요약  

**#367 이 머지되면 해당하는 커밋만 남겨서 제가 머지할게요! approve만 해주세요!** 

`InvalidTokenException` 클래스로만 발생하는 토큰 예외 처리를 `ExpiredTokenException`로 추가 분리

<br>

## 작업 내용

기존 인증/인가를 추가하면서 유효 시간이 지난 토큰도 `InvalidTokenException`으로 처리했었는데요,  
이를 `ExpiredTokenException`으로 분리했습니다  
테스트 코드에서도 메시지 문자열 검사를 삭제했어요~   

<br>

## 관련 이슈

- Close #364 

<br>
