### PR TITLE
refactor: MemberAcceptanceTest 내 @Disabled된 테스트 삭제

### DIFF
--- a/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
@@ -12,7 +12,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,16 +25,6 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     @Autowired
     private MemberRepository members;
-
-    @Disabled
-    @Test
-    void 프로젝트_기동_시점에_유저가_저장되어_있어야_한다() {
-        // given
-        List<Member> members = this.members.findAll();
-
-        // when & then
-        assertThat(members.isEmpty()).isFalse();
-    }
 
     @Test
     void 슬랙_워크스페이스에_신규_멤버가_참여하면_저장되어야_한다() {


### PR DESCRIPTION
## 작업 내용

`MemberAcceptanceTest` 내 `@Disabled`된 테스트를 삭제했습니다  
구동 시점에 전체 멤버 조회 시, 저장된 멤버가 있는지 검사하는 테스트였습니다 

<br>

## 관련 이슈

- Close #483 

<br>
