### PR TITLE
chore: Jacoco, SonarQube 연동

### DIFF
--- a/.github/workflows/backend-sonarqube.yml
+++ b/.github/workflows/backend-sonarqube.yml
@@ -43,21 +43,7 @@ jobs:
       - name: Gradle 명령 실행을 위한 권한을 부여합니다
         run: chmod +x gradlew
 
-      - name: Cache SonarQube packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.sonar/cache
-          key: ${{ runner.os }}-sonar
-          restore-keys: ${{ runner.os }}-sonar
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v1
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
-          restore-keys: ${{ runner.os }}-gradle
-
-      - name: Build and analyze
+      - name: 정적 분석 결과를 SonarQube 서버로 전송합니다
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/backend-sonarqube.yml
+++ b/.github/workflows/backend-sonarqube.yml
@@ -1,0 +1,65 @@
+name: 줍줍 백엔드 SonarQube 정적 분석
+on:
+  push:
+    branches:
+      - main
+      - release/*
+      - develop
+    paths: 'backend/**'
+  pull_request:
+    branches:
+      - main
+      - release/*
+      - develop
+    paths: 'backend/**'
+
+defaults:
+  run:
+    working-directory: backend
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: 리포지토리를 가져옵니다
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SUBMODULE_TOKEN }}
+          submodules: recursive
+
+      - name: JDK 11을 설치합니다
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: TimeZone을 Asia/Seoul로 설정합니다
+        uses: zcong1993/setup-timezone@master
+        with:
+          timezone: Asia/Seoul
+
+      - name: Gradle 명령 실행을 위한 권한을 부여합니다
+        run: chmod +x gradlew
+
+      - name: Cache SonarQube packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.gradle/caches
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
+          restore-keys: ${{ runner.os }}-gradle
+
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
+        run: ./gradlew build sonarqube --info

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -98,20 +98,23 @@ tasks.named('test') {
 }
 
 def querydslDir = "$buildDir/generated/querydsl"
+
 querydsl {
     jpa = true
     querydslSourcesDir = querydslDir
 }
+
 sourceSets {
     main.java.srcDir querydslDir
 }
+
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
 }
 
 sonarqube {
     properties {
-        property "sonar.projectKey", "woowacourse-teams_2022-pickpick_AYKlZap98dMo58Zrdp2E"
+        property "sonar.projectKey", "woowacourse-teams_2022-pickpick_AYKprLeNXDQxKhlck1fc"
     }
 }
 

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -4,6 +4,8 @@ plugins {
     id 'java'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
     id "org.asciidoctor.jvm.convert" version "3.3.2"
+    id "org.sonarqube" version "3.4.0.2513"
+    id "jacoco"
 }
 
 group = 'com.pickpick'
@@ -58,6 +60,7 @@ ext {
 test {
     outputs.dir snippetsDir
     useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
 }
 
 asciidoctor {
@@ -104,4 +107,20 @@ sourceSets {
 }
 compileQuerydsl {
     options.annotationProcessorPath = configurations.querydsl
+}
+
+sonarqube {
+    properties {
+        property "sonar.projectKey", "woowacourse-teams_2022-pickpick_AYKlZap98dMo58Zrdp2E"
+    }
+}
+
+jacoco {
+    toolVersion = '0.8.8'
+}
+
+jacocoTestReport {
+    reports {
+        xml.enabled true
+    }
 }


### PR DESCRIPTION
## 요약

- SonarQube 연동

<br><br>

## 작업 내용

- `build.gradle` 에 `jacoco`, `sonarqube` 관련 설정 추가
- Github Repository Secrets에 SONAR_TOKEN, SONAR_HOST_URL 추가
- Github Actions에 Sonarqube 관련 수행 명령 추가

<br><br>

## 참고 사항

- [Sonarqube PR Decoration 적용기](https://github.com/woowacourse-teams/2022-pickpick/wiki/Sonarqube-PR-Decoration-%EC%A0%81%EC%9A%A9%EA%B8%B0)
- 현재, Github Actions Secret 값이 제대로 설정되어 있지 않아서 Check Fail로 나오고 있습니다.
- 시뮬레이션 영상 제작 과정에서 Secret 값이 변경되어 그렇습니다.
- 다같이 진행해서 프로덕션용으로 구축한 다음 그 값을 넣어주면 정상 동작할 겁니다.

<br><br>

## 관련 이슈

- Close #336
- Close #341

<br><br>