### PR TITLE
feat: DatabaseCleaner 구현

### DIFF
--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -36,7 +36,7 @@ public class AcceptanceTest {
     }
 
     @AfterEach
-    void clear() {
+    void tearDown() {
         databaseCleaner.clear();
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -3,10 +3,12 @@ package com.pickpick.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.config.DatabaseCleaner;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Map;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
@@ -25,9 +27,17 @@ public class AcceptanceTest {
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
+    }
+
+    @AfterEach
+    void clear() {
+        databaseCleaner.clear();
     }
 
     protected ExtractableResponse<Response> post(final String uri, final Object object) {

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -25,7 +25,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/member.sql"})
+@Sql({"/member.sql"})
 @DisplayName("인증 인가 기능")
 @SuppressWarnings("NonAsciiCharacters")
 public class AuthAcceptanceTest extends AcceptanceTest {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/channel.sql"})
+@Sql({"/channel.sql"})
 @DisplayName("채널 기능")
 @SuppressWarnings("NonAsciiCharacters")
 public class ChannelAcceptanceTest extends AcceptanceTest {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -15,8 +15,7 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/channel.sql"})
-@Sql(value = "/truncate.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+@Sql({"/channel.sql"})
 @DisplayName("채널 구독 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {

--- a/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
@@ -12,6 +12,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,6 +27,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Autowired
     private MemberRepository members;
 
+    @Disabled
     @Test
     void 프로젝트_기동_시점에_유저가_저장되어_있어야_한다() {
         // given

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -15,7 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/bookmark.sql"})
+@Sql({"/bookmark.sql"})
 @DisplayName("북마크 기능")
 @SuppressWarnings("NonAsciiCharacters")
 public class BookmarkAcceptanceTest extends AcceptanceTest {
@@ -81,7 +81,8 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId,
+                1L);
 
         // then
         상태코드_확인(response, HttpStatus.NO_CONTENT);
@@ -93,7 +94,8 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId,
+                1L);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -26,8 +26,8 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/message.sql"})
-@Sql(value = "/truncate.sql", executionPhase = Sql.ExecutionPhase.AFTER_TEST_METHOD)
+@Sql({"/message.sql"})
+
 @DisplayName("메시지 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class MessageAcceptanceTest extends AcceptanceTest {

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -22,7 +22,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/reminder.sql"})
+@Sql({"/reminder.sql"})
 @DisplayName("리마인더 기능")
 @SuppressWarnings("NonAsciiCharacters")
 public class ReminderAcceptanceTest extends AcceptanceTest {

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/member.sql"})
+@Sql({"/member.sql"})
 @DisplayName("멤버 이벤트 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class MemberEventAcceptanceTest extends AcceptanceTest {

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/message.sql"})
+@Sql({"/message.sql"})
 @DisplayName("메시지 이벤트 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class MessageEventAcceptanceTest extends AcceptanceTest {

--- a/backend/src/test/java/com/pickpick/channel/ui/ChannelControllerTest.java
+++ b/backend/src/test/java/com/pickpick/channel/ui/ChannelControllerTest.java
@@ -19,7 +19,7 @@ import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/channel.sql", "/channel-subscription.sql"})
+@Sql({"/channel.sql", "/channel-subscription.sql"})
 class ChannelControllerTest extends RestDocsTestSupport {
 
     @MockBean

--- a/backend/src/test/java/com/pickpick/channel/ui/ChannelSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/pickpick/channel/ui/ChannelSubscriptionControllerTest.java
@@ -28,7 +28,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-@Sql({"/truncate.sql", "/channel.sql", "/channel-subscription.sql"})
+@Sql({"/channel.sql", "/channel-subscription.sql"})
 class ChannelSubscriptionControllerTest extends RestDocsTestSupport {
 
     @MockBean

--- a/backend/src/test/java/com/pickpick/config/DatabaseCleaner.java
+++ b/backend/src/test/java/com/pickpick/config/DatabaseCleaner.java
@@ -1,0 +1,66 @@
+package com.pickpick.config;
+
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+import org.hibernate.Session;
+import org.springframework.beans.factory.InitializingBean;
+import org.springframework.stereotype.Component;
+
+@Component
+public class DatabaseCleaner implements InitializingBean {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+    private List<String> tableNames;
+
+    @Override
+    public void afterPropertiesSet() {
+        try (Session session = entityManager.unwrap(Session.class)) {
+            session.doWork(this::extractTableNames);
+        }
+    }
+
+    private void extractTableNames(Connection connection) throws SQLException {
+        List<String> tableNames = new ArrayList<>();
+
+        ResultSet tables = connection
+                .getMetaData()
+                .getTables(connection.getCatalog(), "PUBLIC", "%", new String[]{"TABLE"});
+
+        try (tables) {
+            while (tables.next()) {
+                tableNames.add(tables.getString("table_name"));
+            }
+
+            this.tableNames = tableNames;
+        }
+    }
+
+    public void clear() {
+        try (Session session = entityManager.unwrap(Session.class)) {
+            session.doWork(this::cleanUpDatabase);
+        }
+    }
+
+    private void cleanUpDatabase(Connection conn) throws SQLException {
+        try (Statement statement = conn.createStatement()) {
+
+            statement.executeUpdate("SET REFERENTIAL_INTEGRITY FALSE");
+
+            for (String tableName : tableNames) {
+
+                statement.executeUpdate("TRUNCATE TABLE " + tableName);
+                statement
+                        .executeUpdate("ALTER TABLE " + tableName + " ALTER COLUMN id RESTART WITH 1");
+            }
+
+            statement.executeUpdate("SET REFERENTIAL_INTEGRITY TRUE");
+        }
+    }
+}

--- a/backend/src/test/java/com/pickpick/config/RestDocsTestSupport.java
+++ b/backend/src/test/java/com/pickpick/config/RestDocsTestSupport.java
@@ -1,13 +1,13 @@
 package com.pickpick.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.core.io.ResourceLoader;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -28,10 +28,12 @@ public class RestDocsTestSupport {
 
     @Autowired
     protected RestDocumentationResultHandler restDocs;
+
     @Autowired
     protected ObjectMapper objectMapper;
+
     @Autowired
-    private ResourceLoader resourceLoader;
+    private DatabaseCleaner databaseCleaner;
 
     @BeforeEach
     public void setUp(
@@ -43,5 +45,10 @@ public class RestDocsTestSupport {
                 .alwaysDo(MockMvcResultHandlers.print())
                 .alwaysDo(restDocs)
                 .build();
+    }
+
+    @AfterEach
+    void clear() {
+        databaseCleaner.clear();
     }
 }

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -36,6 +37,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/truncate.sql", "/reminder.sql"})
+@Transactional
 @SpringBootTest
 class ReminderServiceTest {
 

--- a/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-@Sql({"/truncate.sql", "/bookmark.sql"})
+@Sql({"/bookmark.sql"})
 public class BookmarkControllerTest extends RestDocsTestSupport {
 
     private static final String BOOKMARK_API_URL = "/api/bookmarks";

--- a/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
@@ -24,7 +24,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 
-@Sql({"/truncate.sql", "/message.sql"})
+@Sql({"/message.sql"})
 class MessageControllerTest extends RestDocsTestSupport {
 
     @MockBean

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -30,7 +30,7 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-@Sql({"/truncate.sql", "/reminder.sql"})
+@Sql({"/reminder.sql"})
 public class ReminderControllerTest extends RestDocsTestSupport {
 
     private static final String REMINDER_API_URL = "/api/reminders";


### PR DESCRIPTION
## 요약

- 테스트 격리를 위한 DatabaseCleaner 추가

<br><br>

## 작업 내용

- 테스트 패키지 내 DatabaseCleaner 클래스 추가
- AcceptanceTest 클래스에 DatabaseCleaner 의존성 주입 및 AfterEach에 호출
- build.gradle 내 guava 라이브러리 추가

<br><br>

## 참고 사항

- https://tecoble.techcourse.co.kr/post/2020-09-15-test-isolation/
- https://github.com/woowacourse-teams/2021-pick-git/blob/develop/backend/pick-git/src/test/java/com/woowacourse/pickgit/config/DatabaseConfigurator.java
- 인수 테스트에 truncate 를 제거하고 테스트했을 때 3가지 정도 깨지는 케이스가 있었습니다.
- 두 가지 방법이 있어서 의견 교환을 위해 우선 PR 생성해둡니다.
- 방향성 합의가 완료되면 테스트 truncate.sql 모두 제거하고도 테스트 깨지지 않는 점만 확인하고, 수정은 당장 하지 않고 머지 하고 단계적으로 진행하면 어떨까 싶습니다.

<br><br>

## 관련 이슈

- Close #254

<br><br>
