### PR TITLE
fix: 메시지 조회 시 해당 회원의 북마크일 경우만 isBookmarked: true 반환  

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -86,7 +86,7 @@ public class MessageService {
                 .from(QMessage.message)
                 .leftJoin(QMessage.message.member)
                 .leftJoin(QBookmark.bookmark)
-                .on(QMessage.message.id.eq(QBookmark.bookmark.message.id))
+                .on(existsBookmark(memberId))
                 .leftJoin(QReminder.reminder)
                 .on(remainReminder(memberId))
                 .where(meetAllConditions(channelIds, messageRequest))
@@ -114,6 +114,11 @@ public class MessageService {
                 QMessage.message.modifiedDate,
                 QBookmark.bookmark.id,
                 QReminder.reminder.id);
+    }
+
+    private BooleanExpression existsBookmark(final Long memberId) {
+        return QBookmark.bookmark.member.id.eq(memberId)
+                .and(QBookmark.bookmark.message.id.eq(QMessage.message.id));
     }
 
     private BooleanExpression remainReminder(final Long memberId) {


### PR DESCRIPTION
## 요약

메시지 목록 조회 시 해당 회원의 북마크만 조회합니다  

<br>

## 작업 내용

기존에 해당 회원 조회 조건을 안걸어서, 누가 한 것이든 북마크가 존재만 한다면 `isBookmarked: true`로 나가고 있었습니다  
이를 해당 회원의 북마크만 조회하도록 수정했습니다  

<br>

## 관련 이슈

- Close #408 

<br>
