### PR TITLE
refactor: 메세지 조회 시 북마크 join으로 함께 조회

### DIFF
--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
@@ -1,7 +1,9 @@
 package com.pickpick.message.ui.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.querydsl.core.annotations.QueryProjection;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -38,5 +40,24 @@ public class MessageResponse {
         this.postedDate = postedDate;
         this.modifiedDate = modifiedDate;
         this.bookmarked = isBookmarked;
+    }
+
+    @QueryProjection
+    public MessageResponse(final Long id,
+                           final Long memberId,
+                           final String username,
+                           final String userThumbnail,
+                           final String text,
+                           final LocalDateTime postedDate,
+                           final LocalDateTime modifiedDate,
+                           final Long bookmarkId) {
+        this.id = id;
+        this.memberId = memberId;
+        this.username = username;
+        this.userThumbnail = userThumbnail;
+        this.text = text;
+        this.postedDate = postedDate;
+        this.modifiedDate = modifiedDate;
+        this.bookmarked = !Objects.isNull(bookmarkId);
     }
 }


### PR DESCRIPTION
## 요약

메세지 조회 시 북마크 join으로 함께 조회

<br>

## 작업 내용  

- 기존 20개의 메세지 조회 시 1개의 멤버 조회 + 20개의 북마크 조회 쿼리를 추가 실행 후 붙였습니다🥲  
- 이제 한 번의 쿼리로 북마크 여부도 함께 조회해와요!  

💡 Querydsl을 통해 조회해올 때 `ui` 패키지 하위의 `MessageResponse`를 쓰는 대신 별도의 `DTO`를 써야 하나 고민중입니다  
우선 `ui`의 `dto`를 서비스 레이어의 로직에서 활용하고 있는게 문제같아 보이고요,  
`MessageResponse`에 `Querydsl` 패키지가 `import` 되는 것도 문제라고 여겨져요  
반면에 결국 같은 데이터를 다룰텐떼 굳이 분리해서 내용물 그대로 갈아끼우는 행위가 괜찮을까? 싶기도 합니다  
저는 `MessageDto` 같은 이름으로 분리하고 싶다 쪽인데 여러분의 의견이 궁금해요 😁  

<br>

## 관련 이슈

- Close #347 

<br>  
