### PR TITLE
refactor: 채널 생성 역할을 channelService에게 위임

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/application/ChannelService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelService.java
@@ -1,14 +1,40 @@
 package com.pickpick.channel.application;
 
+import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.SlackApiCallException;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.model.Conversation;
+import java.io.IOException;
 import org.springframework.stereotype.Service;
 
 @Service
 public class ChannelService {
 
     private final ChannelRepository channels;
+    private final MethodsClient slackClient;
 
-    public ChannelService(final ChannelRepository channels) {
+    public ChannelService(final ChannelRepository channels, final MethodsClient slackClient) {
         this.channels = channels;
+        this.slackClient = slackClient;
+    }
+
+    public Channel createChannel(final String channelSlackId) {
+        try {
+            Conversation conversation = slackClient.conversationsInfo(
+                    request -> request.channel(channelSlackId)
+            ).getChannel();
+
+            Channel channel = toChannel(conversation);
+
+            return channels.save(channel);
+        } catch (IOException | SlackApiException e) {
+            throw new SlackApiCallException(e);
+        }
+    }
+
+    private Channel toChannel(final Conversation channel) {
+        return new Channel(channel.getId(), channel.getName());
     }
 }

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
@@ -1,8 +1,8 @@
 package com.pickpick.slackevent.application.message;
 
+import com.pickpick.channel.application.ChannelService;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.SlackApiCallException;
 import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -10,10 +10,6 @@ import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
 import com.pickpick.slackevent.application.message.dto.SlackMessageDto;
-import com.slack.api.methods.MethodsClient;
-import com.slack.api.methods.SlackApiException;
-import com.slack.api.model.Conversation;
-import java.io.IOException;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,14 +29,14 @@ public class MessageCreatedService implements SlackEventService {
     private final MessageRepository messages;
     private final MemberRepository members;
     private final ChannelRepository channels;
-    private final MethodsClient slackClient;
+    private final ChannelService channelService;
 
     public MessageCreatedService(final MessageRepository messages, final MemberRepository members,
-                                 final ChannelRepository channels, final MethodsClient slackClient) {
+                                 final ChannelRepository channels, final ChannelService channelService) {
         this.messages = messages;
         this.members = members;
         this.channels = channels;
-        this.slackClient = slackClient;
+        this.channelService = channelService;
     }
 
     @Override
@@ -58,7 +54,7 @@ public class MessageCreatedService implements SlackEventService {
         String channelSlackId = slackMessageDto.getChannelSlackId();
 
         Channel channel = channels.findBySlackId(channelSlackId)
-                .orElseGet(() -> createChannel(channelSlackId));
+                .orElseGet(() -> channelService.createChannel(channelSlackId));
 
         messages.save(slackMessageDto.toEntity(member, channel));
     }
@@ -67,24 +63,6 @@ public class MessageCreatedService implements SlackEventService {
         Map<String, Object> event = (Map<String, Object>) requestBody.get(EVENT);
 
         return event.containsKey(THREAD_TIMESTAMP);
-    }
-
-    private Channel createChannel(final String channelSlackId) {
-        try {
-            Conversation conversation = slackClient.conversationsInfo(
-                    request -> request.channel(channelSlackId)
-            ).getChannel();
-
-            Channel channel = toChannel(conversation);
-
-            return channels.save(channel);
-        } catch (IOException | SlackApiException e) {
-            throw new SlackApiCallException(e);
-        }
-    }
-
-    private Channel toChannel(final Conversation channel) {
-        return new Channel(channel.getId(), channel.getName());
     }
 
     private SlackMessageDto convert(final Map<String, Object> requestBody) {

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
@@ -1,8 +1,8 @@
 package com.pickpick.slackevent.application.message;
 
+import com.pickpick.channel.application.ChannelService;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.SlackApiCallException;
 import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -10,10 +10,6 @@ import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
 import com.pickpick.slackevent.application.message.dto.SlackMessageDto;
-import com.slack.api.methods.MethodsClient;
-import com.slack.api.methods.SlackApiException;
-import com.slack.api.model.Conversation;
-import java.io.IOException;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,14 +28,14 @@ public class MessageFileShareService implements SlackEventService {
     private final MessageRepository messages;
     private final MemberRepository members;
     private final ChannelRepository channels;
-    private final MethodsClient slackClient;
+    private final ChannelService channelService;
 
     public MessageFileShareService(final MessageRepository messages, final MemberRepository members,
-                                   final ChannelRepository channels, final MethodsClient slackClient) {
+                                   final ChannelRepository channels, final ChannelService channelService) {
         this.messages = messages;
         this.members = members;
         this.channels = channels;
-        this.slackClient = slackClient;
+        this.channelService = channelService;
     }
 
     @Override
@@ -52,7 +48,7 @@ public class MessageFileShareService implements SlackEventService {
 
         String channelSlackId = slackMessageDto.getChannelSlackId();
         Channel channel = channels.findBySlackId(channelSlackId)
-                .orElseGet(() -> createChannel(channelSlackId));
+                .orElseGet(() -> channelService.createChannel(channelSlackId));
 
         messages.save(slackMessageDto.toEntity(member, channel));
     }
@@ -68,25 +64,6 @@ public class MessageFileShareService implements SlackEventService {
                 (String) event.getOrDefault(TEXT, ""),
                 (String) event.get(CHANNEL)
         );
-    }
-
-    private Channel createChannel(final String channelSlackId) {
-        try {
-            Conversation conversation = slackClient.conversationsInfo(
-                    request -> request.channel(channelSlackId)
-            ).getChannel();
-
-            Channel channel = toChannel(conversation);
-            channels.save(channel);
-
-            return channel;
-        } catch (IOException | SlackApiException e) {
-            throw new SlackApiCallException(e);
-        }
-    }
-
-    private Channel toChannel(final Conversation channel) {
-        return new Channel(channel.getId(), channel.getName());
     }
 
     @Override

--- a/backend/src/test/java/com/pickpick/channel/application/ChannelServiceTest.java
+++ b/backend/src/test/java/com/pickpick/channel/application/ChannelServiceTest.java
@@ -1,0 +1,82 @@
+package com.pickpick.channel.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+
+import com.pickpick.channel.domain.Channel;
+import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.exception.SlackApiCallException;
+import com.slack.api.RequestConfigurator;
+import com.slack.api.methods.MethodsClient;
+import com.slack.api.methods.SlackApiException;
+import com.slack.api.methods.request.conversations.ConversationsInfoRequest.ConversationsInfoRequestBuilder;
+import com.slack.api.methods.response.conversations.ConversationsInfoResponse;
+import com.slack.api.model.Conversation;
+import java.io.IOException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class ChannelServiceTest {
+
+    @MockBean
+    private MethodsClient slackClient;
+
+    @Autowired
+    private ChannelRepository channels;
+
+    @Autowired
+    private ChannelService channelService;
+
+    @DisplayName("채널을 저장한다.")
+    @Test
+    void save() throws SlackApiException, IOException {
+        // given
+        given(slackClient.conversationsInfo((RequestConfigurator<ConversationsInfoRequestBuilder>) any()))
+                .willReturn(setUpChannelMockData());
+
+        Optional<Channel> channelBeforeExecute = channels.findBySlackId("channelSlackId");
+
+        // when
+        channelService.createChannel("channelSlackId");
+
+        // then
+        Optional<Channel> channelAfterExecute = channels.findBySlackId("channelSlackId");
+        assertAll(
+                () -> assertThat(channelBeforeExecute).isEmpty(),
+                () -> assertThat(channelAfterExecute).isPresent()
+        );
+    }
+
+    @DisplayName("채널 저장 시 Exception이 발생하면 커스텀 예외인 SlackApiCallException을 호출한다")
+    @Test
+    void saveFailAndThrowCustomException() throws SlackApiException, IOException {
+        // given
+        given(slackClient.conversationsInfo((RequestConfigurator<ConversationsInfoRequestBuilder>) any()))
+                .willThrow(SlackApiException.class);
+
+        // when & then
+        assertThatThrownBy(() -> channelService.createChannel("channelSlackId"))
+                .isInstanceOf(SlackApiCallException.class);
+    }
+
+    private ConversationsInfoResponse setUpChannelMockData() {
+        Conversation conversation = new Conversation();
+        conversation.setId("channelSlackId");
+        conversation.setName("channelName");
+
+        ConversationsInfoResponse conversationsInfoResponse = new ConversationsInfoResponse();
+        conversationsInfoResponse.setChannel(conversation);
+
+        return conversationsInfoResponse;
+    }
+}


### PR DESCRIPTION
## 요약

채널 생성 역할을 channelService에게 위임
<br><br>

## 작업 내용

<br><br>

- MessageCreatedService, MessageThreadBroadcastService, MessageFileShareService 세 곳에 중복으로 존재하던 createChannel 로직을 channelService 로 이동했습니다.
- ChannelServiceTest를 만들었습니다.

## 참고 사항

<br><br>

## 관련 이슈

- Close #426 

<br><br>
