### PR TITLE
feat: file_share 이벤트를 저장하는 기능 구현

### DIFF
--- a/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/SlackEvent.java
@@ -11,6 +11,7 @@ public enum SlackEvent {
     MESSAGE_CREATED("message", ""),
     MESSAGE_CHANGED("message", "message_changed"),
     MESSAGE_DELETED("message", "message_deleted"),
+    MESSAGE_FILE_SHARE("message", "file_share"),
     CHANNEL_RENAME("channel_rename", ""),
     CHANNEL_DELETED("channel_deleted", ""),
     MEMBER_CHANGED("user_profile_changed", ""),

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
@@ -51,7 +51,6 @@ public class MessageFileShareService implements SlackEventService {
                 .orElseThrow(() -> new MemberNotFoundException(memberSlackId));
 
         String channelSlackId = slackMessageDto.getChannelSlackId();
-
         Channel channel = channels.findBySlackId(channelSlackId)
                 .orElseGet(() -> createChannel(channelSlackId));
 

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
@@ -1,0 +1,97 @@
+package com.pickpick.slackevent.application.message;
+
+import com.pickpick.channel.domain.Channel;
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.SlackApiCallException;
+import com.pickpick.exception.member.MemberNotFoundException;
+import com.pickpick.member.domain.Member;
+import com.pickpick.member.domain.MemberRepository;
+import com.pickpick.message.domain.MessageRepository;
+import com.pickpick.slackevent.application.SlackEvent;
+import com.pickpick.slackevent.application.SlackEventService;
+import com.pickpick.slackevent.application.message.dto.SlackMessageDto;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.Conversation;
+import java.io.IOException;
+import java.util.Map;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@Service
+public class MessageFileShareService implements SlackEventService {
+
+    private static final String EVENT = "event";
+    private static final String USER = "user";
+    private static final String TIMESTAMP = "ts";
+    private static final String TEXT = "text";
+    private static final String CLIENT_MSG_ID = "client_msg_id";
+    private static final String CHANNEL = "channel";
+
+    private final MessageRepository messages;
+    private final MemberRepository members;
+    private final ChannelRepository channels;
+    private final MethodsClient slackClient;
+
+    public MessageFileShareService(final MessageRepository messages, final MemberRepository members,
+                                   final ChannelRepository channels, final MethodsClient slackClient) {
+        this.messages = messages;
+        this.members = members;
+        this.channels = channels;
+        this.slackClient = slackClient;
+    }
+
+    @Override
+    public void execute(final Map<String, Object> requestBody) {
+        SlackMessageDto slackMessageDto = convert(requestBody);
+
+        String memberSlackId = slackMessageDto.getMemberSlackId();
+        Member member = members.findBySlackId(memberSlackId)
+                .orElseThrow(() -> new MemberNotFoundException(memberSlackId));
+
+        String channelSlackId = slackMessageDto.getChannelSlackId();
+
+        Channel channel = channels.findBySlackId(channelSlackId)
+                .orElseGet(() -> createChannel(channelSlackId));
+
+        messages.save(slackMessageDto.toEntity(member, channel));
+    }
+
+    private SlackMessageDto convert(final Map<String, Object> requestBody) {
+        Map<String, Object> event = (Map<String, Object>) requestBody.get(EVENT);
+
+        return new SlackMessageDto(
+                (String) event.get(USER),
+                (String) event.get(CLIENT_MSG_ID),
+                (String) event.get(TIMESTAMP),
+                (String) event.get(TIMESTAMP),
+                (String) event.getOrDefault(TEXT, ""),
+                (String) event.get(CHANNEL)
+        );
+    }
+
+    private Channel createChannel(final String channelSlackId) {
+        try {
+            Conversation conversation = slackClient.conversationsInfo(
+                    request -> request.channel(channelSlackId)
+            ).getChannel();
+
+            Channel channel = toChannel(conversation);
+            channels.save(channel);
+
+            return channel;
+        } catch (IOException | SlackApiException e) {
+            throw new SlackApiCallException(e);
+        }
+    }
+
+    private Channel toChannel(final Conversation channel) {
+        return new Channel(channel.getId(), channel.getName());
+    }
+
+    @Override
+    public boolean isSameSlackEvent(final SlackEvent slackEvent) {
+        return SlackEvent.MESSAGE_FILE_SHARE == slackEvent;
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -100,4 +100,19 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         // then
         상태코드_200_확인(response);
     }
+
+    @Test
+    void 파일_공유_메시지_요청_시_메시지가_저장된다() {
+        // given
+        Map<String, Object> messageCreatedRequest = createEventRequest("");
+        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+
+        Map<String, Object> messageDeletedRequest = createEventRequest(SlackEvent.MESSAGE_FILE_SHARE.getSubtype());
+
+        // when
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageDeletedRequest);
+
+        // then
+        상태코드_200_확인(response);
+    }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -107,10 +107,10 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageCreatedRequest = createEventRequest("");
         post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
-        Map<String, Object> messageDeletedRequest = createEventRequest(SlackEvent.MESSAGE_FILE_SHARE.getSubtype());
+        Map<String, Object> fileShareMessageRequest = createEventRequest(SlackEvent.MESSAGE_FILE_SHARE.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageDeletedRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, fileShareMessageRequest);
 
         // then
         상태코드_200_확인(response);

--- a/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/SlackEventTest.java
@@ -22,6 +22,8 @@ class SlackEventTest {
                         SlackEvent.MESSAGE_CHANGED),
                 Arguments.of(Map.of("event", Map.of("type", "message", "subtype", "message_deleted")),
                         SlackEvent.MESSAGE_DELETED),
+                Arguments.of(Map.of("event", Map.of("type", "message", "subtype", "file_share")),
+                        SlackEvent.MESSAGE_FILE_SHARE),
                 Arguments.of(Map.of("event", Map.of("type", "channel_rename")), SlackEvent.CHANNEL_RENAME),
                 Arguments.of(Map.of("event", Map.of("type", "channel_deleted")), SlackEvent.CHANNEL_DELETED),
                 Arguments.of(Map.of("event", Map.of("type", "user_profile_changed")), SlackEvent.MEMBER_CHANGED),

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
@@ -4,7 +4,7 @@ import static com.pickpick.slackevent.application.SlackEvent.MESSAGE_FILE_SHARE;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
+import static org.mockito.BDDMockito.given;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
@@ -63,7 +63,7 @@ class MessageFileShareServiceTest {
     @MockBean
     private MethodsClient slackClient;
 
-    @DisplayName("파일과 함께 생성된 메시지에 대한 저장")
+    @DisplayName("파일 공유 이벤트 전달 시 채널이 저장되어 있지 않으면 채널 신규 저장 후 메시지를 저장한다")
     @ValueSource(strings = {"", " ", "파일과 함께 전송한 메시지 text"})
     @ParameterizedTest
     void fileShareMessage(final String expectedText) throws SlackApiException, IOException {
@@ -72,10 +72,10 @@ class MessageFileShareServiceTest {
         Optional<Channel> channelBeforeSave = channels.findBySlackId(SAMPLE_CHANNEL.getSlackId());
         Optional<Message> messageBeforeSave = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
 
-        ConversationsInfoResponse conversationsInfoResponse = setupMockData();
+        ConversationsInfoResponse conversationsInfoResponse = setUpChannelMockData();
 
-        when(slackClient.conversationsInfo((RequestConfigurator<ConversationsInfoRequestBuilder>) any()))
-                .thenReturn(conversationsInfoResponse);
+        given(slackClient.conversationsInfo((RequestConfigurator<ConversationsInfoRequestBuilder>) any()))
+                .willReturn(conversationsInfoResponse);
 
         // when
         messageFileShareService.execute(fileShareRequest(expectedText));
@@ -92,7 +92,7 @@ class MessageFileShareServiceTest {
         );
     }
 
-    @DisplayName("메시지 작성 이벤트 전달 시 채널이 저장되어 있으면 채널 신규 저장 없이 메시지를 저장한다")
+    @DisplayName("파일 공유 이벤트 전달 시 채널이 저장되어 있으면 채널 신규 저장 없이 메시지를 저장한다")
     @ValueSource(strings = {"", " ", "파일과 함께 전송한 메시지 text"})
     @ParameterizedTest
     void saveMessageWhenFileShareEventPassed(final String expectedText) {
@@ -117,7 +117,7 @@ class MessageFileShareServiceTest {
         );
     }
 
-    private ConversationsInfoResponse setupMockData() {
+    private ConversationsInfoResponse setUpChannelMockData() {
         Conversation conversation = new Conversation();
         conversation.setId(SAMPLE_CHANNEL.getSlackId());
         conversation.setName(SAMPLE_CHANNEL.getName());

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
@@ -1,0 +1,143 @@
+package com.pickpick.slackevent.application.message;
+
+import static com.pickpick.slackevent.application.SlackEvent.MESSAGE_FILE_SHARE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.pickpick.channel.domain.Channel;
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.member.domain.Member;
+import com.pickpick.member.domain.MemberRepository;
+import com.pickpick.message.domain.Message;
+import com.pickpick.message.domain.MessageRepository;
+import com.pickpick.utils.TimeUtils;
+import com.slack.api.RequestConfigurator;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.conversations.ConversationsInfoRequest.ConversationsInfoRequestBuilder;
+import com.slack.api.methods.response.conversations.ConversationsInfoResponse;
+import com.slack.api.model.Conversation;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Map;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+class MessageFileShareServiceTest {
+
+    private static final Member SAMPLE_MEMBER = new Member("U03MKN0UW", "사용자", "test.png");
+    private static final Channel SAMPLE_CHANNEL = new Channel("ASDFB", "채널");
+    private static final Message SAMPLE_MESSAGE = new Message(
+            "db8a1f84-8acf-46ab-b93d-85177cee3e97",
+            "메시지 전송!",
+            SAMPLE_MEMBER,
+            SAMPLE_CHANNEL,
+            TimeUtils.toLocalDateTime("1234567890"),
+            TimeUtils.toLocalDateTime("1234567890")
+    );
+
+    @Autowired
+    private MessageFileShareService messageFileShareService;
+
+    @Autowired
+    private MessageRepository messages;
+
+    @Autowired
+    private MemberRepository members;
+
+    @Autowired
+    private ChannelRepository channels;
+
+    @MockBean
+    private MethodsClient slackClient;
+
+    @DisplayName("파일과 함께 생성된 메시지에 대한 저장")
+    @ValueSource(strings = {"", " ", "파일과 함께 전송한 메시지 text"})
+    @ParameterizedTest
+    void fileShareMessage(final String expectedText) throws SlackApiException, IOException {
+        // given
+        members.save(SAMPLE_MEMBER);
+        Optional<Channel> channelBeforeSave = channels.findBySlackId(SAMPLE_CHANNEL.getSlackId());
+        Optional<Message> messageBeforeSave = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
+
+        ConversationsInfoResponse conversationsInfoResponse = setupMockData();
+
+        when(slackClient.conversationsInfo((RequestConfigurator<ConversationsInfoRequestBuilder>) any()))
+                .thenReturn(conversationsInfoResponse);
+
+        // when
+        messageFileShareService.execute(fileShareRequest(expectedText));
+        Optional<Channel> channelAfterSave = channels.findBySlackId(SAMPLE_CHANNEL.getSlackId());
+        Optional<Message> messageAfterSave = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
+
+        // then
+        assertAll(
+                () -> assertThat(channelBeforeSave).isEmpty(),
+                () -> assertThat(messageBeforeSave).isEmpty(),
+                () -> assertThat(channelAfterSave).isPresent(),
+                () -> assertThat(messageAfterSave).isPresent(),
+                () -> assertThat(messageAfterSave.get().getText()).isEqualTo(expectedText)
+        );
+    }
+
+    @DisplayName("메시지 작성 이벤트 전달 시 채널이 저장되어 있으면 채널 신규 저장 없이 메시지를 저장한다")
+    @ValueSource(strings = {"", " ", "파일과 함께 전송한 메시지 text"})
+    @ParameterizedTest
+    void saveMessageWhenFileShareEventPassed(final String expectedText) {
+        // given
+        members.save(SAMPLE_MEMBER);
+        channels.save(SAMPLE_CHANNEL);
+        Optional<Channel> channelBeforeSave = channels.findBySlackId(SAMPLE_CHANNEL.getSlackId());
+        Optional<Message> messageBeforeSave = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
+
+        // when
+        messageFileShareService.execute(fileShareRequest(expectedText));
+        Optional<Channel> channelAfterSave = channels.findBySlackId(SAMPLE_CHANNEL.getSlackId());
+        Optional<Message> messageAfterSave = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
+
+        // then
+        assertAll(
+                () -> assertThat(channelBeforeSave).isPresent(),
+                () -> assertThat(messageBeforeSave).isEmpty(),
+                () -> assertThat(channelAfterSave).isPresent(),
+                () -> assertThat(messageAfterSave).isPresent(),
+                () -> assertThat(messageAfterSave.get().getText()).isEqualTo(expectedText)
+        );
+    }
+
+    private ConversationsInfoResponse setupMockData() {
+        Conversation conversation = new Conversation();
+        conversation.setId(SAMPLE_CHANNEL.getSlackId());
+        conversation.setName(SAMPLE_CHANNEL.getName());
+
+        ConversationsInfoResponse conversationsInfoResponse = new ConversationsInfoResponse();
+        conversationsInfoResponse.setChannel(conversation);
+
+        return conversationsInfoResponse;
+    }
+
+    private Map<String, Object> fileShareRequest(final String text) {
+        return Map.of("event", Map.of(
+                "type", MESSAGE_FILE_SHARE.getType(),
+                "subtype", MESSAGE_FILE_SHARE.getSubtype(),
+                "files", new ArrayList<>(),
+                "channel", SAMPLE_CHANNEL.getSlackId(),
+                "text", text,
+                "user", SAMPLE_MEMBER.getSlackId(),
+                "ts", "1234567890",
+                "client_msg_id", SAMPLE_MESSAGE.getSlackId())
+        );
+    }
+}


### PR DESCRIPTION
### 제가 머지하겠습니다!

## 요약

file_share 이벤트를 저장하는 기능 구현
<br><br>

## 작업 내용

- file_share 이벤트 저장 기능 구현
- SlackEvent test 추가
- Acceptance test 추가

<br><br>

## 참고 사항

- 기존에 작성했던 file_share 이벤트 코드와 동일합니다.
- 기존 코드에 SlackEventTest, MessageEventAcceptanceTest만 추가했습니다.
- 기존 코드 및 리뷰는  #225 에서 확인하실 수 있습니다!
- createChannel은 이 PR과 #424 PR이 머지되면 진행하겠습니다.

<br><br>

## 관련 이슈

- Close #425 

<br><br>
