### PR TITLE
SonarQube 연동 테스트

### DIFF
--- a/.github/workflows/backend-build-test.yml
+++ b/.github/workflows/backend-build-test.yml
@@ -19,10 +19,8 @@ defaults:
     working-directory: backend
 
 jobs:
-  build:
-
+  Build-Test:
     runs-on: ubuntu-latest
-
     steps:
       - name: 리포지토리를 가져옵니다
         uses: actions/checkout@v3
@@ -69,3 +67,33 @@ jobs:
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         if: failure()
+        
+  SonarQube:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: ./gradlew build sonarqube --info

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,7 @@ plugins {
     id 'java'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id "org.sonarqube" version "3.2.0"
 }
 
 group = 'com.pickpick'
@@ -104,4 +105,10 @@ sourceSets {
 }
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
+}
+
+sonarqube {
+  properties {
+    property "sonar.projectKey", "woowacourse-teams_2022-pickpick"
+  }
 }


### PR DESCRIPTION
## 요약

- SonarQube 연동 테스트

<br><br>

## 작업 내용

- `build.gradle` plugin 선언 추가
- `build.gradle` 최하단 sonarqube 정보 추가
- Github Repository Secrets에 SONAR_TOKEN, SONAR_HOST_URL 추가

<br><br>
