### PR TITLE
feat: 프론트엔드 lighthouse-ci 적용

### DIFF
--- a/.github/workflows/frontend-lighthouse-ci.yml
+++ b/.github/workflows/frontend-lighthouse-ci.yml
@@ -1,4 +1,4 @@
-name: 프론트엔드 Google Lighthouse 성능 측정 자동화
+name: 줍줍 프론트엔드 Google Lighthouse 성능 측정 자동화
 on:
   pull_request:
     branches:

--- a/.github/workflows/frontend-lighthouse-ci.yml
+++ b/.github/workflows/frontend-lighthouse-ci.yml
@@ -37,7 +37,7 @@ jobs:
         id: format_lighthouse_score
         uses: actions/github-script@v3
         with:
-          github-token: ${{secrets.LHCI_PERMISSION_TOKEN}}
+          github-token: ${{ secrets.LHCI_PERMISSION_TOKEN }}
           script: |
 
             const fs = require('fs');

--- a/.github/workflows/frontend-lighthouse-ci.yml
+++ b/.github/workflows/frontend-lighthouse-ci.yml
@@ -37,7 +37,7 @@ jobs:
         id: format_lighthouse_score
         uses: actions/github-script@v3
         with:
-          github-token: ${{secrets.GITHUB_TOKEN}}
+          github-token: ${{secrets.LHCI_PERMISSION_TOKEN}}
           script: |
 
             const fs = require('fs');

--- a/.github/workflows/frontend-lighthouse-ci.yml
+++ b/.github/workflows/frontend-lighthouse-ci.yml
@@ -1,0 +1,107 @@
+name: 프론트엔드 Google Lighthouse 성능 측정 자동화
+on:
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - develop
+    paths: "frontend/**"
+
+jobs:
+  lhci:
+    name: Lighthouse
+    runs-on: ubuntu-latest
+    env:
+      working-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Use Node.js 16.x
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+      - name: npm install, build
+        run: |
+          npm install
+          npm run build
+        working-directory: ${{ env.working-directory }}
+      - name: run Lighthouse CI
+        run: |
+          npm install -g @lhci/cli@0.8.x
+          lhci autorun
+        working-directory: ${{ env.working-directory }}
+        env:
+          LHCI_GITHUB_APP_TOKEN: ${{ secrets.LHCI_GITHUB_APP_TOKEN }}
+      - name: Format lighthouse score
+        id: format_lighthouse_score
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          script: |
+
+            const fs = require('fs');
+            const results = JSON.parse(fs.readFileSync("./frontend/lhci_reports/manifest.json"));
+            let comments = "";
+            results.forEach((result) => {
+              const { summary, jsonPath } = result;
+              const details = JSON.parse(fs.readFileSync(jsonPath));
+              const { audits } = details;
+              
+              const formatResult = (res) => Math.round(res * 100);
+              Object.keys(summary).forEach(
+                (key) => (summary[key] = formatResult(summary[key]))
+              );
+
+            const score = (res) => (res >= 90 ? "🟢" : res >= 50 ? "🟠" : "🔴");
+              
+            const comment = [
+                `⚡️ 줍줍 Lighthouse 성능 측정 결과`,
+                `| Category | Score |`,
+                `| --- | --- |`,
+                `| ${score(summary.performance)} Performance | ${summary.performance} |`,
+                `| ${score(summary.accessibility)} Accessibility | ${summary.accessibility} |`,
+                `| ${score(summary["best-practices"])} Best-Practices | ${summary["best-practices"]} |`,
+                `| ${score(summary.seo)} SEO | ${summary.seo} |`,
+                `| ${score(summary.pwa)} PWA | ${summary.pwa} |`
+              ].join("\n");
+
+            const detail = [
+                `| Category | Score |`,
+                `| --- | --- |`,
+                `| ${score(
+                  audits["first-contentful-paint"].score * 100
+                )} First Contentful Paint | ${
+                  audits["first-contentful-paint"].displayValue
+                } |`,
+                `| ${score(
+                  audits["largest-contentful-paint"].score * 100
+                )} Largest Contentful Paint | ${
+                  audits["largest-contentful-paint"].displayValue
+                } |`,
+                `| ${score(
+                  audits["first-meaningful-paint"].score * 100
+                )} First Meaningful Paint | ${
+                  audits["first-meaningful-paint"].displayValue
+                } |`,
+                `| ${score(
+                  audits["speed-index"].score * 100
+                )} Speed Index | ${
+                  audits["speed-index"].displayValue
+                } |`,
+                `| ${score(
+                  audits["total-blocking-time"].score * 100
+                )} Total Blocking Time | ${
+                  audits["total-blocking-time"].displayValue
+                } |`,
+              ].join("\n");
+              
+              comments += comment + "\n" +"\n"+ detail + "\n";
+            });
+            core.setOutput('comments', comments)
+
+      - name: comment PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ${{ steps.format_lighthouse_score.outputs.comments}}

--- a/.github/workflows/frontend-lighthouse-ci.yml
+++ b/.github/workflows/frontend-lighthouse-ci.yml
@@ -37,7 +37,7 @@ jobs:
         id: format_lighthouse_score
         uses: actions/github-script@v3
         with:
-          github-token: ${{ secrets.LHCI_PERMISSION_TOKEN }}
+          github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
 
             const fs = require('fs');

--- a/frontend/lighthouserc.js
+++ b/frontend/lighthouserc.js
@@ -1,0 +1,14 @@
+/* eslint-disable no-undef */
+
+module.exports = {
+  ci: {
+    collect: {
+      numberOfRuns: 1,
+    },
+    upload: {
+      target: "filesystem",
+      outputDir: "./lhci_reports",
+      reportFilenamePattern: "%%PATHNAME%%-%%DATETIME%%-report.%%EXTENSION%%",
+    },
+  },
+};


### PR DESCRIPTION
## 요약

프론트엔드 lighthouse-ci 적용

## 작업 내용

- lighthouserc.js 설정 파일 작성 
     -  아주 기본적인 셋팅만 해놓은 상태입니다.  
- github action 실행을 위한 yml 파일 추가 

## 참고 사항
- PR 시에만 동작하도록 했습니다. 추후 필요시 push 시에도 동작 하는 스크립트도 추가하겠습니다.
- 현재는 로그인 필요 페이지는 검사 하지 못하고, 랜딩페이지만 검사합니다. (추후 디벨롭할게요.)

#### 동작 과정
액션 트리거는 `develop, main, realease 브랜치` 에 `frontend 디렉토리 내부 변경이 있을 때`, `Pull Request` 가 올라왔을 때 입니다.

1. 깃헙 액션이 프론트엔드 정적 파일을 build 합니다.
2. build 된 결과물을 lighthouse ci 를 사용하여 lighthouse 검사를 실행합니다.
3. 실행된 검사의 결과물을 github action 이 해당 pr 의 코멘트로 아래와 같이 남겨줍니다.

<img width="797" alt="스크린샷 2022-08-11 오후 8 45 31" src="https://user-images.githubusercontent.com/61469664/184126370-62f3e9ab-eecd-4f21-bd38-11dd02619aab.png">


## 관련 이슈

- Close #392 

<br><br>
