### PR TITLE
fix: BookmarkResponse에서 bookmark id 도 함께 반환받도록 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponse.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponse.java
@@ -11,6 +11,7 @@ import lombok.Getter;
 public class BookmarkResponse {
 
     private Long id;
+    private Long messageId;
     private Long memberId;
     private String username;
     private String userThumbnail;
@@ -22,6 +23,7 @@ public class BookmarkResponse {
     }
 
     public BookmarkResponse(final Long id,
+                            final Long messageId,
                             final Long memberId,
                             final String username,
                             final String userThumbnail,
@@ -29,6 +31,7 @@ public class BookmarkResponse {
                             final LocalDateTime postedDate,
                             final LocalDateTime modifiedDate) {
         this.id = id;
+        this.messageId = messageId;
         this.memberId = memberId;
         this.username = username;
         this.userThumbnail = userThumbnail;
@@ -41,7 +44,8 @@ public class BookmarkResponse {
         Message message = bookmark.getMessage();
 
         return BookmarkResponse.builder()
-                .id(message.getId())
+                .id(bookmark.getId())
+                .messageId(message.getId())
                 .memberId(message.getMember().getId())
                 .username(message.getMember().getUsername())
                 .userThumbnail(message.getMember().getThumbnailUrl())

--- a/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
@@ -54,6 +54,8 @@ public class BookmarkControllerTest extends RestDocsTestSupport {
                         ),
                         responseFields(
                                 fieldWithPath("bookmarks.[].id").type(JsonFieldType.NUMBER)
+                                        .description("북마크 아이디"),
+                                fieldWithPath("bookmarks.[].messageId").type(JsonFieldType.NUMBER)
                                         .description("메시지 아이디"),
                                 fieldWithPath("bookmarks.[].memberId").type(JsonFieldType.NUMBER)
                                         .description("유저 아이디"),


### PR DESCRIPTION
## 요약

북마크 탭에서 북마크 조회 시 북마크 아이디가 필요한데 현재 서버에서 북마크 아이디를 보내주고 있지 않아서 bookmark를 더이상 조회할 수 없는 에러 발생
<br><br>

## 작업 내용

BookmarkResponse 내부의  {id: 메시지 아이디} 였는데,
{id : 북마크아이디,
messagdId: 메시지아이디}로 수정
(id를 메시지 아이디가 아니라 북마크 아이디로 수정하고, messageId 필드를 추가)
 
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- Close #474

<br><br>
