### PR TITLE
feat: message 도메인 하위 repository에서 save시 해당 도메인 반환하도록 변경

### DIFF
--- a/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
@@ -5,7 +5,7 @@ import org.springframework.data.repository.Repository;
 
 public interface BookmarkRepository extends Repository<Bookmark, Long> {
 
-    void save(Bookmark bookmark);
+    Bookmark save(Bookmark bookmark);
 
     Optional<Bookmark> findById(Long id);
 

--- a/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.repository.Repository;
 
 public interface MessageRepository extends Repository<Message, Long> {
 
-    void save(Message message);
+    Message save(Message message);
 
     List<Message> findAll();
 

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -7,7 +7,7 @@ import org.springframework.data.repository.Repository;
 
 public interface ReminderRepository extends Repository<Reminder, Long> {
 
-    void save(Reminder reminder);
+    Reminder save(Reminder reminder);
 
     Optional<Reminder> findById(Long id);
 

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -65,8 +65,7 @@ class BookmarkServiceTest {
         // given
         Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
-        messages.save(message);
+        Message message = messages.save(new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
 
         BookmarkRequest bookmarkRequest = new BookmarkRequest(message.getId());
         int beforeSize = findBookmarksSize(member);
@@ -112,8 +111,7 @@ class BookmarkServiceTest {
         // given
         Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
-        messages.save(message);
+        Message message = messages.save(new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
         Bookmark bookmark = bookmarks.save(new Bookmark(member, message));
 
         // when
@@ -131,8 +129,7 @@ class BookmarkServiceTest {
         Member owner = members.save(new Member("U1234", "사용자", "user.png"));
         Member other = members.save(new Member("U1235", "다른 사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = new Message("M1234", "메시지", owner, channel, LocalDateTime.now(), LocalDateTime.now());
-        messages.save(message);
+        Message message = messages.save(new Message("M1234", "메시지", owner, channel, LocalDateTime.now(), LocalDateTime.now()));
         Bookmark bookmark = new Bookmark(owner, message);
         bookmarks.save(bookmark);
 

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -114,8 +114,7 @@ class BookmarkServiceTest {
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
         Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
         messages.save(message);
-        Bookmark bookmark = new Bookmark(member, message);
-        bookmarks.save(bookmark);
+        Bookmark bookmark = bookmarks.save(new Bookmark(member, message));
 
         // when
         bookmarkService.delete(message.getId(), member.getId());

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -76,8 +76,7 @@ class ReminderServiceTest {
         // given
         Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now());
-        messages.save(message);
+        Message message = messages.save(new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
 
         ReminderRequest reminderRequest = new ReminderRequest(message.getId(), LocalDateTime.now().plusDays(1));
         int beforeSize = findReminderSize(member);


### PR DESCRIPTION
## 요약

message 도메인 하위 repository의 save 메서드에서 void 대신 해당 도메인 반환하도록 변경했습니다  

<br>

## 작업 내용

이제 아래 레포지토리들은 해당 도메인을 반환합니다   
- MessageRepository (Message)
- BookmarkRepository (Bookmark)
- ReminderRepository (Reminder)

<br> 

## 참고 사항  

테스트도 이에 맞춰 코드를 인라인 처리했습니다  

<br>  

## 관련 이슈

- Close #405 

<br><br>
