### PR TITLE
refactor: MemberInitializer 예외를 프로젝트 예외로 변환  

### DIFF
--- a/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
+++ b/backend/src/main/java/com/pickpick/member/application/MemberInitializer.java
@@ -1,5 +1,6 @@
 package com.pickpick.member.application;
 
+import com.pickpick.exception.SlackApiCallException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.slack.api.methods.MethodsClient;
@@ -25,7 +26,7 @@ public class MemberInitializer {
     }
 
     @PostConstruct
-    void setupMember() throws SlackApiException, IOException {
+    void setupMember() {
         List<String> savedSlackIds = findSavedSlackIds();
         List<Member> currentWorkspaceMembers = fetchWorkspaceMembers();
         List<Member> membersToSave = filterMembersToSave(savedSlackIds, currentWorkspaceMembers);
@@ -40,9 +41,13 @@ public class MemberInitializer {
                 .collect(Collectors.toList());
     }
 
-    private List<Member> fetchWorkspaceMembers() throws IOException, SlackApiException {
-        return toMembers(slackClient.usersList(request -> request)
-                .getMembers());
+    private List<Member> fetchWorkspaceMembers() {
+        try {
+            return toMembers(slackClient.usersList(request -> request)
+                    .getMembers());
+        } catch (IOException | SlackApiException e) {
+            throw new SlackApiCallException(e);
+        }
     }
 
     private List<Member> filterMembersToSave(final List<String> savedSlackIds,


### PR DESCRIPTION
## 요약

MemberInitializer 예외를 프로젝트 예외로 변환  

## 작업 내용

기존에는 슬랙이 던진 `SlackApiException`, `IOException`을 그대로 다시 던졌습니다 
이를 프로젝트 예외인 `SlackApiCallException`으로 변환해 `ControllerAdvice`에서 처리 가능하도록 개선했습니다  

<br>

## 참고 사항  

`SlackApiCallException`의 경우 로깅용 메시지를 남기지 않고 있습니다  
어떤 상황에서 호출에 실패했는지 남기는 게 어떨까요?  
이 예외는 프론트에 전달되지 않으니까 코드, 클라이언트 메시지가 없어도 충분할 것 같네요  

```java
// NotFound 예외 클래스 
public class NotFoundException extends RuntimeException {

    private static final String ERROR_CODE = "NOT_FOUND";
    private static final String CLIENT_MESSAGE = "해당 정보를 조회하지 못했습니다.";

    public NotFoundException(final String message) {
        super(message);
    }
...
```

```java
// SlackApiCall 예외 클래스 
public class SlackApiCallException extends RuntimeException {

    public SlackApiCallException(final Exception e) {
        super(e);
    }
...
```

<br>

## 관련 이슈

- Close #486 

<br>
