### PR TITLE
feat: 메시지 조회 시 isSetReminded 필드 추가

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -88,7 +88,7 @@ public class MessageService {
                 .leftJoin(QBookmark.bookmark)
                 .on(QMessage.message.id.eq(QBookmark.bookmark.message.id))
                 .leftJoin(QReminder.reminder)
-                .on(reminderCondition(memberId))
+                .on(remainReminder(memberId))
                 .where(meetAllConditions(channelIds, messageRequest))
                 .orderBy(arrangeDateByNeedPastMessage(needPastMessage))
                 .limit(messageCount)
@@ -116,7 +116,7 @@ public class MessageService {
                 QReminder.reminder.id);
     }
 
-    private BooleanExpression reminderCondition(final Long memberId) {
+    private BooleanExpression remainReminder(final Long memberId) {
         return QReminder.reminder.member.id.eq(memberId)
                 .and(QReminder.reminder.message.id.eq(QMessage.message.id))
                 .and(QReminder.reminder.remindDate.after(LocalDateTime.now(clock)));

--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -4,11 +4,11 @@ import com.pickpick.channel.domain.ChannelSubscription;
 import com.pickpick.channel.domain.ChannelSubscriptionRepository;
 import com.pickpick.exception.channel.SubscriptionNotFoundException;
 import com.pickpick.exception.message.MessageNotFoundException;
-import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.message.domain.QBookmark;
 import com.pickpick.message.domain.QMessage;
+import com.pickpick.message.domain.QReminder;
 import com.pickpick.message.ui.dto.MessageRequest;
 import com.pickpick.message.ui.dto.MessageResponse;
 import com.pickpick.message.ui.dto.MessageResponses;
@@ -18,6 +18,7 @@ import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.time.Clock;
 import java.time.LocalDateTime;
 import java.util.Comparator;
 import java.util.List;
@@ -36,23 +37,23 @@ public class MessageService {
 
     private final MessageRepository messages;
     private final ChannelSubscriptionRepository channelSubscriptions;
-    private final MemberRepository members;
     private final JPAQueryFactory jpaQueryFactory;
+    private final Clock clock;
 
     public MessageService(final MessageRepository messages,
                           final ChannelSubscriptionRepository channelSubscriptions,
-                          final MemberRepository members,
-                          final JPAQueryFactory jpaQueryFactory) {
+                          final JPAQueryFactory jpaQueryFactory,
+                          final Clock clock) {
         this.messages = messages;
         this.channelSubscriptions = channelSubscriptions;
-        this.members = members;
         this.jpaQueryFactory = jpaQueryFactory;
+        this.clock = clock;
     }
 
     public MessageResponses find(final Long memberId, final MessageRequest messageRequest) {
         List<Long> channelIds = findChannelId(memberId, messageRequest);
 
-        List<MessageResponse> messageResponses = findMessages(channelIds, messageRequest);
+        List<MessageResponse> messageResponses = findMessages(memberId, channelIds, messageRequest);
         boolean isLast = isLast(channelIds, messageRequest, messageResponses);
 
         return new MessageResponses(messageResponses, isLast, messageRequest.isNeedPastMessage());
@@ -75,7 +76,8 @@ public class MessageService {
         return Objects.nonNull(channelIds) && !channelIds.isEmpty();
     }
 
-    private List<MessageResponse> findMessages(final List<Long> channelIds, final MessageRequest messageRequest) {
+    private List<MessageResponse> findMessages(final Long memberId, final List<Long> channelIds,
+                                               final MessageRequest messageRequest) {
         boolean needPastMessage = messageRequest.isNeedPastMessage();
         int messageCount = messageRequest.getMessageCount();
 
@@ -85,6 +87,8 @@ public class MessageService {
                 .leftJoin(QMessage.message.member)
                 .leftJoin(QBookmark.bookmark)
                 .on(QMessage.message.id.eq(QBookmark.bookmark.message.id))
+                .leftJoin(QReminder.reminder)
+                .on(reminderCondition(memberId))
                 .where(meetAllConditions(channelIds, messageRequest))
                 .orderBy(arrangeDateByNeedPastMessage(needPastMessage))
                 .limit(messageCount)
@@ -108,7 +112,14 @@ public class MessageService {
                 QMessage.message.text,
                 QMessage.message.postedDate,
                 QMessage.message.modifiedDate,
-                QBookmark.bookmark.id);
+                QBookmark.bookmark.id,
+                QReminder.reminder.id);
+    }
+
+    private BooleanExpression reminderCondition(final Long memberId) {
+        return QReminder.reminder.member.id.eq(memberId)
+                .and(QReminder.reminder.message.id.eq(QMessage.message.id))
+                .and(QReminder.reminder.remindDate.after(LocalDateTime.now(clock)));
     }
 
     private BooleanExpression meetAllConditions(final List<Long> channelIds, final MessageRequest request) {

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
@@ -17,8 +17,12 @@ public class MessageResponse {
     private String text;
     private LocalDateTime postedDate;
     private LocalDateTime modifiedDate;
+
     @JsonProperty(value = "isBookmarked")
     private boolean bookmarked;
+
+    @JsonProperty(value = "isSetReminded")
+    private boolean setReminded;
 
     private MessageResponse() {
     }
@@ -31,7 +35,8 @@ public class MessageResponse {
                            final String text,
                            final LocalDateTime postedDate,
                            final LocalDateTime modifiedDate,
-                           final boolean isBookmarked) {
+                           final boolean isBookmarked,
+                           final boolean isSetReminded) {
         this.id = id;
         this.memberId = memberId;
         this.username = username;
@@ -40,6 +45,7 @@ public class MessageResponse {
         this.postedDate = postedDate;
         this.modifiedDate = modifiedDate;
         this.bookmarked = isBookmarked;
+        this.setReminded = isSetReminded;
     }
 
     @QueryProjection
@@ -50,7 +56,8 @@ public class MessageResponse {
                            final String text,
                            final LocalDateTime postedDate,
                            final LocalDateTime modifiedDate,
-                           final Long bookmarkId) {
+                           final Long bookmarkId,
+                           final Long reminderId) {
         this.id = id;
         this.memberId = memberId;
         this.username = username;
@@ -59,5 +66,6 @@ public class MessageResponse {
         this.postedDate = postedDate;
         this.modifiedDate = modifiedDate;
         this.bookmarked = !Objects.isNull(bookmarkId);
+        this.setReminded = !Objects.isNull(reminderId);
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
@@ -65,7 +65,7 @@ public class MessageResponse {
         this.text = text;
         this.postedDate = postedDate;
         this.modifiedDate = modifiedDate;
-        this.bookmarked = !Objects.isNull(bookmarkId);
-        this.setReminded = !Objects.isNull(reminderId);
+        this.bookmarked = Objects.nonNull(bookmarkId);
+        this.setReminded = Objects.nonNull(reminderId);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/truncate.sql", "/channel.sql"})
+@Sql(value = "/truncate.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
 @DisplayName("채널 구독 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -145,7 +145,10 @@ class ReminderServiceTest {
     @Test
     void update() {
         // given
-        LocalDateTime updateTime = LocalDateTime.now().plusDays(1);
+        given(clock.instant())
+                .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
+
+        LocalDateTime updateTime = LocalDateTime.now(clock).plusDays(1);
         long memberId = 1L;
         long messageId = 2L;
 
@@ -165,7 +168,10 @@ class ReminderServiceTest {
     @Test
     void updateOtherMembers() {
         // given
-        ReminderRequest request = new ReminderRequest(1L, LocalDateTime.now().plusDays(1));
+        given(clock.instant())
+                .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
+
+        ReminderRequest request = new ReminderRequest(1L, LocalDateTime.now(clock).plusDays(1));
 
         // when & then
         assertThatThrownBy(() -> reminderService.update(1L, request))

--- a/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
@@ -82,6 +82,8 @@ class MessageControllerTest extends RestDocsTestSupport {
                                                 .description("메시지 수정 날짜"),
                                         fieldWithPath("messages.[].isBookmarked").type(JsonFieldType.BOOLEAN)
                                                 .description("북마크 여부"),
+                                        fieldWithPath("messages.[].isSetReminded").type(JsonFieldType.BOOLEAN)
+                                                .description("리마인더 등록 여부"),
                                         fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부"),
                                         fieldWithPath("isNeedPastMessage").type(JsonFieldType.BOOLEAN)
                                                 .description("위/아래 스크롤 방향")

--- a/backend/src/test/resources/message.sql
+++ b/backend/src/test/resources/message.sql
@@ -54,3 +54,6 @@ insert into bookmark(id, member_id, message_id)
 values (1, 1, 1),
       (2, 1, 5),
       (3, 1, 10);
+
+insert into reminder (id, member_id, message_id, remind_date)
+values (1, 1, 38, '2022-08-12 14:20:00');


### PR DESCRIPTION
## 요약

메시지 조회 시 isSetReminded 필드 추가

<br><br>

## 작업 내용

- 메시지 조회 시 isSetReminded 필드 추가
- 관련 서비스 테스트, 인수 테스트 케이스 추가
- 컨트롤러 테스트 수정
- 깨지는 테스트 케이스 수정

<br><br>

## 참고 사항
- 코멘트 달아주시면 확인 후 직접 merge하겠습니다!

<br><br>

## 관련 이슈

- Close #389

<br><br>
