### PR TITLE
feat: 코드와 메세지를 가진 ErrorResponse 반환  

### DIFF
--- a/backend/src/main/java/com/pickpick/config/ControllerAdvice.java
+++ b/backend/src/main/java/com/pickpick/config/ControllerAdvice.java
@@ -1,5 +1,6 @@
 package com.pickpick.config;
 
+import com.pickpick.config.dto.ErrorResponse;
 import com.pickpick.exception.BadRequestException;
 import com.pickpick.exception.NotFoundException;
 import lombok.extern.slf4j.Slf4j;
@@ -14,14 +15,17 @@ public class ControllerAdvice {
 
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler
-    public void handleBadRequestException(final BadRequestException e) {
+    public ErrorResponse handleBadRequestException(final BadRequestException e) {
         log.error("예외 발생: ", e);
+        return new ErrorResponse(e.getErrorCode(), e.getClientMessage());
+
     }
 
     @ResponseStatus(HttpStatus.NOT_FOUND)
     @ExceptionHandler
-    public void handleNotFoundException(final NotFoundException e) {
+    public ErrorResponse handleNotFoundException(final NotFoundException e) {
         log.error("예외 발생: ", e);
+        return new ErrorResponse(e.getErrorCode(), e.getClientMessage());
     }
 
     @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)

--- a/backend/src/main/java/com/pickpick/config/dto/ErrorResponse.java
+++ b/backend/src/main/java/com/pickpick/config/dto/ErrorResponse.java
@@ -1,0 +1,18 @@
+package com.pickpick.config.dto;
+
+import lombok.Getter;
+
+@Getter
+public class ErrorResponse {
+
+    private String code;
+    private String message;
+
+    private ErrorResponse() {
+    }
+
+    public ErrorResponse(final String code, final String message) {
+        this.code = code;
+        this.message = message;
+    }
+}

--- a/backend/src/main/java/com/pickpick/exception/BadRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/BadRequestException.java
@@ -2,10 +2,15 @@ package com.pickpick.exception;
 
 public class BadRequestException extends RuntimeException {
 
+    private static final String ERROR_CODE = "BAD_REQUEST";
     private static final String CLIENT_MESSAGE = "요청 값이 잘못되었습니다.";
 
     public BadRequestException(final String message) {
         super(message);
+    }
+
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     public String getClientMessage() {

--- a/backend/src/main/java/com/pickpick/exception/NotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/NotFoundException.java
@@ -2,10 +2,15 @@ package com.pickpick.exception;
 
 public class NotFoundException extends RuntimeException {
 
+    private static final String ERROR_CODE = "NOT_FOUND";
     private static final String CLIENT_MESSAGE = "해당 정보를 조회하지 못했습니다.";
 
     public NotFoundException(final String message) {
         super(message);
+    }
+
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     public String getClientMessage() {

--- a/backend/src/main/java/com/pickpick/exception/auth/InvalidTokenException.java
+++ b/backend/src/main/java/com/pickpick/exception/auth/InvalidTokenException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.BadRequestException;
 
 public class InvalidTokenException extends BadRequestException {
 
+    private static final String ERROR_CODE = "INVALID_TOKEN";
     private static final String DEFAULT_MESSAGE = "유효하지 않은 토큰으로 요청";
     private static final String CLIENT_MESSAGE = "유효하지 않은 토큰입니다.";
 
     public InvalidTokenException() {
         super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/ChannelNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/ChannelNotFoundException.java
@@ -4,6 +4,7 @@ import com.pickpick.exception.NotFoundException;
 
 public class ChannelNotFoundException extends NotFoundException {
 
+    private static final String ERROR_CODE = "CHANNEL_NOT_FOUND";
     private static final String DEFAULT_MESSAGE = "존재하지 않는 채널 조회";
     private static final String CLIENT_MESSAGE = "채널을 찾지 못했습니다.";
 
@@ -13,6 +14,11 @@ public class ChannelNotFoundException extends NotFoundException {
 
     public ChannelNotFoundException(final String slackId) {
         super(String.format("%s -> channel slack id: %s", DEFAULT_MESSAGE, slackId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionDuplicateException extends BadRequestException {
 
+    private static final String ERROR_CODE = "SUBSCRIPTION_DUPLICATE";
     private static final String DEFAULT_MESSAGE = "구독 중인 채널 중복 구독 시도";
     private static final String CLIENT_MESSAGE = "이미 구독 중인 채널입니다.";
 
     public SubscriptionDuplicateException(final Long channelId) {
         super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, channelId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionInvalidOrderException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionInvalidOrderException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionInvalidOrderException extends BadRequestException {
 
+    private static final String ERROR_CODE = "SUBSCRIPTION_INVALID_ORDER";
     private static final String DEFAULT_MESSAGE = "구독 순서에 0 이하의 수 입력";
     private static final String CLIENT_MESSAGE = "구독 순서는 1 이상이여야합니다.";
 
     public SubscriptionInvalidOrderException() {
         super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
@@ -4,6 +4,7 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionNotExistException extends BadRequestException {
 
+    private static final String ERROR_CODE = "SUBSCRIPTION_NOT_EXIST";
     private static final String DEFAULT_MESSAGE = "구독 중이 아닌 채널을 구독 조회";
     private static final String CLIENT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
 
@@ -13,6 +14,11 @@ public class SubscriptionNotExistException extends BadRequestException {
 
     public SubscriptionNotExistException(final String message) {
         super(message);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.NotFoundException;
 
 public class SubscriptionNotFoundException extends NotFoundException {
 
+    private static final String ERROR_CODE = "SUBSCRIPTION_NOT_FOUND";
     private static final String DEFAULT_MESSAGE = "채널 구독이 0개인 멤버로 구독 목록 조회";
     private static final String CLIENT_MESSAGE = "해당 멤버가 구독 중인 채널이 없습니다.";
 
     public SubscriptionNotFoundException(final Long memberId) {
         super(String.format("%s -> subscription member id: %d", DEFAULT_MESSAGE, memberId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionOrderDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionOrderDuplicateException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.BadRequestException;
 
 public class SubscriptionOrderDuplicateException extends BadRequestException {
 
+    private static final String ERROR_CODE = "SUBSCRIPTION_DUPLICATE";
     private static final String DEFAULT_MESSAGE = "중복된 구독 순서 요청";
     private static final String CLIENT_MESSAGE = "요청한 구독 순서 내부에 중복이 존재합니다.";
 
     public SubscriptionOrderDuplicateException() {
         super(DEFAULT_MESSAGE);
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/member/MemberNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberNotFoundException.java
@@ -4,6 +4,7 @@ import com.pickpick.exception.NotFoundException;
 
 public class MemberNotFoundException extends NotFoundException {
 
+    private static final String ERROR_CODE = "MEMBER_NOT_FOUND";
     private static final String DEFAULT_MESSAGE = "존재하지 않는 멤버 조회";
     private static final String CLIENT_MESSAGE = "사용자를 찾지 못했습니다.";
 
@@ -13,6 +14,11 @@ public class MemberNotFoundException extends NotFoundException {
 
     public MemberNotFoundException(final String slackId) {
         super(String.format("%s -> member slack id: %s", DEFAULT_MESSAGE, slackId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.BadRequestException;
 
 public class BookmarkDeleteFailureException extends BadRequestException {
 
+    private static final String ERROR_CODE = "BOOKMARK_DELETE_FAILURE";
     private static final String DEFAULT_MESSAGE = "외래키가 일치하는 북마크가 없어 삭제 목적 조회 실패";
     private static final String CLIENT_MESSAGE = "해당 북마크를 삭제할 수 없습니다.";
 
     public BookmarkDeleteFailureException(final Long messageId, final Long memberId) {
         super(String.format("%s -> bookmark message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkNotFoundException.java
@@ -4,11 +4,17 @@ import com.pickpick.exception.NotFoundException;
 
 public class BookmarkNotFoundException extends NotFoundException {
 
+    private static final String ERROR_CODE = "BOOKMARK_NOT_FOUND";
     private static final String DEFAULT_MESSAGE = "존재하지 않는 북마크 조회";
     private static final String CLIENT_MESSAGE = "북마크를 찾지 못했습니다.";
 
     public BookmarkNotFoundException(final Long id) {
         super(String.format("%s -> bookmark id: %d", DEFAULT_MESSAGE, id));
+    }
+
+    @Override
+    public String getErrorCode() {
+        return ERROR_CODE;
     }
 
     @Override

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -6,6 +6,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.config.dto.ErrorResponse;
 import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
@@ -95,6 +96,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo("INVALID_TOKEN");
     }
 
     private ExtractableResponse<Response> getWithToken(final String uri, final String token) {
@@ -131,5 +133,6 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo("INVALID_TOKEN");
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
+import com.pickpick.config.dto.ErrorResponse;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.List;
@@ -72,6 +73,8 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "SUBSCRIPTION_INVALID_ORDER");
     }
 
     @Test
@@ -87,6 +90,8 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "SUBSCRIPTION_DUPLICATE");
     }
 
     @Test
@@ -104,6 +109,8 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "SUBSCRIPTION_NOT_EXIST");
     }
 
     @Test
@@ -118,6 +125,8 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "SUBSCRIPTION_NOT_EXIST");
     }
 
     @Test
@@ -127,6 +136,8 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "SUBSCRIPTION_DUPLICATE");
     }
 
     @Test
@@ -139,6 +150,8 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
 
         // then
         상태코드_400_확인(response);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "SUBSCRIPTION_NOT_EXIST");
     }
 
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -3,6 +3,7 @@ package com.pickpick.acceptance.message;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.config.dto.ErrorResponse;
 import com.pickpick.message.ui.dto.BookmarkResponse;
 import com.pickpick.message.ui.dto.BookmarkResponses;
 import io.restassured.response.ExtractableResponse;
@@ -81,7 +82,8 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId,
+                1L);
 
         // then
         상태코드_확인(response, HttpStatus.NO_CONTENT);
@@ -93,9 +95,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId, 1L);
+        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId,
+                1L);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
+                "BOOKMARK_DELETE_FAILURE");
     }
 }


### PR DESCRIPTION
## 요약

400, 401 발생 시 코드와 메세지를 가진 ErrorResponse 반환  

<br>

## 작업 내용

- 에러 코드를 예외별 필드에 추가  
- 해당 에러 코드와 클라이언트 메시지를 담은 `ErrorResponse` 객체를 `ControllerAdvice`에서 반환  

<br>

## 참고 사항

급한 사안 같아서 프론트 코드를 보고 **현재 프론트에서 처리 중인 에러코드** 만 작업했습니다  
일단 이거부터 머지하고 나머지 추가하면 어떨까요?   
마지막에 `approve` 하시는 분이 머지해주세요!! (급해서!!) 

<br>

## 관련 이슈

- Close #450 

<br><br>
