### PR TITLE
fix: 서버 에러 대응 방법 수정 및 구독중인 채널 없을 경우 대응

### DIFF
--- a/frontend/src/@types/shared.ts
+++ b/frontend/src/@types/shared.ts
@@ -79,6 +79,12 @@ export interface ResponseToken {
 }
 
 export interface CustomError {
+  response: {
+    data: Error;
+  };
+}
+
+export interface Error {
   code: keyof typeof ERROR_MESSAGE_BY_CODE;
   message: string;
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -22,6 +22,7 @@ function App() {
       queries: {
         refetchOnWindowFocus: false,
         onError: handleError,
+        retry: 0,
       },
       mutations: {
         onError: handleError,

--- a/frontend/src/hooks/useApiError.ts
+++ b/frontend/src/hooks/useApiError.ts
@@ -1,5 +1,6 @@
-import { ERROR_MESSAGE_BY_CODE } from "@src/@constants";
+import { ERROR_MESSAGE_BY_CODE, PATH_NAME } from "@src/@constants";
 import { CustomError } from "@src/@types/shared";
+import { useNavigate } from "react-router-dom";
 import useSnackbar from "./useSnackbar";
 
 interface ReturnType {
@@ -7,14 +8,19 @@ interface ReturnType {
 }
 
 function useApiError(): ReturnType {
+  const navigate = useNavigate();
   const { openFailureSnackbar } = useSnackbar();
 
   const handleError = (error: CustomError) => {
+    const errorCode = error.response?.data?.code;
     const errorMessage =
-      ERROR_MESSAGE_BY_CODE[error.response?.data?.code] ??
-      ERROR_MESSAGE_BY_CODE.DEFAULT_MESSAGE;
+      ERROR_MESSAGE_BY_CODE[errorCode] ?? ERROR_MESSAGE_BY_CODE.DEFAULT_MESSAGE;
 
     openFailureSnackbar(errorMessage);
+
+    if (errorCode === "SUBSCRIPTION_NOT_FOUND") {
+      navigate(PATH_NAME.ADD_CHANNEL);
+    }
   };
 
   return { handleError };

--- a/frontend/src/hooks/useApiError.ts
+++ b/frontend/src/hooks/useApiError.ts
@@ -11,7 +11,7 @@ function useApiError(): ReturnType {
 
   const handleError = (error: CustomError) => {
     const errorMessage =
-      ERROR_MESSAGE_BY_CODE[error.code] ??
+      ERROR_MESSAGE_BY_CODE[error.response?.data?.code] ??
       ERROR_MESSAGE_BY_CODE.DEFAULT_MESSAGE;
 
     openFailureSnackbar(errorMessage);


### PR DESCRIPTION
## 요약

서버 에러 대응 방법 수정 및 구독중인 채널 없을 경우 대응

## 작업 내용

- 서버에서 내려주는 에러 코드를 사용하기 위해서 에러 타입 수정
- 구독 중인 채널 없다는 에러일 경우, 채널 추가 페이지로 라우팅 되도록 수정 

## 참고 사항

<br><br>

## 관련 이슈

- Close #455 

<br><br>
