### PR TITLE
fix: 리마인더 삭제 api 명세가 북마크 삭제 api 명세로 보였던 에러 수정

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -91,7 +91,7 @@ operation::reminder-controller-test/save[snippets='http-request,request-headers,
 
 === 리마인더 삭제 API
 
-operation::bookmark-controller-test/delete[snippets='http-request,request-headers,request-parameters,http-response']
+operation::reminder-controller-test/delete[snippets='http-request,request-headers,request-parameters,http-response']
 
 === 리마인더 수정 API
 


### PR DESCRIPTION
## 요약

리마인더 삭제 api 명세가 북마크 삭제 api 명세로 보였던 에러 수정
<br><br>

## 작업 내용

**BEFORE**
<img width="961" alt="image" src="https://user-images.githubusercontent.com/55357130/184816359-beef531c-51f1-41dd-9ba3-249f17a72044.png">

**AFTER**
<img width="984" alt="image" src="https://user-images.githubusercontent.com/55357130/184816419-b55fd6e9-be61-4035-81a2-25403d6887fb.png">


<br><br>

## 참고 사항
- 위의 사진 다크모드인건 신경 안쓰셔도 됩니다! 인텔리제이에서 바로 열면 저렇게 안예쁜 디자인으로 나와요.
<br><br>

## 관련 이슈

- Close #434 

<br><br>
