### PR TITLE
feat: 메시지 리마인더 삭제 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -80,3 +80,7 @@ operation::bookmark-controller-test/delete[snippets='http-request,request-header
 === 리마인더 조회 API
 
 operation::reminder-controller-test/find[snippets='http-request,request-headers,request-parameters,http-response,response-fields']
+
+=== 리마인더 삭제 API
+
+operation::bookmark-controller-test/delete[snippets='http-request,request-headers,request-parameters,http-response']

--- a/backend/src/main/java/com/pickpick/exception/message/ReminderDeleteFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/ReminderDeleteFailureException.java
@@ -1,0 +1,18 @@
+package com.pickpick.exception.message;
+
+import com.pickpick.exception.BadRequestException;
+
+public class ReminderDeleteFailureException extends BadRequestException {
+
+    private static final String DEFAULT_MESSAGE = "외래키가 일치하는 리마인더가 없어 삭제 목적 조회 실패";
+    private static final String CLIENT_MESSAGE = "해당 리마인더를 삭제할 수 없습니다.";
+
+    public ReminderDeleteFailureException(final Long messageId, final Long memberId) {
+        super(String.format("%s -> reminder message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
+    }
+}

--- a/backend/src/main/java/com/pickpick/message/application/ReminderService.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderService.java
@@ -1,5 +1,6 @@
 package com.pickpick.message.application;
 
+import com.pickpick.exception.message.ReminderDeleteFailureException;
 import com.pickpick.exception.message.ReminderNotFoundException;
 import com.pickpick.message.domain.QReminder;
 import com.pickpick.message.domain.Reminder;
@@ -87,5 +88,13 @@ public class ReminderService {
         LocalDateTime remindDate = targetReminder.getRemindDate();
 
         return QReminder.reminder.remindDate.after(remindDate);
+    }
+
+    @Transactional
+    public void delete(final Long messageId, final Long memberId) {
+        Reminder reminder = reminders.findByMessageIdAndMemberId(messageId, memberId)
+                .orElseThrow(() -> new ReminderDeleteFailureException(messageId, memberId));
+
+        reminders.deleteById(reminder.getId());
     }
 }

--- a/backend/src/main/java/com/pickpick/message/domain/Reminder.java
+++ b/backend/src/main/java/com/pickpick/message/domain/Reminder.java
@@ -36,8 +36,7 @@ public class Reminder {
     protected Reminder() {
     }
 
-    public Reminder(final Long id, final Member member, final Message message, final LocalDateTime remindDate) {
-        this.id = id;
+    public Reminder(final Member member, final Message message, final LocalDateTime remindDate) {
         this.member = member;
         this.message = message;
         this.remindDate = remindDate;

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -6,4 +6,8 @@ import org.springframework.data.repository.Repository;
 public interface ReminderRepository extends Repository<Reminder, Long> {
 
     Optional<Reminder> findById(Long id);
+
+    Optional<Reminder> findByMessageIdAndMemberId(Long messageId, Long memberId);
+
+    void deleteById(Long id);
 }

--- a/backend/src/main/java/com/pickpick/message/ui/ReminderController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/ReminderController.java
@@ -3,9 +3,12 @@ package com.pickpick.message.ui;
 import com.pickpick.auth.support.AuthenticationPrincipal;
 import com.pickpick.message.application.ReminderService;
 import com.pickpick.message.ui.dto.ReminderResponses;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -22,5 +25,12 @@ public class ReminderController {
     public ReminderResponses find(final @AuthenticationPrincipal Long memberId,
                                   final @RequestParam(required = false) Long reminderId) {
         return reminderService.find(reminderId, memberId);
+    }
+
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    @DeleteMapping
+    public void delete(final @AuthenticationPrincipal Long memberId,
+                       final @RequestParam Long messageId) {
+        reminderService.delete(messageId, memberId);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -111,4 +111,30 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
                 .map(ReminderResponse::getId)
                 .collect(Collectors.toList());
     }
+
+    @Test
+    void 리마인더_정상_삭제() {
+        // given
+        long messageId = 2L;
+
+        // when
+        ExtractableResponse<Response> response = deleteWithCreateToken(REMINDER_API_URL + "?messageId=" + messageId,
+                1L);
+
+        // then
+        상태코드_확인(response, HttpStatus.NO_CONTENT);
+    }
+
+    @Test
+    void 사용자에게_존재하지_않는_리마인더_삭제() {
+        // given
+        long messageId = 1L;
+
+        // when
+        ExtractableResponse<Response> response = deleteWithCreateToken(REMINDER_API_URL + "?messageId=" + messageId,
+                1L);
+
+        // then
+        상태코드_확인(response, HttpStatus.BAD_REQUEST);
+    }
 }

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -1,13 +1,18 @@
 package com.pickpick.message.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.config.QuerydslConfig;
+import com.pickpick.exception.message.ReminderDeleteFailureException;
+import com.pickpick.message.domain.Reminder;
+import com.pickpick.message.domain.ReminderRepository;
 import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.AfterAll;
@@ -30,8 +35,12 @@ import org.springframework.test.context.jdbc.Sql;
 class ReminderServiceTest {
 
     private static MockedStatic<LocalDateTime> localDateTimeMockedStatic;
+
     @Autowired
     private ReminderService reminderService;
+
+    @Autowired
+    private ReminderRepository reminders;
 
     private static Stream<Arguments> parameterProvider() {
         return Stream.of(
@@ -92,5 +101,24 @@ class ReminderServiceTest {
                 () -> assertThat(ids).doesNotContainAnyElementsOf(List.of(24L)),
                 () -> assertThat(response.isLast()).isFalse()
         );
+    }
+
+    @DisplayName("리마인더 삭제")
+    @Test
+    void delete() {
+        // given & when
+        reminderService.delete(1L, 2L);
+
+        // then
+        Optional<Reminder> actual = reminders.findById(1L);
+        assertThat(actual).isEmpty();
+    }
+
+    @DisplayName("다른 사용자의 리마인더 삭제시 예외")
+    @Test
+    void deleteOtherMembers() {
+        // given & when & then
+        assertThatThrownBy(() -> reminderService.delete(1L, 1L))
+                .isInstanceOf(ReminderDeleteFailureException.class);
     }
 }

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -20,6 +20,8 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 @Sql({"/truncate.sql", "/reminder.sql"})
 public class ReminderControllerTest extends RestDocsTestSupport {
@@ -68,6 +70,27 @@ public class ReminderControllerTest extends RestDocsTestSupport {
                                 fieldWithPath("reminders.[].remindDate").type(JsonFieldType.STRING)
                                         .description("리마인드 날짜"),
                                 fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 리마인드 메시지 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("리마인더를 삭제한다")
+    @Test
+    void delete() throws Exception {
+        MultiValueMap<String, String> requestParams = new LinkedMultiValueMap<>();
+        requestParams.set("messageId", "2");
+        mockMvc.perform(MockMvcRequestBuilders
+                        .delete(REMINDER_API_URL)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer 1")
+                        .params(requestParams)
+                )
+                .andExpect(status().isNoContent())
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("유저 식별 토큰(Bearer)")
+                        ),
+                        requestParameters(
+                                parameterWithName("messageId").description("리마인더 삭제할 메세지 아이디")
                         )
                 ));
     }


### PR DESCRIPTION
## 요약
 메시지 리마인더 삭제 API 구현
<br><br>

## 작업 내용

-  메시지 리마인더 삭제 API 구현
- 관련 테스트코드 작성
- RestDocs 에 리마인더 삭제 api 추가
<br><br>

## 참고 사항
- 리마인더 생성 API 구현 후 테스트코드 수정 예정
<br><br>

## 관련 이슈

- Close #383 

<br><br>
