### PR TITLE
feat: 검색 기능 API 연동 및 SearchResult Page 개발

### DIFF
--- a/frontend/src/@constants/index.ts
+++ b/frontend/src/@constants/index.ts
@@ -5,6 +5,7 @@ export const PATH_NAME = {
   BOOKMARK: "/bookmark",
   ADD_CHANNEL: "/add-channel",
   CERTIFICATION: "/certification",
+  SEARCH_RESULT: "/search-result",
 } as const;
 
 export const QUERY_KEY = {

--- a/frontend/src/@utils/index.ts
+++ b/frontend/src/@utils/index.ts
@@ -102,3 +102,19 @@ export const getMessagesDate = (postedDate: string): string => {
 
   return `${givenDate.month}월 ${givenDate.date}일 ${givenDate.day}`;
 };
+
+export const convertSeparatorToKey = ({
+  value,
+  separator,
+  key,
+}: {
+  value: string;
+  separator: string;
+  key: string;
+}) => {
+  if (value.search(separator) === -1) {
+    return value;
+  }
+  // eslint-disable-next-line
+  return value.replace(/\,/g, key);
+};

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -81,7 +81,11 @@ const routes = [
       },
       {
         path: PATH_NAME.SEARCH_RESULT,
-        element: <SearchResult />,
+        element: (
+          <PrivateRouter>
+            <SearchResult />
+          </PrivateRouter>
+        ),
       },
       {
         path: "*",

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -12,6 +12,7 @@ import {
 } from "./pages";
 import PrivateRouter from "@src/components/PrivateRouter";
 import PublicRouter from "@src/components/PublicRouter";
+import SearchResult from "./pages/SearchResult";
 
 const routes = [
   {
@@ -77,6 +78,10 @@ const routes = [
       {
         path: PATH_NAME.CERTIFICATION,
         element: <Certification />,
+      },
+      {
+        path: PATH_NAME.SEARCH_RESULT,
+        element: <SearchResult />,
       },
       {
         path: "*",

--- a/frontend/src/api/messages.ts
+++ b/frontend/src/api/messages.ts
@@ -12,6 +12,7 @@ interface PageParam {
 interface HighOrderParam {
   date?: string;
   channelId?: string;
+  keyword?: string;
 }
 
 interface ReturnFunctionParam {
@@ -19,13 +20,15 @@ interface ReturnFunctionParam {
 }
 
 export const getMessages =
-  ({ date = "", channelId = "" }: HighOrderParam) =>
+  ({ date = "", channelId = "", keyword = "" }: HighOrderParam) =>
   async ({ pageParam }: ReturnFunctionParam) => {
     if (!pageParam) {
       const { data } = await fetcher.get<ResponseMessages>(
         `${API_ENDPOINT.MESSAGES}?channelIds=${
           !channelId || channelId === "main" ? "" : channelId
-        }&messageId=&needPastMessage=${true}&date=${date ?? ""}`,
+        }&keyword=${keyword}&messageId=&needPastMessage=${true}&date=${
+          date ?? ""
+        }`,
         {
           headers: { ...getPrivateHeaders() },
         }
@@ -43,7 +46,7 @@ export const getMessages =
     const { data } = await fetcher.get<ResponseMessages>(
       `${API_ENDPOINT.MESSAGES}?channelIds=${
         !channelId || channelId === "main" ? "" : channelId
-      }&messageId=${messageId}&needPastMessage=${needPastMessage}&date=${currentDate}`,
+      }&keyword=${keyword}&messageId=${messageId}&needPastMessage=${needPastMessage}&date=${currentDate}`,
       {
         headers: { ...getPrivateHeaders() },
       }

--- a/frontend/src/components/Drawer/style.ts
+++ b/frontend/src/components/Drawer/style.ts
@@ -9,6 +9,7 @@ export const Container = styled.div`
   height: calc(100% - 78px);
   padding: 20px 0;
   border-radius: 0 4px 4px 0;
+  z-index: 1;
 
   ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.CONTAINER.DEFAULT};

--- a/frontend/src/components/SearchForm/index.tsx
+++ b/frontend/src/components/SearchForm/index.tsx
@@ -4,13 +4,19 @@ import SearchInput from "@src/components/SearchInput";
 import * as Styled from "./style";
 import useSelectChannels from "@src/hooks/useSelectChannels";
 import useModal from "@src/hooks/useModal";
-import { FormEvent } from "react";
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { PATH_NAME } from "@src/@constants";
+import useSnackbar from "@src/hooks/useSnackbar";
 
 interface Props {
   channelId: number;
 }
 
 function SearchForm({ channelId }: Props) {
+  const navigate = useNavigate();
+  const [searchKeyword, setSearchKeyword] = useState("");
+
   const {
     channelsData,
     channelIds,
@@ -27,9 +33,32 @@ function SearchForm({ channelId }: Props) {
     handleCloseModal: handleCloseSearchOptions,
   } = useModal();
 
+  const { openFailureSnackbar } = useSnackbar();
+
   const handleSubmit = (event: FormEvent) => {
     event.preventDefault();
-    console.log("submit");
+
+    if (!channelIds.length) {
+      openFailureSnackbar("채널을 하나 이상 선택 후 검색 버튼을 눌러주세요.");
+
+      return;
+    }
+
+    if (!searchKeyword.length) {
+      openFailureSnackbar(
+        "검색할 키워드를 입력하신 후 검색 버튼을 눌러주세요."
+      );
+
+      return;
+    }
+
+    navigate(
+      `${PATH_NAME.SEARCH_RESULT}?keyword=${searchKeyword}&channelIds=${channelIds}`
+    );
+  };
+
+  const handleChangeSearchKeyword = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(event.target.value);
   };
 
   return (
@@ -41,6 +70,8 @@ function SearchForm({ channelId }: Props) {
         <SearchInput
           placeholder="검색 할 키워드를 입력해주세요."
           onFocus={handleOpenSearchOptions}
+          onChange={handleChangeSearchKeyword}
+          value={searchKeyword}
         >
           {channelsData && defaultChannel && isSearchInputFocused && (
             <SearchOptions

--- a/frontend/src/components/SearchForm/index.tsx
+++ b/frontend/src/components/SearchForm/index.tsx
@@ -1,0 +1,60 @@
+import Dimmer from "@src/components/@shared/Dimmer";
+import SearchOptions from "@src/components/SearchOptions";
+import SearchInput from "@src/components/SearchInput";
+import * as Styled from "./style";
+import useSelectChannels from "@src/hooks/useSelectChannels";
+import useModal from "@src/hooks/useModal";
+import { FormEvent } from "react";
+
+interface Props {
+  channelId: number;
+}
+
+function SearchForm({ channelId }: Props) {
+  const {
+    channelsData,
+    channelIds,
+    defaultChannel,
+    handleToggleChannelId,
+    handleToggleAllChannelIds,
+  } = useSelectChannels({
+    defaultChannelId: channelId ? Number(channelId) : 0,
+  });
+
+  const {
+    isModalOpened: isSearchInputFocused,
+    handleOpenModal: handleOpenSearchOptions,
+    handleCloseModal: handleCloseSearchOptions,
+  } = useModal();
+
+  const handleSubmit = (event: FormEvent) => {
+    event.preventDefault();
+    console.log("submit");
+  };
+
+  return (
+    <>
+      {isSearchInputFocused && (
+        <Dimmer hasBackgroundColor={false} onClick={handleCloseSearchOptions} />
+      )}
+      <Styled.Container onSubmit={handleSubmit}>
+        <SearchInput
+          placeholder="검색 할 키워드를 입력해주세요."
+          onFocus={handleOpenSearchOptions}
+        >
+          {channelsData && defaultChannel && isSearchInputFocused && (
+            <SearchOptions
+              data={channelsData}
+              defaultChannel={defaultChannel}
+              channelIds={channelIds}
+              handleToggleChannelId={handleToggleChannelId}
+              handleToggleAllChannelIds={handleToggleAllChannelIds}
+            />
+          )}
+        </SearchInput>
+      </Styled.Container>
+    </>
+  );
+}
+
+export default SearchForm;

--- a/frontend/src/components/SearchForm/index.tsx
+++ b/frontend/src/components/SearchForm/index.tsx
@@ -4,19 +4,13 @@ import SearchInput from "@src/components/SearchInput";
 import * as Styled from "./style";
 import useSelectChannels from "@src/hooks/useSelectChannels";
 import useModal from "@src/hooks/useModal";
-import { ChangeEvent, FormEvent, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { PATH_NAME } from "@src/@constants";
-import useSnackbar from "@src/hooks/useSnackbar";
+import useSearchKeywordForm from "@src/hooks/useSearchKeywordForm";
 
 interface Props {
   channelId: number;
 }
 
 function SearchForm({ channelId }: Props) {
-  const navigate = useNavigate();
-  const [searchKeyword, setSearchKeyword] = useState("");
-
   const {
     channelsData,
     channelIds,
@@ -33,40 +27,18 @@ function SearchForm({ channelId }: Props) {
     handleCloseModal: handleCloseSearchOptions,
   } = useModal();
 
-  const { openFailureSnackbar } = useSnackbar();
-
-  const handleSubmit = (event: FormEvent) => {
-    event.preventDefault();
-
-    if (!channelIds.length) {
-      openFailureSnackbar("채널을 하나 이상 선택 후 검색 버튼을 눌러주세요.");
-
-      return;
-    }
-
-    if (!searchKeyword.length) {
-      openFailureSnackbar(
-        "검색할 키워드를 입력하신 후 검색 버튼을 눌러주세요."
-      );
-
-      return;
-    }
-
-    navigate(
-      `${PATH_NAME.SEARCH_RESULT}?keyword=${searchKeyword}&channelIds=${channelIds}`
-    );
-  };
-
-  const handleChangeSearchKeyword = (event: ChangeEvent<HTMLInputElement>) => {
-    setSearchKeyword(event.target.value);
-  };
+  const {
+    searchKeyword,
+    handleChangeSearchKeyword,
+    handleSubmitSearchKeyword,
+  } = useSearchKeywordForm({ channelIds });
 
   return (
     <>
       {isSearchInputFocused && (
         <Dimmer hasBackgroundColor={false} onClick={handleCloseSearchOptions} />
       )}
-      <Styled.Container onSubmit={handleSubmit}>
+      <Styled.Container onSubmit={handleSubmitSearchKeyword}>
         <SearchInput
           placeholder="검색 할 키워드를 입력해주세요."
           onFocus={handleOpenSearchOptions}

--- a/frontend/src/components/SearchForm/style.ts
+++ b/frontend/src/components/SearchForm/style.ts
@@ -1,0 +1,16 @@
+import { StyledDefaultProps } from "@src/@types/shared";
+import styled, { css } from "styled-components";
+
+export const Container = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 10px 14px;
+  width: 100%;
+  border-radius: 4px;
+  z-index: 1;
+
+  ${({ theme }: StyledDefaultProps) => css`
+    background-color: ${theme.COLOR.BACKGROUND.SECONDARY};
+  `}
+`;

--- a/frontend/src/components/SearchInput/index.tsx
+++ b/frontend/src/components/SearchInput/index.tsx
@@ -13,7 +13,7 @@ function SearchInput({ children, ...props }: Props) {
       <FlexRow gap="6px" alignItems="center">
         <SearchIcon width="20px" height="20px" fill="#8B8B8B" />
         <Styled.Input {...props} />
-        <Styled.SearchButton type="button">검색</Styled.SearchButton>
+        <Styled.SearchButton type="submit">검색</Styled.SearchButton>
       </FlexRow>
       {children}
     </Styled.Container>

--- a/frontend/src/components/SearchInput/style.ts
+++ b/frontend/src/components/SearchInput/style.ts
@@ -1,19 +1,7 @@
 import styled, { css } from "styled-components";
 import { StyledDefaultProps } from "@src/@types/shared";
 
-export const Container = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 10px 14px;
-  width: 100%;
-  border-radius: 4px;
-  z-index: 1;
-
-  ${({ theme }: StyledDefaultProps) => css`
-    background-color: ${theme.COLOR.BACKGROUND.SECONDARY};
-  `}
-`;
+export const Container = styled.div``;
 
 export const Input = styled.input`
   display: inline-block;

--- a/frontend/src/components/SearchOptions/index.tsx
+++ b/frontend/src/components/SearchOptions/index.tsx
@@ -29,6 +29,7 @@ function SearchOptions({
           isActive={channelIds.length === data.channels.length}
           size="small"
           onClick={handleToggleAllChannelIds}
+          type="button"
         >
           {channelIds.length === data.channels.length
             ? "전체 해제"
@@ -40,6 +41,7 @@ function SearchOptions({
           isActive={channelIds.includes(defaultId)}
           size="small"
           onClick={() => handleToggleChannelId(defaultId)}
+          type="button"
         >
           <>#{defaultName}</>
         </Button>
@@ -52,6 +54,7 @@ function SearchOptions({
               isActive={channelIds.includes(id)}
               size="small"
               onClick={() => handleToggleChannelId(id)}
+              type="button"
             >
               <>#{name}</>
             </Button>

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -39,7 +39,12 @@ function useModal(refetch?: Refetch): ReturnType {
 
       return;
     }
+
     document.body.style.overflowY = "auto";
+
+    return () => {
+      document.body.style.overflowY = "auto";
+    };
   }, [isModalOpened]);
 
   return {

--- a/frontend/src/hooks/useSearchKeywordForm.ts
+++ b/frontend/src/hooks/useSearchKeywordForm.ts
@@ -1,0 +1,54 @@
+import { ChangeEvent, FormEvent, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import useSnackbar from "@src/hooks/useSnackbar";
+import { PATH_NAME } from "@src/@constants";
+
+interface Props {
+  channelIds: (number | undefined)[];
+}
+
+interface ReturnType {
+  searchKeyword: string;
+  handleChangeSearchKeyword: (event: ChangeEvent<HTMLInputElement>) => void;
+  handleSubmitSearchKeyword: (event: FormEvent) => void;
+}
+
+function useSearchKeywordForm({ channelIds }: Props): ReturnType {
+  const navigate = useNavigate();
+  const { openFailureSnackbar } = useSnackbar();
+  const [searchKeyword, setSearchKeyword] = useState("");
+
+  const handleChangeSearchKeyword = (event: ChangeEvent<HTMLInputElement>) => {
+    setSearchKeyword(event.target.value);
+  };
+
+  const handleSubmitSearchKeyword = (event: FormEvent) => {
+    event.preventDefault();
+
+    if (!channelIds.length) {
+      openFailureSnackbar("채널을 하나 이상 선택 후 검색 버튼을 눌러주세요.");
+
+      return;
+    }
+
+    if (!searchKeyword.length) {
+      openFailureSnackbar(
+        "검색할 키워드를 입력하신 후 검색 버튼을 눌러주세요."
+      );
+
+      return;
+    }
+
+    navigate(
+      `${PATH_NAME.SEARCH_RESULT}?keyword=${searchKeyword}&channelIds=${channelIds}`
+    );
+  };
+
+  return {
+    searchKeyword,
+    handleChangeSearchKeyword,
+    handleSubmitSearchKeyword,
+  };
+}
+
+export default useSearchKeywordForm;

--- a/frontend/src/hooks/useSelectChannels.ts
+++ b/frontend/src/hooks/useSelectChannels.ts
@@ -7,7 +7,7 @@ interface Props {
   defaultChannelId?: number;
 }
 
-function useChannelIds({ defaultChannelId }: Props) {
+function useSelectChannels({ defaultChannelId }: Props) {
   const [channelIds, setChannelIds] = useState<(number | undefined)[]>([]);
 
   const { data: channelsData } = useQuery(
@@ -72,4 +72,4 @@ function useChannelIds({ defaultChannelId }: Props) {
   };
 }
 
-export default useChannelIds;
+export default useSelectChannels;

--- a/frontend/src/hooks/useSelectChannels.ts
+++ b/frontend/src/hooks/useSelectChannels.ts
@@ -1,4 +1,8 @@
 import { QUERY_KEY } from "@src/@constants";
+import {
+  ResponseSubscribedChannels,
+  SubscribedChannel,
+} from "@src/@types/shared";
 import { getSubscribedChannels } from "@src/api/channels";
 import { useEffect, useState } from "react";
 import { useQuery } from "react-query";
@@ -7,7 +11,15 @@ interface Props {
   defaultChannelId?: number;
 }
 
-function useSelectChannels({ defaultChannelId }: Props) {
+interface ReturnType {
+  channelIds: (number | undefined)[];
+  channelsData: ResponseSubscribedChannels | undefined;
+  defaultChannel: SubscribedChannel | undefined;
+  handleToggleChannelId: (id: number) => void;
+  handleToggleAllChannelIds: () => void;
+}
+
+function useSelectChannels({ defaultChannelId }: Props): ReturnType {
   const [channelIds, setChannelIds] = useState<(number | undefined)[]>([]);
 
   const { data: channelsData } = useQuery(
@@ -64,8 +76,8 @@ function useSelectChannels({ defaultChannelId }: Props) {
   }, [defaultChannelId]);
 
   return {
-    channelsData,
     channelIds,
+    channelsData,
     defaultChannel,
     handleToggleChannelId,
     handleToggleAllChannelIds,

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -1,6 +1,5 @@
 import { FlexColumn } from "@src/@styles/shared";
 import MessageCard from "@src/components/MessageCard";
-import SearchInput from "@src/components/SearchInput";
 import * as Styled from "./style";
 import { useInfiniteQuery } from "react-query";
 import { getMessages } from "@src/api/messages";
@@ -19,9 +18,8 @@ import useModal from "@src/hooks/useModal";
 import Portal from "@src/components/@shared/Portal";
 import Dimmer from "@src/components/@shared/Dimmer";
 import Calendar from "@src/components/Calendar";
-import SearchOptions from "@src/components/SearchOptions";
-import useChannelIds from "@src/hooks/useChannelIds";
 import EmptyStatus from "@src/components/EmptyStatus";
+import SearchForm from "@src/components/SearchForm";
 
 function Feed() {
   const { channelId } = useParams();
@@ -47,20 +45,6 @@ function Feed() {
   );
 
   const {
-    channelsData,
-    channelIds,
-    defaultChannel,
-    handleToggleChannelId,
-    handleToggleAllChannelIds,
-  } = useChannelIds({ defaultChannelId: channelId ? Number(channelId) : 0 });
-
-  const {
-    isModalOpened: isSearchInputFocused,
-    handleOpenModal: handleOpenSearchOptions,
-    handleCloseModal: handleCloseSearchOptions,
-  } = useModal();
-
-  const {
     isModalOpened: isCalenderOpened,
     handleOpenModal: handleOpenCalendar,
     handleCloseModal: handleCloseCalendar,
@@ -76,23 +60,7 @@ function Feed() {
 
   return (
     <Styled.Container>
-      {isSearchInputFocused && (
-        <Dimmer hasBackgroundColor={false} onClick={handleCloseSearchOptions} />
-      )}
-      <SearchInput
-        placeholder="검색 할 키워드를 입력해주세요."
-        onFocus={handleOpenSearchOptions}
-      >
-        {channelsData && defaultChannel && isSearchInputFocused && (
-          <SearchOptions
-            data={channelsData}
-            defaultChannel={defaultChannel}
-            channelIds={channelIds}
-            handleToggleChannelId={handleToggleChannelId}
-            handleToggleAllChannelIds={handleToggleAllChannelIds}
-          />
-        )}
-      </SearchInput>
+      <SearchForm channelId={channelId ? Number(channelId) : 0} />
 
       <InfiniteScroll
         callback={fetchNextPage}

--- a/frontend/src/pages/SearchResult/index.tsx
+++ b/frontend/src/pages/SearchResult/index.tsx
@@ -48,8 +48,6 @@ function SearchResult() {
 
   const parsedData = extractResponseMessages(data);
 
-  if (isError) return <div>이거슨 에러양!!!!</div>;
-
   return (
     <Styled.Container>
       <InfiniteScroll

--- a/frontend/src/pages/SearchResult/index.tsx
+++ b/frontend/src/pages/SearchResult/index.tsx
@@ -1,0 +1,95 @@
+import React from "react";
+import * as Styled from "../Feed/style";
+import { QUERY_KEY } from "@src/@constants";
+import { ResponseMessages } from "@src/@types/shared";
+import { getMessages } from "@src/api/messages";
+import { nextMessagesCallback } from "@src/api/utils";
+import { useInfiniteQuery } from "react-query";
+import { useSearchParams } from "react-router-dom";
+import MessageCard from "@src/components/MessageCard";
+import MessagesLoadingStatus from "@src/components/MessagesLoadingStatus";
+import { FlexColumn } from "@src/@styles/shared";
+import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
+import EmptyStatus from "@src/components/EmptyStatus";
+import useBookmark from "@src/hooks/useBookmark";
+import { convertSeparatorToKey, extractResponseMessages } from "@src/@utils";
+
+function SearchResult() {
+  const [searchParams] = useSearchParams();
+  const keyword = searchParams.get("keyword") ?? "";
+  const channelIds = searchParams.get("channelIds") ?? "";
+
+  const {
+    data,
+    isLoading,
+    isSuccess,
+    isError,
+    fetchNextPage,
+    hasNextPage,
+    refetch,
+  } = useInfiniteQuery<ResponseMessages>(
+    QUERY_KEY.ALL_MESSAGES,
+    getMessages({
+      channelId: convertSeparatorToKey({
+        key: "&channelIds=",
+        separator: ",",
+        value: channelIds,
+      }),
+      keyword,
+    }),
+    {
+      getNextPageParam: nextMessagesCallback,
+    }
+  );
+
+  const { handleAddBookmark, handleRemoveBookmark } = useBookmark({
+    handleSettle: refetch,
+  });
+
+  const parsedData = extractResponseMessages(data);
+
+  if (isError) return <div>이거슨 에러양!!!!</div>;
+
+  return (
+    <Styled.Container>
+      <InfiniteScroll
+        callback={fetchNextPage}
+        threshold={0.9}
+        endPoint={!hasNextPage}
+      >
+        <FlexColumn gap="4px" width="100%">
+          {isSuccess && parsedData.length === 0 && <EmptyStatus />}
+          {parsedData.map(
+            ({
+              id,
+              username,
+              postedDate,
+              text,
+              userThumbnail,
+              isBookmarked,
+            }) => (
+              <React.Fragment key={id}>
+                <MessageCard
+                  username={username}
+                  date={postedDate}
+                  text={text}
+                  thumbnail={userThumbnail}
+                  isBookmarked={isBookmarked}
+                  toggleBookmark={
+                    isBookmarked
+                      ? handleRemoveBookmark(id)
+                      : handleAddBookmark(id)
+                  }
+                />
+              </React.Fragment>
+            )
+          )}
+
+          {isLoading && <MessagesLoadingStatus length={20} />}
+        </FlexColumn>
+      </InfiniteScroll>
+    </Styled.Container>
+  );
+}
+
+export default SearchResult;

--- a/frontend/src/pages/SpecificDateFeed/index.tsx
+++ b/frontend/src/pages/SpecificDateFeed/index.tsx
@@ -7,7 +7,6 @@ import { getMessages } from "@src/api/messages";
 import { FlexColumn } from "@src/@styles/shared";
 import MessageCard from "@src/components/MessageCard";
 import { useLocation, useParams } from "react-router-dom";
-import SearchInput from "@src/components/SearchInput";
 import useTopScreenEventHandler from "@src/hooks/useTopScreenEventHandlers";
 import { previousMessagesCallback, nextMessagesCallback } from "@src/api/utils";
 import useMessageDate from "@src/hooks/useMessageDate";
@@ -21,8 +20,7 @@ import Portal from "@src/components/@shared/Portal";
 import Dimmer from "@src/components/@shared/Dimmer";
 import Calendar from "@src/components/Calendar";
 import EmptyStatus from "@src/components/EmptyStatus";
-import SearchOptions from "@src/components/SearchOptions";
-import useChannelIds from "@src/hooks/useChannelIds";
+import SearchForm from "@src/components/SearchForm";
 
 function SpecificDateFeed() {
   const { key: queryKey } = useLocation();
@@ -50,20 +48,6 @@ function SpecificDateFeed() {
       getNextPageParam: nextMessagesCallback,
     }
   );
-
-  const {
-    channelsData,
-    channelIds,
-    defaultChannel,
-    handleToggleChannelId,
-    handleToggleAllChannelIds,
-  } = useChannelIds({ defaultChannelId: channelId ? Number(channelId) : 0 });
-
-  const {
-    isModalOpened: isSearchInputFocused,
-    handleOpenModal: handleOpenSearchOptions,
-    handleCloseModal: handleCloseSearchOptions,
-  } = useModal();
 
   const {
     isModalOpened: isCalenderOpened,
@@ -100,23 +84,7 @@ function SpecificDateFeed() {
       onTouchStart={onTouchStart}
       onTouchEnd={onTouchEnd}
     >
-      {isSearchInputFocused && (
-        <Dimmer hasBackgroundColor={false} onClick={handleCloseSearchOptions} />
-      )}
-      <SearchInput
-        placeholder="검색 할 키워드를 입력해주세요."
-        onFocus={handleOpenSearchOptions}
-      >
-        {channelsData && defaultChannel && isSearchInputFocused && (
-          <SearchOptions
-            data={channelsData}
-            defaultChannel={defaultChannel}
-            channelIds={channelIds}
-            handleToggleChannelId={handleToggleChannelId}
-            handleToggleAllChannelIds={handleToggleAllChannelIds}
-          />
-        )}
-      </SearchInput>
+      <SearchForm channelId={channelId ? Number(channelId) : 0} />
 
       <InfiniteScroll
         callback={fetchNextPage}


### PR DESCRIPTION
## 요약
검색 기능 API 연동 및 SearchResult Page 개발

<br><br>

## 작업 내용
- useChannelIds hook 네이밍 변경 -> useSelectChannels
- SearchForm component 개발
- SearchInput, SearchOptions button type 설정 및 스타일 변경
- SearchForm component Feed, SpecificDateFeed page component에 적용
- SearchResult component Routes 연결 및 PATH_NAME 상수화
- getMessages API 명세에 맞게 keyword 추가
- convertSeparatorToKey util 함수 작성
- SearchResult page component 개발
- useModal hook useEffect clean up callback 함수 작성
    - scroll hidden -> auto 로 변경하는 clean up callback 함수 작성
- useSearchKeywordForm custom hook 으로 form 관련 로직 분리


<br><br>

## 참고 사항

이야기 했던 것 처럼 기존에 SearchInput, SearchOptions로 구성되어 있던 것을 SearchForm Component로 추출 후 API 연동을 진행했습니다.
SearchResult page Component를 생성했으니 확인해주시면 감사하겠습니다.

이슈를 따로 만들까 하다 이번 커밋에 useModal hook안에 useEffect clean up 함수가 작성되어 있지 않아 스크롤이 고장나는 이슈가 있어 clean up 함수 작성해서 해결했어요.

확인하고 리뷰 남겨주세요~! 😊



<br><br>

## 관련 이슈

- Close #369 

<br><br>
