### PR TITLE
hotfix: 홈버튼 누르면 최근 방문 페이지로 돌아가는 로직 버그 수정

### DIFF
--- a/frontend/src/@utils/index.ts
+++ b/frontend/src/@utils/index.ts
@@ -150,3 +150,7 @@ export const parsedOptionText = ({
 }): string => {
   return needZeroPaddingStart ? optionText.padStart(2, "0") : optionText;
 };
+
+// const isFeedPath = (path: string) => {
+
+// }

--- a/frontend/src/hooks/useRecentFeedPath.ts
+++ b/frontend/src/hooks/useRecentFeedPath.ts
@@ -6,13 +6,16 @@ function useRecentFeedPath() {
   const { key, pathname } = useLocation();
   const { setItem: setRecentFeedPath, getItem: getRecentFeedPath } =
     useWebStorage<string>({
-      key: "default-feed-path",
+      key: "recent-feed-path",
       kind: STORAGE_KIND.SESSION,
     });
 
   useEffect(() => {
-    setRecentFeedPath(pathname);
-  }, [key, pathname]);
+    const name = pathname.split("/")[1];
+    if (name === "feed") {
+      setRecentFeedPath(pathname);
+    }
+  }, [pathname, key]);
 
   return { setRecentFeedPath, getRecentFeedPath };
 }


### PR DESCRIPTION

## 요약

- 모든 페이지의 정보를 sessionStorage에 저장하는 문제 해결


## 작업 내용

- pathname 이 'feed' 인지 확인한 후, 저장하도록 수정 


