### PR TITLE
feat: 메시지 리마인더 등록 및 수정 API 구현

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -88,3 +88,7 @@ operation::reminder-controller-test/save[snippets='http-request,request-headers,
 === 리마인더 삭제 API
 
 operation::bookmark-controller-test/delete[snippets='http-request,request-headers,request-parameters,http-response']
+
+=== 리마인더 수정 API
+
+operation::reminder-controller-test/update[snippets='http-request,request-headers,request-fields,http-response']

--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -80,3 +80,7 @@ operation::bookmark-controller-test/delete[snippets='http-request,request-header
 === 리마인더 조회 API
 
 operation::reminder-controller-test/find[snippets='http-request,request-headers,request-parameters,http-response,response-fields']
+
+=== 리마인더 추가 API
+
+operation::reminder-controller-test/save[snippets='http-request,request-headers,request-fields,http-response']

--- a/backend/src/main/java/com/pickpick/exception/message/ReminderUpdateFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/ReminderUpdateFailureException.java
@@ -1,0 +1,18 @@
+package com.pickpick.exception.message;
+
+import com.pickpick.exception.BadRequestException;
+
+public class ReminderUpdateFailureException extends BadRequestException {
+
+    private static final String DEFAULT_MESSAGE = "외래키가 일치하는 리마인더가 없어 수정 목적 조회 실패";
+    private static final String CLIENT_MESSAGE = "해당 리마인더를 수정할 수 없습니다.";
+
+    public ReminderUpdateFailureException(final Long messageId, final Long memberId) {
+        super(String.format("%s -> reminder message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
+    }
+
+    @Override
+    public String getClientMessage() {
+        return CLIENT_MESSAGE;
+    }
+}

--- a/backend/src/main/java/com/pickpick/message/application/ReminderService.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderService.java
@@ -4,6 +4,7 @@ import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.exception.message.ReminderDeleteFailureException;
 import com.pickpick.exception.message.ReminderNotFoundException;
+import com.pickpick.exception.message.ReminderUpdateFailureException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -112,6 +113,14 @@ public class ReminderService {
         LocalDateTime remindDate = targetReminder.getRemindDate();
 
         return QReminder.reminder.remindDate.after(remindDate);
+    }
+
+    @Transactional
+    public void update(final Long memberId, final ReminderRequest reminderRequest) {
+        Reminder reminder = reminders.findByMessageIdAndMemberId(reminderRequest.getMessageId(), memberId)
+                .orElseThrow(() -> new ReminderUpdateFailureException(reminderRequest.getMessageId(), memberId));
+
+        reminder.updateRemindDate(reminderRequest.getReminderDate());
     }
 
     @Transactional

--- a/backend/src/main/java/com/pickpick/message/domain/Reminder.java
+++ b/backend/src/main/java/com/pickpick/message/domain/Reminder.java
@@ -41,4 +41,8 @@ public class Reminder {
         this.message = message;
         this.remindDate = remindDate;
     }
+
+    public void updateRemindDate(final LocalDateTime remindDate) {
+        this.remindDate = remindDate;
+    }
 }

--- a/backend/src/main/java/com/pickpick/message/domain/Reminder.java
+++ b/backend/src/main/java/com/pickpick/message/domain/Reminder.java
@@ -36,8 +36,7 @@ public class Reminder {
     protected Reminder() {
     }
 
-    public Reminder(final Long id, final Member member, final Message message, final LocalDateTime remindDate) {
-        this.id = id;
+    public Reminder(final Member member, final Message message, final LocalDateTime remindDate) {
         this.member = member;
         this.message = message;
         this.remindDate = remindDate;

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -5,5 +5,7 @@ import org.springframework.data.repository.Repository;
 
 public interface ReminderRepository extends Repository<Reminder, Long> {
 
+    void save(Reminder reminder);
+
     Optional<Reminder> findById(Long id);
 }

--- a/backend/src/main/java/com/pickpick/message/ui/ReminderController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/ReminderController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -26,10 +27,10 @@ public class ReminderController {
 
     @ResponseStatus(HttpStatus.CREATED)
     @PostMapping
-    public void save(final @AuthenticationPrincipal Long memberId, final @RequestBody ReminderRequest reminderRequest) {
+    public void save(final @AuthenticationPrincipal Long memberId,
+                     final @RequestBody ReminderRequest reminderRequest) {
         reminderService.save(memberId, reminderRequest);
     }
-
 
     @GetMapping
     public ReminderResponses find(final @AuthenticationPrincipal Long memberId,
@@ -42,5 +43,11 @@ public class ReminderController {
     public void delete(final @AuthenticationPrincipal Long memberId,
                        final @RequestParam Long messageId) {
         reminderService.delete(messageId, memberId);
+    }
+
+    @PutMapping
+    public void update(final @AuthenticationPrincipal Long memberId,
+                       final @RequestBody ReminderRequest reminderRequest) {
+        reminderService.update(memberId, reminderRequest);
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/ReminderController.java
+++ b/backend/src/main/java/com/pickpick/message/ui/ReminderController.java
@@ -2,10 +2,15 @@ package com.pickpick.message.ui;
 
 import com.pickpick.auth.support.AuthenticationPrincipal;
 import com.pickpick.message.application.ReminderService;
+import com.pickpick.message.ui.dto.ReminderRequest;
 import com.pickpick.message.ui.dto.ReminderResponses;
+import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -17,6 +22,13 @@ public class ReminderController {
     public ReminderController(final ReminderService reminderService) {
         this.reminderService = reminderService;
     }
+
+    @ResponseStatus(HttpStatus.CREATED)
+    @PostMapping
+    public void save(final @AuthenticationPrincipal Long memberId, final @RequestBody ReminderRequest reminderRequest) {
+        reminderService.save(memberId, reminderRequest);
+    }
+
 
     @GetMapping
     public ReminderResponses find(final @AuthenticationPrincipal Long memberId,

--- a/backend/src/main/java/com/pickpick/message/ui/dto/ReminderRequest.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/ReminderRequest.java
@@ -1,0 +1,19 @@
+package com.pickpick.message.ui.dto;
+
+import java.time.LocalDateTime;
+import lombok.Getter;
+
+@Getter
+public class ReminderRequest {
+
+    private Long messageId;
+    private LocalDateTime reminderDate;
+
+    private ReminderRequest() {
+    }
+
+    public ReminderRequest(final Long messageId, final LocalDateTime reminderDate) {
+        this.messageId = messageId;
+        this.reminderDate = reminderDate;
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -25,6 +25,16 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     private static final String REMINDER_API_URL = "/api/reminders";
 
     @Test
+    void 리마인더_생성() {
+        // given & when
+        ExtractableResponse<Response> response = postWithCreateToken(REMINDER_API_URL,
+                Map.of("messageId", 1, "reminderDate", "2022-08-10T19:21:55"), 1L);
+
+        // then
+        상태코드_확인(response, HttpStatus.CREATED);
+    }
+
+    @Test
     void 멤버_ID_2번으로_리마인더_목록_조회() {
         // given
         Map<String, Object> request = Map.of("reminderId", "");

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -9,6 +9,7 @@ import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -120,6 +121,30 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
                 .stream()
                 .map(ReminderResponse::getId)
                 .collect(Collectors.toList());
+    }
+
+    @Test
+    void 리마인더_정상_수정() {
+        // given
+        Map<String, Object> request = Map.of("messageId", "2", "reminderDate", LocalDateTime.now().toString());
+
+        // when
+        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
+
+        // then
+        상태코드_확인(response, HttpStatus.OK);
+    }
+
+    @Test
+    void 사용자에게_존재하지_않는_리마인더_수정() {
+        // given
+        Map<String, Object> request = Map.of("messageId", "1", "reminderDate", LocalDateTime.now().toString());
+
+        // when
+        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
+
+        // then
+        상태코드_확인(response, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -59,8 +59,8 @@ public class ReminderControllerTest extends RestDocsTestSupport {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("유저 식별 토큰(Bearer)")
                         ),
                         requestFields(
-                                fieldWithPath("messageId").type(JsonFieldType.NUMBER).description("리마인더할 메세지 아이디"),
-                                fieldWithPath("reminderDate").type(JsonFieldType.STRING).description("리마인더할 날짜")
+                                fieldWithPath("messageId").type(JsonFieldType.NUMBER).description("리마인드할 메세지 아이디"),
+                                fieldWithPath("reminderDate").type(JsonFieldType.STRING).description("리마인드할 날짜")
                         )
                 ));
     }
@@ -97,7 +97,32 @@ public class ReminderControllerTest extends RestDocsTestSupport {
                                         .description("메시지 수정 날짜"),
                                 fieldWithPath("reminders.[].remindDate").type(JsonFieldType.STRING)
                                         .description("리마인드 날짜"),
-                                fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 리마인드 메시지 여부")
+                                fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 리마인더 메시지 여부")
+                        )
+                ));
+    }
+
+    @DisplayName("리마인더를 수정한다")
+    @Test
+    void update() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                new ReminderRequest(2L, LocalDateTime.now().plusDays(2))
+        );
+        mockMvc.perform(MockMvcRequestBuilders
+                        .put(REMINDER_API_URL)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer 1")
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("유저 식별 토큰(Bearer)")
+                        ),
+                        requestFields(
+                                fieldWithPath("messageId").type(JsonFieldType.NUMBER)
+                                        .description("수정 예정인 리마인더의 메세지 아이디"),
+                                fieldWithPath("reminderDate").type(JsonFieldType.STRING).description("수정할 날짜")
                         )
                 ));
     }
@@ -118,7 +143,7 @@ public class ReminderControllerTest extends RestDocsTestSupport {
                                 headerWithName(HttpHeaders.AUTHORIZATION).description("유저 식별 토큰(Bearer)")
                         ),
                         requestParameters(
-                                parameterWithName("messageId").description("리마인더 삭제할 메세지 아이디")
+                                parameterWithName("messageId").description("삭제 예정인 리마인더의 메세지 아이디")
                         )
                 ));
     }

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -5,6 +5,7 @@ import static org.mockito.BDDMockito.given;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.requestFields;
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
@@ -12,11 +13,14 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.config.RestDocsTestSupport;
+import com.pickpick.message.ui.dto.ReminderRequest;
+import java.time.LocalDateTime;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -33,6 +37,30 @@ public class ReminderControllerTest extends RestDocsTestSupport {
     void setup() {
         given(jwtTokenProvider.getPayload(any(String.class)))
                 .willReturn("1");
+    }
+
+    @DisplayName("리마인더를 추가한다")
+    @Test
+    void save() throws Exception {
+        String body = objectMapper.writeValueAsString(
+                new ReminderRequest(1L, LocalDateTime.now().plusDays(2))
+        );
+        mockMvc.perform(MockMvcRequestBuilders
+                        .post(REMINDER_API_URL)
+                        .header(HttpHeaders.AUTHORIZATION, "Bearer 1")
+                        .content(body)
+                        .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andExpect(status().isCreated())
+                .andDo(restDocs.document(
+                        requestHeaders(
+                                headerWithName(HttpHeaders.AUTHORIZATION).description("유저 식별 토큰(Bearer)")
+                        ),
+                        requestFields(
+                                fieldWithPath("messageId").type(JsonFieldType.NUMBER).description("리마인더할 메세지 아이디"),
+                                fieldWithPath("reminderDate").type(JsonFieldType.STRING).description("리마인더할 날짜")
+                        )
+                ));
     }
 
     @DisplayName("리마인더를 조회한다")


### PR DESCRIPTION
## 요약

메시지 리마인더 등록 및 수정 API 구현
<br><br>

## 작업 내용

- 메시지 리마인더 등록 api 추가 (`POST /api/reminders`)
- 메시지 리마인더 수정 api 추가 (`PUT /api/reminders`)
- 위 API에 대한 Service, controller, acceptance test 추가
- RestDocs에 해당 API 명세 작성


<br><br>
## 관련 이슈

- Close #386 
- Close #387

<br><br>
