### PR TITLE
refactor: Channel, Member 도메인 하위 레포지토리 save() 반환형 수정  

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.Repository;
 
 public interface ChannelRepository extends Repository<Channel, Long> {
 
-    void save(Channel channel);
+    Channel save(Channel channel);
 
     List<Channel> findAll();
 

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.Repository;
 
 public interface ChannelSubscriptionRepository extends Repository<ChannelSubscription, Long> {
 
-    void save(ChannelSubscription channelSubscription);
+    ChannelSubscription save(ChannelSubscription channelSubscription);
 
     void saveAll(Iterable<ChannelSubscription> channelSubscriptions);
 

--- a/backend/src/main/java/com/pickpick/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/pickpick/member/domain/MemberRepository.java
@@ -10,7 +10,7 @@ public interface MemberRepository extends Repository<Member, Long> {
 
     Optional<Member> findBySlackId(String slackId);
 
-    void save(Member member);
+    Member save(Member member);
 
     void saveAll(Iterable<Member> members);
 

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
@@ -75,9 +75,9 @@ public class MessageCreatedService implements SlackEventService {
                     request -> request.channel(channelSlackId)
             ).getChannel();
 
-            Channel channel = channels.save(toChannel(conversation));
+            Channel channel = toChannel(conversation);
 
-            return channel;
+            return channels.save(channel);
         } catch (IOException | SlackApiException e) {
             throw new SlackApiCallException(e);
         }

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
@@ -75,8 +75,7 @@ public class MessageCreatedService implements SlackEventService {
                     request -> request.channel(channelSlackId)
             ).getChannel();
 
-            Channel channel = toChannel(conversation);
-            channels.save(channel);
+            Channel channel = channels.save(toChannel(conversation));
 
             return channel;
         } catch (IOException | SlackApiException e) {

--- a/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
@@ -53,8 +53,7 @@ class AuthServiceTest {
     @Test
     void login() throws SlackApiException, IOException {
         // given
-        Member member = new Member("slackId", "username", "thumbnail.png");
-        members.save(member);
+        Member member = members.save(new Member("slackId", "username", "thumbnail.png"));
 
         given(slackClient.oauthV2Access(any(OAuthV2AccessRequest.class)))
                 .willReturn(generateOAuthV2AccessResponse());

--- a/backend/src/test/java/com/pickpick/channel/application/ChannelSubscriptionServiceTest.java
+++ b/backend/src/test/java/com/pickpick/channel/application/ChannelSubscriptionServiceTest.java
@@ -236,8 +236,7 @@ class ChannelSubscriptionServiceTest {
     }
 
     private Channel saveChannel(final String slackId, final String channelName) {
-        Channel channel = new Channel(slackId, channelName);
-        channels.save(channel);
+        Channel channel = channels.save(new Channel(slackId, channelName));
         return channel;
     }
 

--- a/backend/src/test/java/com/pickpick/channel/application/ChannelSubscriptionServiceTest.java
+++ b/backend/src/test/java/com/pickpick/channel/application/ChannelSubscriptionServiceTest.java
@@ -230,8 +230,7 @@ class ChannelSubscriptionServiceTest {
     }
 
     private Member saveMember() {
-        Member member = new Member("TESTMEMBER", "테스트 계정", "test.png");
-        members.save(member);
+        Member member = members.save(new Member("TESTMEMBER", "테스트 계정", "test.png"));
         return member;
     }
 

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -65,8 +65,7 @@ class BookmarkServiceTest {
         // given
         Member member = new Member("U1234", "사용자", "user.png");
         members.save(member);
-        Channel channel = new Channel("C1234", "기본채널");
-        channels.save(channel);
+        Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
 
@@ -114,8 +113,7 @@ class BookmarkServiceTest {
         // given
         Member member = new Member("U1234", "사용자", "user.png");
         members.save(member);
-        Channel channel = new Channel("C1234", "기본채널");
-        channels.save(channel);
+        Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
         Bookmark bookmark = new Bookmark(member, message);
@@ -137,8 +135,7 @@ class BookmarkServiceTest {
         members.save(owner);
         Member other = new Member("U1235", "다른 사용자", "user.png");
         members.save(other);
-        Channel channel = new Channel("C1234", "기본채널");
-        channels.save(channel);
+        Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", owner, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
         Bookmark bookmark = new Bookmark(owner, message);

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -63,8 +63,7 @@ class BookmarkServiceTest {
     @Test
     void save() {
         // given
-        Member member = new Member("U1234", "사용자", "user.png");
-        members.save(member);
+        Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
@@ -111,8 +110,7 @@ class BookmarkServiceTest {
     @Test
     void delete() {
         // given
-        Member member = new Member("U1234", "사용자", "user.png");
-        members.save(member);
+        Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
@@ -131,10 +129,8 @@ class BookmarkServiceTest {
     @Test
     void deleteOtherMembers() {
         // given
-        Member owner = new Member("U1234", "사용자", "user.png");
-        members.save(owner);
-        Member other = new Member("U1235", "다른 사용자", "user.png");
-        members.save(other);
+        Member owner = members.save(new Member("U1234", "사용자", "user.png"));
+        Member other = members.save(new Member("U1235", "다른 사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", owner, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -74,8 +74,7 @@ class ReminderServiceTest {
     @Test
     void save() {
         // given
-        Member member = new Member("U1234", "사용자", "user.png");
-        members.save(member);
+        Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -76,8 +76,7 @@ class ReminderServiceTest {
         // given
         Member member = new Member("U1234", "사용자", "user.png");
         members.save(member);
-        Channel channel = new Channel("C1234", "기본채널");
-        channels.save(channel);
+        Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
@@ -27,8 +27,7 @@ class ChannelRenameServiceTest {
     @Test
     void channelNameShouldBeChangedOnChannelRenameEvent() {
         // given
-        Channel channel = new Channel("slackId", "channelName");
-        channels.save(channel);
+        Channel channel = channels.save(new Channel("slackId", "channelName"));
 
         String expectedChannelName = "변경된 채널 이름";
         Map<String, Object> request = Map.of(

--- a/backend/src/test/java/com/pickpick/slackevent/application/member/MemberChangedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/member/MemberChangedServiceTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
-import com.pickpick.slackevent.application.member.MemberChangedService;
 import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -33,8 +32,7 @@ class MemberChangedServiceTest {
     @ParameterizedTest(name = "{1}이 들어오는 경우 {2}")
     void changedUsername(final String realName, final String displayName, final String expectedName) {
         // given
-        Member member = new Member(SLACK_ID, "사용자", "test.png");
-        members.save(member);
+        Member member = members.save(new Member(SLACK_ID, "사용자", "test.png"));
 
         Map<String, Object> request = memberChangedEvent(realName, displayName, "test.png");
 
@@ -54,8 +52,7 @@ class MemberChangedServiceTest {
     @Test
     void changedThumbnailUrl() {
         // given
-        Member member = new Member(SLACK_ID, "사용자", "test.png");
-        members.save(member);
+        Member member = members.save(new Member(SLACK_ID, "사용자", "test.png"));
 
         String thumbnailUrl = "new_test.png";
         Map<String, Object> request = memberChangedEvent("사용자", "표시 이름", thumbnailUrl);


### PR DESCRIPTION
## 요약

Channel, Member 도메인 하위 레포지토리 save() 반환형을 해당 엔티티 클래스로 수정  

<br>

## 작업 내용

- ChannelRepository
- ChannelSubscriptionRepository
- MemberRepository

해당 클래스들의 `save()` 반환형을 엔티티 클래스로 변경하고, 사용하는 코드도 찾아 수정했습니다  

<br>

## 참고 사항

`Message` 도메인 하위는 리마인더 작업과 충돌날 것 같아서 끝나고 할게요  

<br>

## 관련 이슈

- #405 

<br>