### PR TITLE
fix: 배포된 페이지에서 favicon 누락 해결

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -7,11 +7,9 @@
   <meta property="og:type" content="website">
   <meta property="og:url" content="https://jupjup.site">
   <meta property="og:title" content="줍줍">
-  <meta property="og:image" content="/assets/images/pickpick.png">
   <meta property="og:description" content="사라지는 Slack 메시지, 우리가 주워줄게!">
   <meta property="og:site_name" content="줍줍">
   <meta property="og:locale" content="ko">
-  <link rel="shortcut icon" href="/assets/images/favicon.ico" />
   <title>줍줍</title>
 </head>
 <body>

--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -51,6 +51,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       template: "./public/index.html",
+      favicon: "./public/assets/images/favicon.ico",
     }),
   ],
 };


### PR DESCRIPTION
- htmlWebpackPlugin 사용하여, HTML에 로컬 이미지가 함께 빌드되도록 추가
- 제대로 동작하지 않는 og image 태그 삭제

- Close #452 

<br><br>
