### PR TITLE
refactor: 메시지/북마크/리마인더 조회 API 스펙 변경  

### DIFF
--- a/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponses.java
@@ -1,13 +1,13 @@
 package com.pickpick.message.ui.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import lombok.Getter;
 
-@Getter
 public class BookmarkResponses {
 
     private List<BookmarkResponse> bookmarks;
 
+    @JsonProperty(value = "hasPast")
     private boolean hasPast;
 
     private BookmarkResponses() {
@@ -16,5 +16,13 @@ public class BookmarkResponses {
     public BookmarkResponses(final List<BookmarkResponse> bookmarks, final boolean hasPast) {
         this.bookmarks = bookmarks;
         this.hasPast = hasPast;
+    }
+
+    public List<BookmarkResponse> getBookmarks() {
+        return bookmarks;
+    }
+
+    public boolean hasPast() {
+        return hasPast;
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponses.java
@@ -9,14 +9,14 @@ public class BookmarkResponses {
 
     private List<BookmarkResponse> bookmarks;
 
-    @JsonProperty(value = "isLast")
-    private boolean last;
+    @JsonProperty(value = "hasPast")
+    private boolean hasPast;
 
     private BookmarkResponses() {
     }
 
-    public BookmarkResponses(final List<BookmarkResponse> bookmarks, final boolean last) {
+    public BookmarkResponses(final List<BookmarkResponse> bookmarks, final boolean hasPast) {
         this.bookmarks = bookmarks;
-        this.last = last;
+        this.hasPast = hasPast;
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/BookmarkResponses.java
@@ -1,6 +1,5 @@
 package com.pickpick.message.ui.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Getter;
 
@@ -9,7 +8,6 @@ public class BookmarkResponses {
 
     private List<BookmarkResponse> bookmarks;
 
-    @JsonProperty(value = "hasPast")
     private boolean hasPast;
 
     private BookmarkResponses() {

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
@@ -9,8 +9,11 @@ public class MessageResponses {
 
     private List<MessageResponse> messages;
 
-    @JsonProperty(value = "isLast")
-    private boolean last;
+    @JsonProperty(value = "hasPast")
+    private boolean hasPast;
+
+    @JsonProperty(value = "hasFuture")
+    private boolean hasFuture;
 
     @JsonProperty(value = "isNeedPastMessage")
     private boolean needPastMessage;
@@ -18,9 +21,11 @@ public class MessageResponses {
     private MessageResponses() {
     }
 
-    public MessageResponses(final List<MessageResponse> messages, final boolean last, final boolean needPastMessage) {
+    public MessageResponses(final List<MessageResponse> messages, final boolean hasPast, final boolean hasFuture,
+                            final boolean needPastMessage) {
         this.messages = messages;
-        this.last = last;
+        this.hasPast = hasPast;
+        this.hasFuture = hasFuture;
         this.needPastMessage = needPastMessage;
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
@@ -2,15 +2,15 @@ package com.pickpick.message.ui.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import lombok.Getter;
 
-@Getter
 public class MessageResponses {
 
     private List<MessageResponse> messages;
 
+    @JsonProperty(value = "hasPast")
     private boolean hasPast;
 
+    @JsonProperty(value = "hasFuture")
     private boolean hasFuture;
 
     @JsonProperty(value = "isNeedPastMessage")
@@ -25,5 +25,21 @@ public class MessageResponses {
         this.hasPast = hasPast;
         this.hasFuture = hasFuture;
         this.needPastMessage = needPastMessage;
+    }
+
+    public List<MessageResponse> getMessages() {
+        return messages;
+    }
+
+    public boolean hasPast() {
+        return this.hasPast;
+    }
+
+    public boolean hasFuture() {
+        return hasFuture;
+    }
+
+    public boolean isNeedPastMessage() {
+        return needPastMessage;
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/MessageResponses.java
@@ -9,10 +9,8 @@ public class MessageResponses {
 
     private List<MessageResponse> messages;
 
-    @JsonProperty(value = "hasPast")
     private boolean hasPast;
 
-    @JsonProperty(value = "hasFuture")
     private boolean hasFuture;
 
     @JsonProperty(value = "isNeedPastMessage")

--- a/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponses.java
@@ -9,14 +9,14 @@ public class ReminderResponses {
 
     private List<ReminderResponse> reminders;
 
-    @JsonProperty(value = "isLast")
-    private boolean last;
+    @JsonProperty(value = "hasFuture")
+    private boolean hasFuture;
 
     private ReminderResponses() {
     }
 
-    public ReminderResponses(final List<ReminderResponse> reminders, final boolean last) {
+    public ReminderResponses(final List<ReminderResponse> reminders, final boolean hasFuture) {
         this.reminders = reminders;
-        this.last = last;
+        this.hasFuture = hasFuture;
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponses.java
@@ -1,13 +1,13 @@
 package com.pickpick.message.ui.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
-import lombok.Getter;
 
-@Getter
 public class ReminderResponses {
 
     private List<ReminderResponse> reminders;
 
+    @JsonProperty(value = "hasFuture")
     private boolean hasFuture;
 
     private ReminderResponses() {
@@ -16,5 +16,13 @@ public class ReminderResponses {
     public ReminderResponses(final List<ReminderResponse> reminders, final boolean hasFuture) {
         this.reminders = reminders;
         this.hasFuture = hasFuture;
+    }
+
+    public List<ReminderResponse> getReminders() {
+        return reminders;
+    }
+
+    public boolean hasFuture() {
+        return hasFuture;
     }
 }

--- a/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponses.java
+++ b/backend/src/main/java/com/pickpick/message/ui/dto/ReminderResponses.java
@@ -1,6 +1,5 @@
 package com.pickpick.message.ui.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import lombok.Getter;
 
@@ -9,7 +8,6 @@ public class ReminderResponses {
 
     private List<ReminderResponse> reminders;
 
-    @JsonProperty(value = "hasFuture")
     private boolean hasFuture;
 
     private ReminderResponses() {

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -46,7 +46,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
-        assertThat(bookmarkResponses.isHasPast()).isEqualTo(expectedHasPast);
+        assertThat(bookmarkResponses.hasPast()).isEqualTo(expectedHasPast);
         assertThat(convertToIds(bookmarkResponses)).containsExactlyElementsOf(expectedIds);
     }
 
@@ -65,7 +65,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
-        assertThat(bookmarkResponses.isHasPast()).isEqualTo(expectedHasPast);
+        assertThat(bookmarkResponses.hasPast()).isEqualTo(expectedHasPast);
         assertThat(convertToIds(bookmarkResponses)).containsExactlyElementsOf(expectedIds);
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -37,7 +37,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         // given
         Map<String, Object> request = Map.of("bookmarkId", "");
         List<Long> expectedIds = List.of(1L);
-        boolean expectedIsLast = true;
+        boolean expectedHasPast = false;
 
         // when
         ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 2L, request);
@@ -46,7 +46,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
-        assertThat(bookmarkResponses.isLast()).isEqualTo(expectedIsLast);
+        assertThat(bookmarkResponses.isHasPast()).isEqualTo(expectedHasPast);
         assertThat(convertToIds(bookmarkResponses)).containsExactlyElementsOf(expectedIds);
     }
 
@@ -56,7 +56,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("bookmarkId", "23");
         List<Long> expectedIds = List.of(22L, 21L, 20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L, 10L, 9L, 8L, 7L,
                 6L, 5L, 4L, 3L);
-        boolean expectedIsLast = false;
+        boolean expectedHasPast = true;
 
         // when
         ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 1L, request);
@@ -65,7 +65,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
-        assertThat(bookmarkResponses.isLast()).isEqualTo(expectedIsLast);
+        assertThat(bookmarkResponses.isHasPast()).isEqualTo(expectedHasPast);
         assertThat(convertToIds(bookmarkResponses)).containsExactlyElementsOf(expectedIds);
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -43,49 +43,49 @@ class MessageAcceptanceTest extends AcceptanceTest {
                 Arguments.of(
                         "channelIds가 5이면, 5번 채널의 가장 최근 메시지 20개가 응답되어야 한다.",
                         createQueryParams("", "", "5", "", "", ""),
-                        false,
+                        true,
                         createExpectedMessageIds(38L, 19L),
                         true),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 true이고 date가 존재할 경우, 5번 채널의 해당 날짜 보다 과거 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "2022-07-13T19:21:55", "5", "true", "", ""),
-                        true,
+                        false,
                         createExpectedMessageIds(6L, 1L),
                         true),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 해당 메시지 보다 과거 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "5", "true", "6", ""),
-                        true,
+                        false,
                         createExpectedMessageIds(5L, 1L),
                         true),
                 Arguments.of(
                         "channelIds가 5이고, needPastMessage가 false이고 messageId가 존재할 경우, 5번 채널의 해당 메시지 보다 미래 데이터 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "5", "false", "6", ""),
-                        false,
+                        true,
                         createExpectedMessageIds(26L, 7L),
                         false),
                 Arguments.of(
                         "channelIds가 5이고, keyword가 '줍'일 경우, 5번 채널의 메시지 중 '줍'이 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("줍", "", "5", "", "", ""),
-                        true,
+                        false,
                         createExpectedMessageIds(28L, 23L),
                         true),
                 Arguments.of(
                         "channelIds가 5이고, keyword가 '호'이고, needPastMessage가 true이고 messageId가 존재할 경우, 5번 채널의 '호'가 포함된 메시지 중, 전달된 메시지 ID의 메시지보다 더 과거 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("호", "", "5", "", "13", ""),
-                        true,
+                        false,
                         createExpectedMessageIds(7L, 4L),
                         true),
                 Arguments.of(
                         "channelIds가 5이고, keyword가 'jupjup'일 경우, 5번 채널의 메시지 중 'jupjup'이 포함된 메시지 20개를 시간 내림차순으로 응답해야 한다.",
                         createQueryParams("jupjup", "", "5", "", "", ""),
-                        true,
+                        false,
                         createExpectedMessageIds(18L, 14L),
                         true),
                 Arguments.of(
                         "쿼리 파라미터가 전혀 전달되지 않았을 경우, 회원의 채널 정렬 상 첫번째 채널의 최신 20개 메시지를 작성시간 내림차순으로 응답해야 한다.",
                         createQueryParams("", "", "", "", "", ""),
-                        false,
+                        true,
                         createExpectedMessageIds(38L, 19L),
                         true)
         );
@@ -114,7 +114,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{0}")
-    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedIsLast,
+    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedhasPast,
                     final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
         // given & when
         ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
@@ -124,7 +124,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 () -> 상태코드_200_확인(response),
-                () -> assertThat(messageResponses.isHasPast()).isEqualTo(expectedIsLast),
+                () -> assertThat(messageResponses.isHasPast()).isEqualTo(expectedhasPast),
                 () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
                         .extracting("id")

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -124,7 +124,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 () -> 상태코드_200_확인(response),
-                () -> assertThat(messageResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(messageResponses.isHasPast()).isEqualTo(expectedIsLast),
                 () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
                         .extracting("id")

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -124,7 +124,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
         assertAll(
                 () -> 상태코드_200_확인(response),
-                () -> assertThat(messageResponses.isHasPast()).isEqualTo(expectedhasPast),
+                () -> assertThat(messageResponses.hasPast()).isEqualTo(expectedhasPast),
                 () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
                         .extracting("id")

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -86,7 +86,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
+                () -> assertThat(reminderResponses.hasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }
@@ -109,7 +109,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
+                () -> assertThat(reminderResponses.hasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }
@@ -132,7 +132,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
+                () -> assertThat(reminderResponses.hasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }
@@ -156,7 +156,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
+                () -> assertThat(reminderResponses.hasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -76,7 +76,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         Map<String, Object> request = Map.of("reminderId", "");
         List<Long> expectedIds = List.of(1L);
-        boolean expectedIsLast = true;
+        boolean expectedHasPast = false;
 
         // when
         ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
@@ -86,7 +86,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }
@@ -99,7 +99,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         Map<String, Object> request = Map.of("reminderId", "10");
         List<Long> expectedIds = List.of(11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L);
-        boolean expectedIsLast = true;
+        boolean expectedHasPast = false;
 
         // when
         ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
@@ -109,20 +109,20 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }
 
     @Test
-    void 리마인더_조회_시_가장_최신인_리마인더가_포함된다면_isLast가_True다() {
+    void 리마인더_조회_시_가장_최신인_리마인더가_포함된다면_hasFuture가_False다() {
         // given
         given(clock.instant())
                 .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
 
         Map<String, Object> request = Map.of("reminderId", "");
         List<Long> expectedIds = List.of(1L);
-        boolean expectedIsLast = true;
+        boolean expectedHasPast = false;
 
         // when
         ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
@@ -132,13 +132,13 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }
 
     @Test
-    void 리마인더_조회_시_가장_최신인_리마인더가_포함되지_않는다면_isLast가_False다() {
+    void 리마인더_조회_시_가장_최신인_리마인더가_포함되지_않는다면_hasFuture가_True다() {
         // given
         given(clock.instant())
                 .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
@@ -146,7 +146,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "2");
         List<Long> expectedIds = List.of(
                 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L);
-        boolean expectedIsLast = false;
+        boolean expectedHasPast = true;
 
         // when
         ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
@@ -156,7 +156,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
-                () -> assertThat(reminderResponses.isLast()).isEqualTo(expectedIsLast),
+                () -> assertThat(reminderResponses.isHasFuture()).isEqualTo(expectedHasPast),
                 () -> assertThat(convertToIds(reminderResponses)).containsExactlyElementsOf(expectedIds)
         );
     }

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -61,7 +61,7 @@ class BookmarkServiceTest {
                 Arguments.arguments("멤버 ID가 1번이고 북마크 id 23번일 때 북마크 목록을 조회한다", 23L, 1L,
                         List.of(22L, 21L, 20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L, 10L, 9L, 8L, 7L, 6L, 5L, 4L,
                                 3L), true),
-                Arguments.arguments("북마크 조회 시 가장 오래된 북마크가 포함된다면 isLast가 true이다", null, 2L, List.of(1L), false)
+                Arguments.arguments("북마크 조회 시 가장 오래된 북마크가 포함된다면 hasPast가 false이다", null, 2L, List.of(1L), false)
         );
     }
 

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -57,11 +57,11 @@ class BookmarkServiceTest {
 
     private static Stream<Arguments> parameterProvider() {
         return Stream.of(
-                Arguments.arguments("멤버 ID 2번으로 북마크를 조회한다", null, 2L, List.of(1L), true),
+                Arguments.arguments("멤버 ID 2번으로 북마크를 조회한다", null, 2L, List.of(1L), false),
                 Arguments.arguments("멤버 ID가 1번이고 북마크 id 23번일 때 북마크 목록을 조회한다", 23L, 1L,
                         List.of(22L, 21L, 20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L, 10L, 9L, 8L, 7L, 6L, 5L, 4L,
-                                3L), false),
-                Arguments.arguments("북마크 조회 시 가장 오래된 북마크가 포함된다면 isLast가 true이다", null, 2L, List.of(1L), true)
+                                3L), true),
+                Arguments.arguments("북마크 조회 시 가장 오래된 북마크가 포함된다면 isLast가 true이다", null, 2L, List.of(1L), false)
         );
     }
 
@@ -98,7 +98,7 @@ class BookmarkServiceTest {
     @ParameterizedTest(name = "{0}")
     @MethodSource("parameterProvider")
     void findBookmarks(final String subscription, final Long bookmarkId, final Long memberId,
-                       final List<Long> expectedIds, final boolean expectedIsLast) {
+                       final List<Long> expectedIds, final boolean expectedHasPast) {
         // given & when
         BookmarkResponses response = bookmarkService.find(new BookmarkFindRequest(bookmarkId, null), memberId);
 
@@ -106,7 +106,7 @@ class BookmarkServiceTest {
         List<Long> ids = convertToIds(response);
         assertAll(
                 () -> assertThat(ids).containsExactlyElementsOf(expectedIds),
-                () -> assertThat(response.isLast()).isEqualTo(expectedIsLast)
+                () -> assertThat(response.isHasPast()).isEqualTo(expectedHasPast)
         );
     }
 

--- a/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/BookmarkServiceTest.java
@@ -106,7 +106,7 @@ class BookmarkServiceTest {
         List<Long> ids = convertToIds(response);
         assertAll(
                 () -> assertThat(ids).containsExactlyElementsOf(expectedIds),
-                () -> assertThat(response.isHasPast()).isEqualTo(expectedHasPast)
+                () -> assertThat(response.hasPast()).isEqualTo(expectedHasPast)
         );
     }
 

--- a/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
@@ -120,38 +120,71 @@ class MessageServiceTest {
 
         }
 
-        @DisplayName("더 이상 조회할 메시지가 없다면")
+        @DisplayName("조회 할 과거 메시지가 남아 있다면")
         @Nested
-        class noMoreMessagesRemain {
-
-            MessageRequest request = onlyCount(noticeMessages.size());
-            MessageResponses response = messageService.find(summer.getId(), request);
-
-            @DisplayName("isLast는 true이다")
-            @Test
-            void messageRemainIsLastFalse() {
-                boolean isLast = response.isLast();
-
-                assertThat(isLast).isTrue();
-            }
-
-        }
-
-        @DisplayName("조회 할 메시지가 남아있다면")
-        @Nested
-        class messagesRemain {
+        class pastMessagesRemain {
 
             MessageRequest request = onlyCount(MESSAGE_COUNT);
             MessageResponses response = messageService.find(summer.getId(), request);
 
-            @DisplayName("isLast는 false다")
+            @DisplayName("hasPast는 true다")
             @Test
-            void messageRemainIsLastTrue() {
-                boolean isLast = response.isLast();
+            void messagesHasPastTrue() {
+                boolean hasPast = response.isHasPast();
 
-                assertThat(isLast).isFalse();
+                assertThat(hasPast).isTrue();
             }
 
+        }
+
+        @DisplayName("조회 할 과거 메시지가 더 이상 없다면")
+        @Nested
+        class noMorePastMessagesRemain {
+
+            MessageRequest request = onlyCount(noticeMessages.size());
+            MessageResponses response = messageService.find(summer.getId(), request);
+
+            @DisplayName("hasPast는 false이다")
+            @Test
+            void messagesHasPastFalse() {
+                boolean hasPast = response.isHasPast();
+
+                assertThat(hasPast).isFalse();
+            }
+
+        }
+
+        @DisplayName("조회 할 미래 메시지가 남아 있다면")
+        @Nested
+        class futureMessagesRemain {
+
+            MessageRequest request = pastFromTargetMessageInChannels(
+                    List.of(notice), noticeMessages.get(noticeMessages.size() - 1), MESSAGE_COUNT);
+            MessageResponses response = messageService.find(summer.getId(), request);
+
+            @DisplayName("hasFuture는 true이다")
+            @Test
+            void messagesHasFutureTrue() {
+                boolean hasFuture = response.isHasFuture();
+
+                assertThat(hasFuture).isTrue();
+            }
+        }
+
+        @DisplayName("조회 할 미래 메시지가 더 이상 없다면")
+        @Nested
+        class noMoreFutureMessagesRemain {
+
+            MessageRequest request = onlyCount(MESSAGE_COUNT);
+            MessageResponses response = messageService.find(summer.getId(), request);
+
+            @DisplayName("hasFutre는 false이다")
+            @Test
+            void messagesHasFutureFalse() {
+                boolean hasFuture = response.isHasFuture();
+
+                assertThat(hasFuture).isFalse();
+            }
         }
 
         @DisplayName("특정 단어로 여러 채널에서 검색한다면")

--- a/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/MessageServiceTest.java
@@ -130,7 +130,7 @@ class MessageServiceTest {
             @DisplayName("hasPast는 true다")
             @Test
             void messagesHasPastTrue() {
-                boolean hasPast = response.isHasPast();
+                boolean hasPast = response.hasPast();
 
                 assertThat(hasPast).isTrue();
             }
@@ -147,7 +147,7 @@ class MessageServiceTest {
             @DisplayName("hasPast는 false이다")
             @Test
             void messagesHasPastFalse() {
-                boolean hasPast = response.isHasPast();
+                boolean hasPast = response.hasPast();
 
                 assertThat(hasPast).isFalse();
             }
@@ -165,7 +165,7 @@ class MessageServiceTest {
             @DisplayName("hasFuture는 true이다")
             @Test
             void messagesHasFutureTrue() {
-                boolean hasFuture = response.isHasFuture();
+                boolean hasFuture = response.hasFuture();
 
                 assertThat(hasFuture).isTrue();
             }
@@ -181,7 +181,7 @@ class MessageServiceTest {
             @DisplayName("hasFutre는 false이다")
             @Test
             void messagesHasFutureFalse() {
-                boolean hasFuture = response.isHasFuture();
+                boolean hasFuture = response.hasFuture();
 
                 assertThat(hasFuture).isFalse();
             }

--- a/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
+++ b/backend/src/test/java/com/pickpick/message/application/ReminderServiceTest.java
@@ -150,7 +150,7 @@ class ReminderServiceTest {
         List<Long> ids = convertToIds(response);
         assertAll(
                 () -> assertThat(ids).containsExactlyElementsOf(expectedIds),
-                () -> assertThat(response.isHasFuture()).isEqualTo(expectedHasFuture)
+                () -> assertThat(response.hasFuture()).isEqualTo(expectedHasFuture)
         );
     }
 
@@ -207,7 +207,7 @@ class ReminderServiceTest {
         int size = response.getReminders().size();
         assertAll(
                 () -> assertThat(size).isEqualTo(count),
-                () -> assertThat(response.isHasFuture()).isTrue(),
+                () -> assertThat(response.hasFuture()).isTrue(),
                 () -> assertThat(response.getReminders()).extracting("id")
                         .containsExactly(29L, 30L)
         );
@@ -228,7 +228,7 @@ class ReminderServiceTest {
         int size = response.getReminders().size();
         assertAll(
                 () -> assertThat(size).isEqualTo(count),
-                () -> assertThat(response.isHasFuture()).isTrue(),
+                () -> assertThat(response.hasFuture()).isTrue(),
                 () -> assertThat(response.getReminders()).extracting("id")
                         .containsExactly(25L, 26L)
         );
@@ -249,7 +249,7 @@ class ReminderServiceTest {
         int size = response.getReminders().size();
         assertAll(
                 () -> assertThat(size).isEqualTo(count),
-                () -> assertThat(response.isHasFuture()).isFalse(),
+                () -> assertThat(response.hasFuture()).isFalse(),
                 () -> assertThat(response.getReminders()).extracting("id")
                         .containsExactly(27L, 28L)
         );
@@ -270,7 +270,7 @@ class ReminderServiceTest {
         int size = response.getReminders().size();
         assertAll(
                 () -> assertThat(size).isEqualTo(count),
-                () -> assertThat(response.isHasFuture()).isFalse(),
+                () -> assertThat(response.hasFuture()).isFalse(),
                 () -> assertThat(response.getReminders()).extracting("id")
                         .containsExactly(31L, 29L, 30L, 25L, 26L, 27L, 28L)
         );
@@ -291,7 +291,7 @@ class ReminderServiceTest {
         List<Long> ids = convertToIds(response);
         assertAll(
                 () -> assertThat(ids).doesNotContainAnyElementsOf(List.of(24L)),
-                () -> assertThat(response.isHasFuture()).isTrue()
+                () -> assertThat(response.hasFuture()).isTrue()
         );
     }
 

--- a/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
@@ -69,7 +69,7 @@ public class BookmarkControllerTest extends RestDocsTestSupport {
                                         .description("메시지 게시 날짜"),
                                 fieldWithPath("bookmarks.[].modifiedDate").type(JsonFieldType.STRING)
                                         .description("메시지 수정 날짜"),
-                                fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부")
+                                fieldWithPath("hasPast").type(JsonFieldType.BOOLEAN).description("더 과거의 북마크 조회 가능 여부")
                         )
                 ));
     }

--- a/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
@@ -85,7 +85,8 @@ class MessageControllerTest extends RestDocsTestSupport {
                                         fieldWithPath("messages.[].isSetReminded").type(JsonFieldType.BOOLEAN)
                                                 .description("리마인더 등록 여부"),
                                         fieldWithPath("messages.[].remindDate").type(JsonFieldType.STRING).optional().description("리마인더 등록된 날짜"),
-                                        fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 메시지 여부"),
+                                        fieldWithPath("hasPast").type(JsonFieldType.BOOLEAN).description("더 과거의 메시지 조회 가능 여부"),
+                                        fieldWithPath("hasFuture").type(JsonFieldType.BOOLEAN).description("더 미래의 메시지 조회 가능 여부"),
                                         fieldWithPath("isNeedPastMessage").type(JsonFieldType.BOOLEAN)
                                                 .description("위/아래 스크롤 방향")
                                 )

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -149,7 +149,7 @@ public class ReminderControllerTest extends RestDocsTestSupport {
                                         .description("메시지 수정 날짜"),
                                 fieldWithPath("reminders.[].remindDate").type(JsonFieldType.STRING)
                                         .description("리마인드 날짜"),
-                                fieldWithPath("hasFuture").type(JsonFieldType.BOOLEAN).description("더 미래의 미라인더 조회 가능 여부")
+                                fieldWithPath("hasFuture").type(JsonFieldType.BOOLEAN).description("더 미래의 리마인더 조회 가능 여부")
                         )
                 ));
     }

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -149,7 +149,7 @@ public class ReminderControllerTest extends RestDocsTestSupport {
                                         .description("메시지 수정 날짜"),
                                 fieldWithPath("reminders.[].remindDate").type(JsonFieldType.STRING)
                                         .description("리마인드 날짜"),
-                                fieldWithPath("isLast").type(JsonFieldType.BOOLEAN).description("마지막 리마인더 메시지 여부")
+                                fieldWithPath("hasFuture").type(JsonFieldType.BOOLEAN).description("더 미래의 미라인더 조회 가능 여부")
                         )
                 ));
     }


### PR DESCRIPTION
## 요약

메시지/북마크/리마인더 조회 API 스펙을 일괄 변경했습니다
- `isLast`가 `hasPast, hasFuture`로 나뉘어졌습니다  

<br>

## 작업 내용

#### 전체적으로 `isLast`와 불린값이 반대가 된 것에 주의

메시지 조회 시 
- 더 과거의 메시지가 
  - 조회 가능(존재)할 때 `"hasPast": "true"`
  - 조회 불가(존재하지 않음)일 때 `"hasPast": "false"`
- 더 미래의 메시지가
  - 조회 가능(존재)할 때 `"hasFuture": "true"`
  - 조회 불가(존재하지 않음)일 때 `"hasFuture": "false"`
- `isNeedPastMessage`는 변동없고 무관합니다 

북마크 조회 시
- 더 과거의 북마크가 
  - 조회 가능(존재)할 때 `"hasPast": "true"`
  - 조회 불가(존재하지 않음)일 때 `"hasPast": "false"`

리마인더 조회 시 
- 더 미래의 리마인더가
  - 조회 가능(존재)할 때 `"hasFuture": "true"`
  - 조회 불가(존재하지 않음)일 때 `"hasFuture": "false"`

<br>

## 참고 사항

북마크 조회 정렬 기준 변경은 별도 테스크로 가져가길 희망합니다
하지만 프론트 쪽에서 같이 작업하는 게 편하다면 추가 개발해서 여기에 올리겠습니다  

<br>

## 관련 이슈

- Close #484 

<br>
