### PR TITLE
refactor: 최상단으로 스크롤을 움직이는 로직 리팩터링 

### DIFF
--- a/frontend/src/hooks/useScrollToTop.ts
+++ b/frontend/src/hooks/useScrollToTop.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+interface Props {
+  dependencies?: unknown[];
+}
+
+function useScrollToTop({ dependencies = [] }: Props = {}) {
+  useEffect(() => {
+    window.scrollTo({
+      top: 0,
+    });
+  }, dependencies);
+}
+
+export default useScrollToTop;

--- a/frontend/src/pages/Bookmark/index.tsx
+++ b/frontend/src/pages/Bookmark/index.tsx
@@ -7,8 +7,8 @@ import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
 import EmptyStatus from "@src/components/EmptyStatus";
 import BookmarkButton from "@src/components/MessageIconButtons/BookmarkButton";
 import { extractResponseBookmarks, parseTime } from "@src/@utils";
-import { useEffect } from "react";
 import useGetInfiniteBookmarks from "@src/hooks/query/useGetInfiniteBookmarks";
+import useScrollToTop from "@src/hooks/useScrollToTop";
 
 function Bookmark() {
   const { data, isLoading, isSuccess, fetchNextPage, hasNextPage, refetch } =
@@ -20,11 +20,7 @@ function Bookmark() {
 
   const parsedData = extractResponseBookmarks(data);
 
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-    });
-  }, []);
+  useScrollToTop();
 
   return (
     <Styled.Container>

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -1,7 +1,7 @@
 import { FlexColumn } from "@src/@styles/shared";
 import MessageCard from "@src/components/MessageCard";
 import * as Styled from "./style";
-import React, { useEffect } from "react";
+import React from "react";
 import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
 import MessagesLoadingStatus from "@src/components/MessagesLoadingStatus";
 import { extractResponseMessages, parseTime } from "@src/@utils";
@@ -20,6 +20,7 @@ import BookmarkButton from "@src/components/MessageIconButtons/BookmarkButton";
 import ReminderButton from "@src/components/MessageIconButtons/ReminderButton";
 import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
 import useGetInfiniteMessages from "@src/hooks/query/useGetInfiniteMessages";
+import useScrollToTop from "@src/hooks/useScrollToTop";
 
 function Feed() {
   const { channelId } = useParams();
@@ -57,11 +58,7 @@ function Feed() {
 
   const parsedData = extractResponseMessages(data);
 
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-    });
-  }, [queryKey]);
+  useScrollToTop();
 
   return (
     <Styled.Container>

--- a/frontend/src/pages/Reminder/index.tsx
+++ b/frontend/src/pages/Reminder/index.tsx
@@ -11,8 +11,8 @@ import ReminderModal from "@src/components/ReminderModal";
 import useModal from "@src/hooks/useModal";
 import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
 import ReminderButton from "@src/components/MessageIconButtons/ReminderButton";
-import { useEffect } from "react";
 import useGetInfiniteReminders from "@src/hooks/query/useGetInfiniteReminders";
+import useScrollToTop from "@src/hooks/useScrollToTop";
 
 function Reminder() {
   const {
@@ -33,11 +33,7 @@ function Reminder() {
     handleCloseModal: handleCloseReminderModal,
   } = useModal();
 
-  useEffect(() => {
-    window.scrollTo({
-      top: 0,
-    });
-  }, []);
+  useScrollToTop();
 
   return (
     <Styled.Container>

--- a/frontend/src/pages/SpecificDateFeed/index.tsx
+++ b/frontend/src/pages/SpecificDateFeed/index.tsx
@@ -21,6 +21,7 @@ import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage"
 import BookmarkButton from "@src/components/MessageIconButtons/BookmarkButton";
 import ReminderButton from "@src/components/MessageIconButtons/ReminderButton";
 import useGetInfiniteMessages from "@src/hooks/query/useGetInfiniteMessages";
+import useScrollToTop from "@src/hooks/useScrollToTop";
 
 function SpecificDateFeed() {
   const { key: queryKey } = useLocation();
@@ -82,6 +83,8 @@ function SpecificDateFeed() {
       behavior: "smooth",
     });
   }, [queryKey]);
+
+  useScrollToTop({ dependencies: [queryKey] });
 
   return (
     <Styled.Container


### PR DESCRIPTION
## 요약

최상단으로 스크롤을 움직이는 로직 리팩터링 

## 작업 내용

```tsx
import { useEffect } from "react";

interface Props {
  dependencies?: unknown[];
}

function useScrollToTop({ dependencies = [] }: Props = {}) {
  useEffect(() => {
    window.scrollTo({
      top: 0,
    });
  }, dependencies);
}

export default useScrollToTop;

```

- 위와 같은 useScrollToTop 훅을 작성하여 적용하였습니다.
- useEffect 에 의존성 배열 주입이 필요한 경우가 있어서 dependencies 를 옵셔널 Props 로 받도록 구현했습니다.
- Bookmark, Feed, SpecificDateFeed, Reminder 페이지에 적용했습니다.



## 관련 이슈

- Close #523 

<br><br>
