### PR TITLE
fix: Drawer 내부 클릭 시, Drawer 가 닫히는 문제 해결

### DIFF
--- a/frontend/src/components/@layouts/Navigation/index.tsx
+++ b/frontend/src/components/@layouts/Navigation/index.tsx
@@ -37,12 +37,12 @@ function Navigation() {
     handleToggleModal: handleToggleLogoutButton,
   } = useModal();
 
-  const { innerRefArray: drawerInnerRefArray } = useOuterClick({
+  const [menuIconInnerRef, drawerInnerRef] = useOuterClick({
     callback: handleCloseDrawer,
     requiredInnerRefCount: 2,
   });
 
-  const { innerRef: logoutButtonInnerRef } = useOuterClick({
+  const [logoutButtonInnerRef] = useOuterClick({
     callback: handleCloseLogoutButton,
     requiredInnerRefCount: 1,
   });
@@ -54,7 +54,7 @@ function Navigation() {
 
   return (
     <Styled.Container>
-      <div ref={drawerInnerRefArray[0]}>
+      <div ref={menuIconInnerRef}>
         <WrapperButton kind="bigIcon" onClick={handleToggleDrawer}>
           <MenuIcon
             width="24px"
@@ -125,7 +125,7 @@ function Navigation() {
       <Portal isOpened={isMenuDrawerOpened}>
         <>
           <Dimmer hasBackgroundColor={true} onClick={handleCloseDrawer} />
-          <div ref={drawerInnerRefArray[1]}>
+          <div ref={drawerInnerRef}>
             <Drawer
               channels={data?.channels}
               handleCloseDrawer={handleCloseDrawer}

--- a/frontend/src/components/@layouts/Navigation/index.tsx
+++ b/frontend/src/components/@layouts/Navigation/index.tsx
@@ -39,11 +39,12 @@ function Navigation() {
 
   const { innerRefArray: drawerInnerRefArray } = useOuterClick({
     callback: handleCloseDrawer,
-    requiredRefCount: 2,
+    requiredInnerRefCount: 2,
   });
 
   const { innerRef: logoutButtonInnerRef } = useOuterClick({
     callback: handleCloseLogoutButton,
+    requiredInnerRefCount: 1,
   });
 
   const handleLogout = () => {

--- a/frontend/src/components/@layouts/Navigation/index.tsx
+++ b/frontend/src/components/@layouts/Navigation/index.tsx
@@ -37,10 +37,14 @@ function Navigation() {
     handleToggleModal: handleToggleLogoutButton,
   } = useModal();
 
-  const { innerRef: drawerInnerRef } = useOuterClick(handleCloseDrawer);
-  const { innerRef: logoutButtonInnerRef } = useOuterClick(
-    handleCloseLogoutButton
-  );
+  const { innerRefArray: drawerInnerRefArray } = useOuterClick({
+    callback: handleCloseDrawer,
+    requiredRefCount: 2,
+  });
+
+  const { innerRef: logoutButtonInnerRef } = useOuterClick({
+    callback: handleCloseLogoutButton,
+  });
 
   const handleLogout = () => {
     handleCloseLogoutButton();
@@ -49,7 +53,7 @@ function Navigation() {
 
   return (
     <Styled.Container>
-      <div ref={drawerInnerRef}>
+      <div ref={drawerInnerRefArray[0]}>
         <WrapperButton kind="bigIcon" onClick={handleToggleDrawer}>
           <MenuIcon
             width="24px"
@@ -120,10 +124,12 @@ function Navigation() {
       <Portal isOpened={isMenuDrawerOpened}>
         <>
           <Dimmer hasBackgroundColor={true} onClick={handleCloseDrawer} />
-          <Drawer
-            channels={data?.channels}
-            handleCloseDrawer={handleCloseDrawer}
-          />
+          <div ref={drawerInnerRefArray[1]}>
+            <Drawer
+              channels={data?.channels}
+              handleCloseDrawer={handleCloseDrawer}
+            />
+          </div>
         </>
       </Portal>
 

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -23,7 +23,10 @@ function Dropdown({ toggleHandler, children }: Props) {
     handleToggleDropdown,
   } = useDropdown();
 
-  const { innerRef } = useOuterClick({ callback: handleCloseDropdown });
+  const { innerRef } = useOuterClick({
+    callback: handleCloseDropdown,
+    requiredInnerRefCount: 1,
+  });
 
   useEffect(() => {
     toggleHandler && toggleHandler();

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -23,7 +23,7 @@ function Dropdown({ toggleHandler, children }: Props) {
     handleToggleDropdown,
   } = useDropdown();
 
-  const { innerRef } = useOuterClick(handleCloseDropdown);
+  const { innerRef } = useOuterClick({ callback: handleCloseDropdown });
 
   useEffect(() => {
     toggleHandler && toggleHandler();

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -23,7 +23,7 @@ function Dropdown({ toggleHandler, children }: Props) {
     handleToggleDropdown,
   } = useDropdown();
 
-  const { innerRef } = useOuterClick({
+  const [innerRef] = useOuterClick({
     callback: handleCloseDropdown,
     requiredInnerRefCount: 1,
   });

--- a/frontend/src/hooks/useOuterClick.ts
+++ b/frontend/src/hooks/useOuterClick.ts
@@ -6,6 +6,11 @@ interface Props {
   callback: CallbackType;
   requiredInnerRefCount: number;
 }
+/**
+ * 함수 반환 객체
+ * innerRef - innerRefArray 의 첫번째 값 반환
+ * innerRefArray
+ */
 
 function useOuterClick({ callback, requiredInnerRefCount = 1 }: Props) {
   const callbackRef = useRef<CallbackType>();

--- a/frontend/src/hooks/useOuterClick.ts
+++ b/frontend/src/hooks/useOuterClick.ts
@@ -9,7 +9,7 @@ interface Props {
 
 function useOuterClick({ callback, requiredRefCount = 1 }: Props) {
   const callbackRef = useRef<CallbackType>();
-  const innerRefArray = [...Array(requiredRefCount)].map(() =>
+  const innerRefArray = [...Array(requiredRefCount ?? 1)].map(() =>
     useRef<HTMLDivElement>(null)
   );
   callbackRef.current = callback;

--- a/frontend/src/hooks/useOuterClick.ts
+++ b/frontend/src/hooks/useOuterClick.ts
@@ -9,7 +9,7 @@ interface Props {
 
 function useOuterClick({ callback, requiredRefCount = 1 }: Props) {
   const callbackRef = useRef<CallbackType>();
-  const innerRefArray = [...Array(requiredRefCount ?? 1)].map(() =>
+  const innerRefArray = [...Array(requiredRefCount || 1)].map(() =>
     useRef<HTMLDivElement>(null)
   );
   callbackRef.current = callback;

--- a/frontend/src/hooks/useOuterClick.ts
+++ b/frontend/src/hooks/useOuterClick.ts
@@ -4,14 +4,14 @@ type CallbackType = () => void;
 
 interface Props {
   callback: CallbackType;
-  requiredRefCount?: number;
+  requiredInnerRefCount: number;
 }
 
-function useOuterClick({ callback, requiredRefCount = 1 }: Props) {
+function useOuterClick({ callback, requiredInnerRefCount = 1 }: Props) {
   const callbackRef = useRef<CallbackType>();
-  const innerRefArray = [...Array(requiredRefCount || 1)].map(() =>
-    useRef<HTMLDivElement>(null)
-  );
+  const innerRefArray = [
+    ...Array(requiredInnerRefCount <= 0 ? 1 : requiredInnerRefCount),
+  ].map(() => useRef<HTMLDivElement>(null));
   callbackRef.current = callback;
 
   useEffect(() => {

--- a/frontend/src/hooks/useOuterClick.ts
+++ b/frontend/src/hooks/useOuterClick.ts
@@ -17,7 +17,6 @@ function useOuterClick({ callback, requiredRefCount = 1 }: Props) {
   useEffect(() => {
     const handleClick = (event: MouseEvent) => {
       if (
-        innerRefArray.length &&
         callbackRef.current &&
         !innerRefArray.some(
           (ref) =>

--- a/frontend/src/hooks/useOuterClick.ts
+++ b/frontend/src/hooks/useOuterClick.ts
@@ -6,11 +6,6 @@ interface Props {
   callback: CallbackType;
   requiredInnerRefCount: number;
 }
-/**
- * 함수 반환 객체
- * innerRef - innerRefArray 의 첫번째 값 반환
- * innerRefArray
- */
 
 function useOuterClick({ callback, requiredInnerRefCount = 1 }: Props) {
   const callbackRef = useRef<CallbackType>();
@@ -37,7 +32,7 @@ function useOuterClick({ callback, requiredInnerRefCount = 1 }: Props) {
     return () => document.removeEventListener("click", handleClick);
   }, []);
 
-  return { innerRef: innerRefArray[0], innerRefArray };
+  return innerRefArray;
 }
 
 export default useOuterClick;


### PR DESCRIPTION
## 요약
![ezgif-5-7c7bca741f](https://user-images.githubusercontent.com/61469664/191493271-7ca0c4a7-3c7e-439f-87e3-1b06eed46941.gif)

<br><br>

## 작업 내용

Drawer 내부 클릭시 Drawer 가 닫히는 문제 해결했습니다.
이를 해결하기 위해서는 ..`useOuterClick` 을 수정했어야 했습니다. 😭 
원래는 innerRef 를 Drawer 컴포넌트에도 붙여주면 될 거라고 생각했지만,
그럴 경우 innerRef 2개를 저장해야 하지만 하나만 저장해서 제대로 동작하지 않았습니다.
그래서 innerRef 를 Array 형식으로 변경해야했습니다.

- 클릭해도 닫히지 않는 영역이 2개 이상이어야 할 경우 ref 가 2개여야 했습니다..
- 이를 좀 더 범용적으로 사용하기 위해서, 닫히지 않는 영역의 갯수를 props 로 받고, 갯수 만큼 innerRef를 생성하여 반환하도록 했습니다. 

```ts
import { useEffect, useRef } from "react";

type CallbackType = () => void;

interface Props {
  callback: CallbackType;
  requiredRefCount?: number; // 눌러도 닫히지 않는 영역의 갯수. 디폴트는 1개 
}

function useOuterClick({ callback, requiredRefCount = 1 }: Props) {
  const callbackRef = useRef<CallbackType>();
  const innerRefArray = [...Array(requiredRefCount || 1)].map(() =>
    useRef<HTMLDivElement>(null)
  );
  callbackRef.current = callback;

  useEffect(() => {
    const handleClick = (event: MouseEvent) => {
      if (
        callbackRef.current &&
        !innerRefArray.some(
          (ref) =>
            ref.current && ref.current.contains(event.target as HTMLDivElement)
        )
      ) {
        callbackRef.current();
      }
    };

    document.addEventListener("click", handleClick);

    return () => document.removeEventListener("click", handleClick);
  }, []);

 // 최대한 이전 코드를 수정하지 않기 위해서 두개 모두 반환 하도록 하였습니다. 
  return { innerRef: innerRefArray[0], innerRefArray };
}

export default useOuterClick;

```




## 관련 이슈

- Close #524 

<br><br>
