### PR TITLE
feat: 메시지 댓글 이벤트 전달 시 저장 제외

### DIFF
--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageCreatedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageCreatedServiceTest.java
@@ -53,6 +53,16 @@ class MessageCreatedServiceTest {
                     "ts", "1234567890",
                     "client_msg_id", SAMPLE_MESSAGE.getSlackId())
             );
+    private static final Map<String, Object> MESSAGE_REPLIED_REQUEST =
+            Map.of("event", Map.of(
+                    "type", "message",
+                    "channel", SAMPLE_CHANNEL.getSlackId(),
+                    "text", SAMPLE_MESSAGE.getText(),
+                    "user", SAMPLE_MEMBER.getSlackId(),
+                    "ts", "1234567890",
+                    "client_msg_id", SAMPLE_MESSAGE.getSlackId(),
+                    "thread_ts", "1234599999")
+            );
     private static final int FIRST_INDEX = 0;
 
     @Autowired
@@ -129,5 +139,21 @@ class MessageCreatedServiceTest {
                 () -> assertThat(channelAfterSave).isPresent(),
                 () -> assertThat(messageAfterSave).isPresent()
         );
+    }
+    
+    @DisplayName("메시지 댓글 생성 이벤트는 전달되어도 내용을 저장하지 않는다")
+    @Test
+    void doNotSaveReplyMessage() {
+        //given
+        members.save(SAMPLE_MEMBER);
+        channels.save(SAMPLE_CHANNEL);
+
+        // when
+        messageCreatedService.execute(MESSAGE_REPLIED_REQUEST);
+
+        // then
+        Optional<Message> message = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
+
+        assertThat(message).isEmpty();
     }
 }


### PR DESCRIPTION
## 요약

전달된 메시지 생성 이벤트가 메시지 댓글 생성일 시 저장하지 않고 early return 처리

<br>

## 작업 내용

`event` 필드 내에 `thread_ts` 값이 존재할 시, 메시지의 댓글(스레드) 생성 이벤트입니다  
논의 결과 저장하지 않기로 했기에 `early return`으로 저장하지 않고, 테스트를 추가했습니다  
인수테스트는 똑같이 `200`응답 처리가 될 거라 따로 케이스 추가하지 않았습니다 🤔 

<br>

## 관련 이슈

- Close #397 

<br>
