### PR TITLE
fix: 리마인더 조회 시 메시지 작성자의 정보 전달

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/ReminderService.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderService.java
@@ -76,8 +76,6 @@ public class ReminderService {
                 .selectFrom(QReminder.reminder)
                 .leftJoin(QReminder.reminder.message)
                 .fetchJoin()
-                .leftJoin(QReminder.reminder.member)
-                .fetchJoin()
                 .where(QReminder.reminder.member.id.eq(memberId))
                 .where(remindDateCondition(reminderId))
                 .orderBy(QReminder.reminder.remindDate.asc())

--- a/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponse.java
@@ -38,7 +38,7 @@ public class ReminderResponse {
 
     public static ReminderResponse from(final Reminder reminder) {
         Message message = reminder.getMessage();
-        Member member = reminder.getMember();
+        Member member = message.getMember();
 
         return ReminderResponse.builder()
                 .id(reminder.getId())


### PR DESCRIPTION
## 요약

리마인더 조회 시 메시지 작성자의 정보 전달

<br><br>

## 작업 내용

(1)
리마인더 조회 시 리마인더를 등록한 사용자의 정보를 가져오고 있었습니다.
메시지를 등록한 사용자의 정보를 가져올 수 있도록 수정했습니다.

(2)
불필요한 join을 제거했습니다.

<br><br>

## 관련 이슈

- Close #431 

<br><br>
