### PR TITLE
refactor: 서비스 테스트에 DatabaseCleaner 도입

### DIFF
--- a/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
+++ b/backend/src/test/java/com/pickpick/auth/application/AuthServiceTest.java
@@ -26,11 +26,9 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 
-@AutoConfigureMockMvc
 @SpringBootTest
 class AuthServiceTest {
 

--- a/backend/src/test/java/com/pickpick/channel/application/ChannelServiceTest.java
+++ b/backend/src/test/java/com/pickpick/channel/application/ChannelServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.exception.SlackApiCallException;
 import com.slack.api.RequestConfigurator;
 import com.slack.api.methods.MethodsClient;
@@ -17,15 +18,14 @@ import com.slack.api.methods.response.conversations.ConversationsInfoResponse;
 import com.slack.api.model.Conversation;
 import java.io.IOException;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@Transactional
 class ChannelServiceTest {
 
     @MockBean
@@ -36,6 +36,14 @@ class ChannelServiceTest {
 
     @Autowired
     private ChannelService channelService;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("채널을 저장한다.")
     @Test

--- a/backend/src/test/java/com/pickpick/channel/application/ChannelSubscriptionServiceTest.java
+++ b/backend/src/test/java/com/pickpick/channel/application/ChannelSubscriptionServiceTest.java
@@ -8,6 +8,7 @@ import com.pickpick.channel.domain.ChannelRepository;
 import com.pickpick.channel.domain.ChannelSubscription;
 import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.exception.channel.ChannelNotFoundException;
 import com.pickpick.exception.channel.SubscriptionDuplicateException;
 import com.pickpick.exception.channel.SubscriptionNotExistException;
@@ -15,6 +16,7 @@ import com.pickpick.exception.channel.SubscriptionOrderDuplicateException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,7 +24,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
 @SpringBootTest
-@Transactional
 class ChannelSubscriptionServiceTest {
 
     private static final long NOT_EXISTED_CHANNEL_ID = 1L;
@@ -35,6 +36,14 @@ class ChannelSubscriptionServiceTest {
 
     @Autowired
     private MemberRepository members;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("채널 구독을 단건 저장")
     @Test
@@ -73,6 +82,7 @@ class ChannelSubscriptionServiceTest {
                 .isInstanceOf(SubscriptionDuplicateException.class);
     }
 
+    @Transactional
     @DisplayName("구독한 채널 조회 시 view order 순서대로 출력")
     @Test
     void subscribeChannelOrderIsLast() {
@@ -85,14 +95,15 @@ class ChannelSubscriptionServiceTest {
         subscribeChannelsInListOrder(member, List.of(channel3, channel1, channel2));
 
         // when
-        List<ChannelSubscription> channelSubscriptions = channelSubscriptionService.findAllOrderByViewOrder(
-                member.getId());
+        List<ChannelSubscription> channelSubscriptions = channelSubscriptionService
+                .findAllOrderByViewOrder(member.getId());
 
         // then
         assertThat(channelSubscriptions).extracting("channel")
                 .containsExactly(channel3, channel1, channel2);
     }
 
+    @Transactional
     @DisplayName("채널 구독 순서를 변경하기")
     @Test
     void updateChannelSubscriptionOrder() {
@@ -106,18 +117,18 @@ class ChannelSubscriptionServiceTest {
 
         // when
         List<ChannelOrderRequest> request = List.of(
-                new ChannelOrderRequest(channel1.getId(), 1),
-                new ChannelOrderRequest(channel2.getId(), 2),
+                new ChannelOrderRequest(channel2.getId(), 1),
+                new ChannelOrderRequest(channel1.getId(), 2),
                 new ChannelOrderRequest(channel3.getId(), 3)
         );
         channelSubscriptionService.updateOrders(request, member.getId());
 
-        List<ChannelSubscription> channelSubscriptions = channelSubscriptionService.findAllOrderByViewOrder(
-                member.getId());
+        List<ChannelSubscription> channelSubscriptions = channelSubscriptionService
+                .findAllOrderByViewOrder(member.getId());
 
         //then
         assertThat(channelSubscriptions).extracting("channel")
-                .containsExactly(channel1, channel2, channel3);
+                .containsExactly(channel2, channel1, channel3);
     }
 
     @DisplayName("채널 구독 순서 변경 시 중복 viewOrder가 들어올 경우 에러 발생")

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.exception.message.BookmarkDeleteFailureException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -13,15 +14,16 @@ import com.pickpick.message.domain.Bookmark;
 import com.pickpick.message.domain.BookmarkRepository;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
+import com.pickpick.message.ui.dto.BookmarkFindRequest;
 import com.pickpick.message.ui.dto.BookmarkRequest;
 import com.pickpick.message.ui.dto.BookmarkResponse;
 import com.pickpick.message.ui.dto.BookmarkResponses;
-import com.pickpick.message.ui.dto.BookmarkFindRequest;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -31,7 +33,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/bookmark.sql"})
+@Sql({"/bookmark.sql"})
 @SpringBootTest
 class BookmarkServiceTest {
 
@@ -50,6 +52,9 @@ class BookmarkServiceTest {
     @Autowired
     private BookmarkRepository bookmarks;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     private static Stream<Arguments> parameterProvider() {
         return Stream.of(
                 Arguments.arguments("멤버 ID 2번으로 북마크를 조회한다", null, 2L, List.of(1L), true),
@@ -60,13 +65,19 @@ class BookmarkServiceTest {
         );
     }
 
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
+
     @DisplayName("북마크를 생성한다")
     @Test
     void save() {
         // given
         Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = messages.save(new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
+        Message message = messages.save(
+                new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
 
         BookmarkRequest bookmarkRequest = new BookmarkRequest(message.getId());
         int beforeSize = findBookmarksSize(member);
@@ -112,7 +123,8 @@ class BookmarkServiceTest {
         // given
         Member member = members.save(new Member("U1234", "사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = messages.save(new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
+        Message message = messages.save(
+                new Message("M1234", "메시지", member, channel, LocalDateTime.now(), LocalDateTime.now()));
         Bookmark bookmark = bookmarks.save(new Bookmark(member, message));
 
         // when
@@ -130,7 +142,8 @@ class BookmarkServiceTest {
         Member owner = members.save(new Member("U1234", "사용자", "user.png"));
         Member other = members.save(new Member("U1235", "다른 사용자", "user.png"));
         Channel channel = channels.save(new Channel("C1234", "기본채널"));
-        Message message = messages.save(new Message("M1234", "메시지", owner, channel, LocalDateTime.now(), LocalDateTime.now()));
+        Message message = messages.save(
+                new Message("M1234", "메시지", owner, channel, LocalDateTime.now(), LocalDateTime.now()));
         Bookmark bookmark = new Bookmark(owner, message);
         bookmarks.save(bookmark);
 

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.exception.message.ReminderDeleteFailureException;
 import com.pickpick.exception.message.ReminderNotFoundException;
 import com.pickpick.exception.message.ReminderUpdateFailureException;
@@ -16,10 +17,10 @@ import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.message.domain.Reminder;
 import com.pickpick.message.domain.ReminderRepository;
-import com.pickpick.message.ui.dto.ReminderSaveRequest;
+import com.pickpick.message.ui.dto.ReminderFindRequest;
 import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
-import com.pickpick.message.ui.dto.ReminderFindRequest;
+import com.pickpick.message.ui.dto.ReminderSaveRequest;
 import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
@@ -27,7 +28,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import javax.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
@@ -38,8 +39,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.jdbc.Sql;
 
-@Sql({"/truncate.sql", "/reminder.sql"})
-@Transactional
+@Sql({"/reminder.sql"})
 @SpringBootTest
 class ReminderServiceTest {
 
@@ -58,6 +58,9 @@ class ReminderServiceTest {
     @Autowired
     private ReminderRepository reminders;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @SpyBean
     private Clock clock;
 
@@ -73,8 +76,12 @@ class ReminderServiceTest {
         );
     }
 
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
+
     @DisplayName("리마인더를 생성한다")
-    @Sql("/truncate.sql")
     @Test
     void save() {
         // given

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -5,21 +5,19 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import java.time.LocalDateTime;
 import java.util.Map;
-import javax.transaction.Transactional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.jdbc.Sql;
 
-@Sql("/truncate.sql")
-@Transactional
 @SpringBootTest
 class ChannelDeletedServiceTest {
 
@@ -54,6 +52,14 @@ class ChannelDeletedServiceTest {
 
     @Autowired
     private ChannelDeletedService channelDeletedService;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("채널 삭제 이벤트가 전달되면 채널과 메시지들이 삭제된다")
     @Test

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelRenameServiceTest.java
@@ -7,13 +7,11 @@ import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
 import com.pickpick.exception.channel.ChannelNotFoundException;
 import java.util.Map;
-import javax.transaction.Transactional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@Transactional
 @SpringBootTest
 class ChannelRenameServiceTest {
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/member/MemberChangedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/member/MemberChangedServiceTest.java
@@ -3,19 +3,19 @@ package com.pickpick.slackevent.application.member;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
 class MemberChangedServiceTest {
 
@@ -26,6 +26,14 @@ class MemberChangedServiceTest {
 
     @Autowired
     private MemberRepository members;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("사용자 이름 변경")
     @CsvSource(value = {"김진짜, 표시 이름, 표시 이름", "김진짜, '', 김진짜"})

--- a/backend/src/test/java/com/pickpick/slackevent/application/member/MemberJoinServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/member/MemberJoinServiceTest.java
@@ -3,21 +3,21 @@ package com.pickpick.slackevent.application.member;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.slackevent.application.SlackEvent;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
-import org.springframework.context.annotation.Import;
+import org.springframework.boot.test.context.SpringBootTest;
 
 @DisplayName("MemberJoinService는")
-@Import(MemberJoinService.class)
-@DataJpaTest
+@SpringBootTest
 class MemberJoinServiceTest {
 
     private static final String SLACK_ID = "U03MKN0UW";
@@ -27,6 +27,14 @@ class MemberJoinServiceTest {
 
     @Autowired
     private MemberRepository members;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("MEMBER_JOIN 타입에 대해서만 true를 반환한다")
     @CsvSource(value = {"MEMBER_JOIN,true",

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageChangedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageChangedServiceTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -15,13 +16,13 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
 class MessageChangedServiceTest {
 
@@ -48,6 +49,14 @@ class MessageChangedServiceTest {
     @Autowired
     private ChannelRepository channels;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
+
     @DisplayName("메시지 내용 및 수정 날짜 변경")
     @Test
     void changedMessage() {
@@ -71,6 +80,7 @@ class MessageChangedServiceTest {
         );
     }
 
+    @Transactional
     @DisplayName("subtype이 메시지 수정 이벤트 발생이지만, message 내부에 thread_broadcast 타입이 있다면 메시지 저장")
     @Test
     void saveThreadBroadcastMessage() {

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageCreatedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageCreatedServiceTest.java
@@ -24,13 +24,11 @@ import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@AutoConfigureMockMvc
 @SpringBootTest
 class MessageCreatedServiceTest {
 
@@ -140,7 +138,7 @@ class MessageCreatedServiceTest {
                 () -> assertThat(messageAfterSave).isPresent()
         );
     }
-    
+
     @DisplayName("메시지 댓글 생성 이벤트는 전달되어도 내용을 저장하지 않는다")
     @Test
     void doNotSaveReplyMessage() {

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageCreatedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageCreatedServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -21,14 +22,13 @@ import com.slack.api.model.Conversation;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
 class MessageCreatedServiceTest {
 
@@ -75,8 +75,16 @@ class MessageCreatedServiceTest {
     @Autowired
     private ChannelRepository channels;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @MockBean
     private MethodsClient slackClient;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("메시지 작성 이벤트 전달 시 채널이 없으면 채널 생성 후 메시지를 저장한다")
     @Test

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageDeletedServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -12,13 +13,12 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
 class MessageDeletedServiceTest {
 
@@ -45,6 +45,14 @@ class MessageDeletedServiceTest {
 
     @Autowired
     private ChannelRepository channels;
+
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("메시지 slack id가 전달되었을 때 메시지를 삭제한다.")
     @Test

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
@@ -27,13 +27,11 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.transaction.annotation.Transactional;
 
 @Transactional
-@AutoConfigureMockMvc
 @SpringBootTest
 class MessageFileShareServiceTest {
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageFileShareServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.BDDMockito.given;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -23,15 +24,14 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
 class MessageFileShareServiceTest {
 
@@ -57,9 +57,16 @@ class MessageFileShareServiceTest {
 
     @Autowired
     private ChannelRepository channels;
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
 
     @MockBean
     private MethodsClient slackClient;
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("파일 공유 이벤트 전달 시 채널이 저장되어 있지 않으면 채널 신규 저장 후 메시지를 저장한다")
     @ValueSource(strings = {"", " ", "파일과 함께 전송한 메시지 text"})

--- a/backend/src/test/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.when;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.config.DatabaseCleaner;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Message;
@@ -23,14 +24,13 @@ import com.slack.api.model.Conversation;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Optional;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.transaction.annotation.Transactional;
 
-@Transactional
 @SpringBootTest
 class MessageThreadBroadcastServiceTest {
     private static final int FIRST_INDEX = 0;
@@ -67,8 +67,17 @@ class MessageThreadBroadcastServiceTest {
     @Autowired
     private ChannelRepository channels;
 
+    @Autowired
+    private DatabaseCleaner databaseCleaner;
+
     @MockBean
     private MethodsClient slackClient;
+
+
+    @AfterEach
+    void tearDown() {
+        databaseCleaner.clear();
+    }
 
     @DisplayName("스레드 메시지 채널로 전송 이벤트 전달 시 채널이 없으면 채널 생성 후 메시지를 저장한다")
     @Test


### PR DESCRIPTION
## 요약

서비스 테스트에 DatabaseCleaner 도입

<br><br>

## 작업 내용

- DatabaseCleaner를 서비스테스트에 도입
- 서비스테스트에서 롤백을 위한 @Transactional 어노테이션 제거
- 서비스테스트에서 Truncate.sql 파일 import 제거
- 서비스테스트 중 @DataJpaTest로 작성된 테스트를 @SpringBootTest로 변경
- 불필요하게 붙어있던 @AutoConfigureMockMvc 제거

<br><br>

## 참고 사항

- 우선 작업의 흔적이라도 남기려고 draft로 PR 엽니다.

- @AutoConfigureMockMvc 어노테이션은 slackClient 테스트 시 mocking 시도하다가 붙어있던 것 같습니다. 현재 사용하지 않아도 무방한 서비스테스트에서는 모두 제거했습니다.
- ServiceTest 에서 @Transactional 어노테이션을 제거했더니 깨지는 테스트가 존재해서(Lazy Initialization Exception - no session), 우선은 깨지는 테스트 메서드 레벨에 @Transactional을 붙였습니다. draft로 작성할 PR이라 해결방법은 계속 고민해보겠습니다.

<br><br>

## 관련 이슈

- Close #446 

<br><br>
