### PR TITLE
refacotor: 접근제어자 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/slackevent/application/SlackEventServiceFinder.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/SlackEventServiceFinder.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class SlackEventServiceFinder {
 
-    public final List<SlackEventService> slackEventServices;
+    private final List<SlackEventService> slackEventServices;
 
     public SlackEventServiceFinder(final List<SlackEventService> slackEventServices) {
         this.slackEventServices = slackEventServices;


### PR DESCRIPTION
## 요약

SlackEventServiceFinder 내부 필드인 List<SlackEventService>의 접근제어자를 public에서 private으로 수정
<br><br>

## 작업 내용

SlackEventServiceFinder 내부 필드인 List<SlackEventService>의 접근제어자를 public에서 private으로 수정
<br><br>


## 관련 이슈

- Close #511 

<br><br>

pr 올리기 머쓱하네요 😵‍💫 
