### PR TITLE
fix: 로그인 되지 않은 사용자에게 랜딩페이지에서 에러메시지를 띄우는 버그 

### DIFF
--- a/frontend/src/components/PublicRouter/index.tsx
+++ b/frontend/src/components/PublicRouter/index.tsx
@@ -17,6 +17,7 @@ function PublicRouter({ children }: Props) {
     isCertificated,
     {
       retry: false,
+      onError: () => null,
     }
   );
 

--- a/frontend/src/hooks/useModeTheme.ts
+++ b/frontend/src/hooks/useModeTheme.ts
@@ -35,7 +35,10 @@ function useTheme(): ReturnType {
   };
 
   useEffect(() => {
-    if (window.matchMedia("(prefers-color-scheme: dark)").matches)
+    if (
+      window.matchMedia("(prefers-color-scheme: dark)").matches &&
+      theme !== THEME_KIND.LIGHT
+    )
       handleChangeTheme(THEME_KIND.DARK);
   }, []);
 


### PR DESCRIPTION
## 요약
로그인 되지 않은 사용자에게 랜딩페이지에서 에러메시지를 띄우는 버그 해결 

## 작업 내용

- 로그인 되지 않은 사용자에게 랜딩페이지에서 에러메시지를 띄우는 버그 해결  (PublicRouter 수정)
- OS 환경 설정값 상관 없이 사용자가 light mode 세팅했으면 light mode 로 보여주도록 수정 

## 참고 사항

- PublicRouter 에서는 400 에러가 나도, 에러메시지가 보여지지 않아야 하므로 전역의 onError 핸들러가 오버라이드 되도록 빈 함수를 주입했습니다.

## 관련 이슈

- Close #418 

<br><br>
