### PR TITLE
feat: 메시지 조회 시 remindDate 필드 추가

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -113,7 +113,8 @@ public class MessageService {
                 QMessage.message.postedDate,
                 QMessage.message.modifiedDate,
                 QBookmark.bookmark.id,
-                QReminder.reminder.id);
+                QReminder.reminder.id,
+                QReminder.reminder.remindDate);
     }
 
     private BooleanExpression existsBookmark(final Long memberId) {

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponse.java
@@ -17,6 +17,7 @@ public class MessageResponse {
     private String text;
     private LocalDateTime postedDate;
     private LocalDateTime modifiedDate;
+    private LocalDateTime remindDate;
 
     @JsonProperty(value = "isBookmarked")
     private boolean bookmarked;
@@ -36,7 +37,8 @@ public class MessageResponse {
                            final LocalDateTime postedDate,
                            final LocalDateTime modifiedDate,
                            final boolean isBookmarked,
-                           final boolean isSetReminded) {
+                           final boolean isSetReminded,
+                           final LocalDateTime remindDate) {
         this.id = id;
         this.memberId = memberId;
         this.username = username;
@@ -46,6 +48,7 @@ public class MessageResponse {
         this.modifiedDate = modifiedDate;
         this.bookmarked = isBookmarked;
         this.setReminded = isSetReminded;
+        this.remindDate = remindDate;
     }
 
     @QueryProjection
@@ -57,7 +60,8 @@ public class MessageResponse {
                            final LocalDateTime postedDate,
                            final LocalDateTime modifiedDate,
                            final Long bookmarkId,
-                           final Long reminderId) {
+                           final Long reminderId,
+                           final LocalDateTime remindDate) {
         this.id = id;
         this.memberId = memberId;
         this.username = username;
@@ -67,5 +71,6 @@ public class MessageResponse {
         this.modifiedDate = modifiedDate;
         this.bookmarked = Objects.nonNull(bookmarkId);
         this.setReminded = Objects.nonNull(reminderId);
+        this.remindDate = remindDate;
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -162,7 +162,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 이미_리마인드_완료된_메시지_조회_시_isSetReminded가_false() {
+    void 이미_리마인드_완료된_메시지_조회_시_isSetReminded가_false이고_remindDate가_null() {
         // given
         given(clock.instant())
                 .willReturn(Instant.parse("2022-08-13T00:00:00Z"));
@@ -176,11 +176,14 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
         // then
         상태코드_200_확인(response);
-        assertThat(messageResponse.isSetReminded()).isFalse();
+        assertAll(
+                () -> assertThat(messageResponse.isSetReminded()).isFalse(),
+                () -> assertThat(messageResponse.getRemindDate()).isNull()
+        );
     }
 
     @Test
-    void 리마인드_해야하는_메시지_조회_시_isSetReminded가_true() {
+    void 리마인드_해야하는_메시지_조회_시_isSetReminded가_true이고_remindDate에_값이_존재() {
         // given
         given(clock.instant())
                 .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
@@ -194,6 +197,9 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
         // then
         상태코드_200_확인(response);
-        assertThat(messageResponse.isSetReminded()).isTrue();
+        assertAll(
+                () -> assertThat(messageResponse.isSetReminded()).isTrue(),
+                () -> assertThat(messageResponse.getRemindDate()).isNotNull()
+        );
     }
 }

--- a/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
@@ -9,6 +9,7 @@ import com.pickpick.message.ui.dto.MessageResponse;
 import com.pickpick.message.ui.dto.MessageResponses;
 import java.time.Clock;
 import java.time.Instant;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -153,7 +154,7 @@ class MessageServiceTest {
                 .get(0);
 
         // then
-        assertThat(message.getRemindDate()).isNotNull();
+        assertThat(message.getRemindDate()).isEqualTo(LocalDateTime.of(2022, 8, 12, 14, 20, 0));
     }
 
     @DisplayName("메시지 조회 시, remindDate 값이 없으면 빈 값으로 전달된다")

--- a/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
@@ -137,4 +137,40 @@ class MessageServiceTest {
                         false)
         );
     }
+
+    @DisplayName("메시지 조회 시, remindDate가 함께 전달된다")
+    @Test
+    void checkRemindDate2() {
+        // given
+        given(clock.instant())
+                .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
+
+        MessageRequest request = new MessageRequest("", "", List.of(5L), true, null, 1);
+
+        // when
+        MessageResponse message = messageService.find(MEMBER_ID, request)
+                .getMessages()
+                .get(0);
+
+        // then
+        assertThat(message.getRemindDate()).isNotNull();
+    }
+
+    @DisplayName("메시지 조회 시, remindDate 값이 없으면 빈 값으로 전달된다")
+    @Test
+    void checkRemindDate() {
+        // given
+        given(clock.instant())
+                .willReturn(Instant.parse("2022-08-12T14:20:00Z"));
+
+        MessageRequest request = new MessageRequest("", "", List.of(5L), true, null, 1);
+
+        // when
+        MessageResponse message = messageService.find(MEMBER_ID, request)
+                .getMessages()
+                .get(0);
+
+        // then
+        assertThat(message.getRemindDate()).isNull();
+    }
 }

--- a/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
@@ -84,6 +84,7 @@ class MessageControllerTest extends RestDocsTestSupport {
                                                 .description("북마크 여부"),
                                         fieldWithPath("messages.[].isSetReminded").type(JsonFieldType.BOOLEAN)
                                                 .description("리마인더 등록 여부"),
+                                        fieldWithPath("messages.[].remindDate").type(JsonFieldType.STRING).optional().description("리마인더 등록된 날짜"),
                                         fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부"),
                                         fieldWithPath("isNeedPastMessage").type(JsonFieldType.BOOLEAN)
                                                 .description("위/아래 스크롤 방향")


### PR DESCRIPTION
## 요약

메시지 조회 시 remindDate 필드 추가

<br><br>

## 작업 내용

- 메시지 조회 시 remindDate 추가
- 테스트 케이스 추가

<br><br>

## 참고 사항

- remindDate 값이 없으면 null로 전달

<br><br>

## 관련 이슈

- Close #438 

<br><br>
