### PR TITLE
refactor: AuthorizationExtractor를 auth 패키지로 이동

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
@@ -1,4 +1,4 @@
-package com.pickpick.utils;
+package com.pickpick.auth.support;
 
 import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
@@ -1,8 +1,8 @@
 package com.pickpick.auth.ui;
 
 import com.pickpick.auth.application.AuthService;
+import com.pickpick.auth.support.AuthorizationExtractor;
 import com.pickpick.auth.ui.dto.LoginResponse;
-import com.pickpick.utils.AuthorizationExtractor;
 import javax.servlet.http.HttpServletRequest;
 import javax.validation.constraints.NotEmpty;
 import org.springframework.web.bind.annotation.GetMapping;

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationInterceptor.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationInterceptor.java
@@ -1,7 +1,7 @@
 package com.pickpick.auth.ui;
 
+import com.pickpick.auth.support.AuthorizationExtractor;
 import com.pickpick.auth.support.JwtTokenProvider;
-import com.pickpick.utils.AuthorizationExtractor;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.web.cors.CorsUtils;

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthenticationPrincipalArgumentResolver.java
@@ -1,8 +1,8 @@
 package com.pickpick.auth.ui;
 
 import com.pickpick.auth.support.AuthenticationPrincipal;
+import com.pickpick.auth.support.AuthorizationExtractor;
 import com.pickpick.auth.support.JwtTokenProvider;
-import com.pickpick.utils.AuthorizationExtractor;
 import javax.servlet.http.HttpServletRequest;
 import org.springframework.core.MethodParameter;
 import org.springframework.web.bind.support.WebDataBinderFactory;


### PR DESCRIPTION
## 요약

`AuthorizationExtractor`를 `auth/supprot` 패키지로 이동

<br>

## 작업 내용

`AuthorizationExtractor`를 이동시켰습니다
`pickpick/utils` -> `pickpick/auth/supprot`  

<br>

## 관련 이슈

#503 

<br>
