### PR TITLE
fix: thread_broadcast 메시지 수정 시 수정이 반영되지 않는 버그 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastService.java
@@ -63,9 +63,11 @@ public class MessageThreadBroadcastService implements SlackEventService {
     }
 
     public void saveWhenSubtypeIsMessageChanged(final SlackMessageDto slackMessageDto) {
-        if (isNewMessage(slackMessageDto)) {
-            save(slackMessageDto);
-        }
+        messages.findBySlackId(slackMessageDto.getSlackId())
+                .ifPresentOrElse(
+                        message -> message.changeText(slackMessageDto.getText(), slackMessageDto.getModifiedDate()),
+                        () -> save(slackMessageDto)
+                );
     }
 
     private boolean isNewMessage(final SlackMessageDto slackMessageDto) {

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastService.java
@@ -70,10 +70,6 @@ public class MessageThreadBroadcastService implements SlackEventService {
                 );
     }
 
-    private boolean isNewMessage(final SlackMessageDto slackMessageDto) {
-        return messages.findBySlackId(slackMessageDto.getSlackId()).isEmpty();
-    }
-
     private void save(final SlackMessageDto slackMessageDto) {
         String memberSlackId = slackMessageDto.getMemberSlackId();
         Member member = members.findBySlackId(memberSlackId)

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastServiceTest.java
@@ -28,11 +28,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.test.context.jdbc.Sql;
 
-@Transactional
+@Sql("/truncate.sql")
 @SpringBootTest
 class MessageThreadBroadcastServiceTest {
+
     private static final int FIRST_INDEX = 0;
     private final Member SAMPLE_MEMBER = new Member("U03MKN0UW", "사용자", "test.png");
     private final Channel SAMPLE_CHANNEL = new Channel("ASDFB", "채널");
@@ -131,7 +132,7 @@ class MessageThreadBroadcastServiceTest {
         );
     }
 
-    @DisplayName("스레드 메시지 채널로 전송 이벤트 전달 시 subtype이 message_changed인 요청이 왔을 경우, DB에 저장되어 있는 메시지라면 저장하지 않는다")
+    @DisplayName("스레드 메시지 채널로 전송 이벤트 전달 시 subtype이 message_changed인 요청이 왔을 경우, DB에 저장되어 있는 메시지라면 수정한다.")
     @Test
     void notSave() {
         // given
@@ -145,7 +146,7 @@ class MessageThreadBroadcastServiceTest {
                 SAMPLE_MESSAGE.getSlackId(),
                 "1234567890",
                 "1234567890",
-                "messageText",
+                "수정된 메시지 텍스트",
                 SAMPLE_CHANNEL.getSlackId());
 
         // when
@@ -154,12 +155,12 @@ class MessageThreadBroadcastServiceTest {
         // then
         Optional<Message> messageAfterExecute = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
 
-        assertAll(
-                () -> assertThat(messageBeforeExecute).isPresent(),
-                () -> assertThat(messageBeforeExecute.get())
-                        .usingRecursiveComparison()
-                        .ignoringFields("id")
-                        .isEqualTo(messageAfterExecute.get())
+        assertAll(() -> {
+                    assertThat(messageBeforeExecute).isPresent();
+                    assertThat(messageAfterExecute).isPresent();
+                    assertThat(messageBeforeExecute.get().getText()).isNotEqualTo(messageAfterExecute.get().getText());
+                    assertThat(messageAfterExecute.get().getText()).isEqualTo("수정된 메시지 텍스트");
+                }
         );
     }
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastServiceTest.java
@@ -155,12 +155,10 @@ class MessageThreadBroadcastServiceTest {
         // then
         Optional<Message> messageAfterExecute = messages.findBySlackId(SAMPLE_MESSAGE.getSlackId());
 
-        assertAll(() -> {
-                    assertThat(messageBeforeExecute).isPresent();
-                    assertThat(messageAfterExecute).isPresent();
-                    assertThat(messageBeforeExecute.get().getText()).isNotEqualTo(messageAfterExecute.get().getText());
-                    assertThat(messageAfterExecute.get().getText()).isEqualTo("수정된 메시지 텍스트");
-                }
+        assertAll(
+                () -> assertThat(messageBeforeExecute.get().getText()).isNotEqualTo(
+                        messageAfterExecute.get().getText()),
+                () -> assertThat(messageAfterExecute.get().getText()).isEqualTo("수정된 메시지 텍스트")
         );
     }
 


### PR DESCRIPTION
### 제가 머지하겠습니다~!~!
## 요약

thread_broadcast 메시지 수정 시 수정이 반영되지 않는 버그 수정
<br><br>

## 작업 내용

- MessageThreadBroadcastService 내부 로직 수정
- MessageThreadBroadcastServiceTest 수정
<br><br>

## 참고 사항

- 궁금한거 댓글에 하나 달아놨어요!
- 제가 머지하겠습니다
<br><br>

## 관련 이슈

- Close #456 

<br><br>
