### PR TITLE
refactor: 쿼리에서 불필요한 left outer join 삭제

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -50,7 +50,7 @@ public class ChannelSubscriptionService {
 
         validateDuplicatedSubscription(channel, member);
 
-        channelSubscriptions.save(new ChannelSubscription(channel, member, getMaxViewOrder(memberId)));
+        channelSubscriptions.save(new ChannelSubscription(channel, member, getMaxViewOrder(member)));
     }
 
     private void validateDuplicatedSubscription(final Channel channel, final Member member) {
@@ -59,8 +59,8 @@ public class ChannelSubscriptionService {
         }
     }
 
-    private int getMaxViewOrder(final Long memberId) {
-        return channelSubscriptions.findFirstByMemberIdOrderByViewOrderDesc(memberId)
+    private int getMaxViewOrder(final Member member) {
+        return channelSubscriptions.findFirstByMemberOrderByViewOrderDesc(member)
                 .map(it -> it.getViewOrder() + ORDER_NEXT)
                 .orElse(ORDER_FIRST);
     }

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -3,6 +3,7 @@ package com.pickpick.channel.domain;
 import com.pickpick.member.domain.Member;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface ChannelSubscriptionRepository extends Repository<ChannelSubscription, Long> {
@@ -11,17 +12,17 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     void saveAll(Iterable<ChannelSubscription> channelSubscriptions);
 
+    @Query("select cs from ChannelSubscription cs where cs.member.id = :memberId")
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
+    @Query("select cs from ChannelSubscription cs where cs.member.id = :memberId order by cs.viewOrder")
     List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
 
-    Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderDesc(Long memberId);
+    Optional<ChannelSubscription> findFirstByMemberOrderByViewOrderDesc(Member member);
 
     Optional<ChannelSubscription> findFirstByMemberIdOrderByViewOrderAsc(Long memberId);
 
     boolean existsByChannelAndMember(Channel channel, Member member);
-
-    void deleteAllByMemberId(Long memberId);
 
     void deleteAllByChannelAndMember(Channel channel, Member member);
 }

--- a/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
@@ -1,6 +1,7 @@
 package com.pickpick.message.domain;
 
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface BookmarkRepository extends Repository<Bookmark, Long> {
@@ -9,6 +10,7 @@ public interface BookmarkRepository extends Repository<Bookmark, Long> {
 
     Optional<Bookmark> findById(Long id);
 
+    @Query("select b from Bookmark b WHERE b.message.id = :messageId and b.member.id = :memberId")
     Optional<Bookmark> findByMessageIdAndMemberId(Long messageId, Long memberId);
 
     void deleteById(Long id);

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -3,6 +3,7 @@ package com.pickpick.message.domain;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
 public interface ReminderRepository extends Repository<Reminder, Long> {
@@ -11,6 +12,7 @@ public interface ReminderRepository extends Repository<Reminder, Long> {
 
     Optional<Reminder> findById(Long id);
 
+    @Query("select r from Reminder r WHERE r.message.id = :messageId and r.member.id = :memberId")
     Optional<Reminder> findByMessageIdAndMemberId(Long messageId, Long memberId);
 
     void deleteById(Long id);


### PR DESCRIPTION
## 요약

쿼리에서 불필요한 left outer join을 제거합니다.
<br><br>

## 작업 내용
[노션 페이지](https://www.notion.so/findByObject-vs-findByObjectId-cecf5fb30cac41e7883783e119693a4b)에 Repository 단에서 불필요한 left outer join이 일어나는 쿼리들과 해당 쿼리들을 어떻게 수정했는지, 수정하지 않았다면 왜 수정하지 않았는지에 대해서 정리해뒀습니다!

<br><br>

## 참고 사항

노션 페이지 내부에 기록한 내용인데, 
channelSubscriptionRepository의 findFirstByMemberIdOrderByViewOrderAsc(Long memberId)쿼리를 개선하지 않은 이유에 대해서 써놨는데, 연로그와 써머의 의견도 들어보고싶습니다!

그리고 각 쿼리를 개선한 것에 대해서 `이 쿼리는 이렇게 개선하는 것 보다 다른 방법이 더 좋을 것 같다!`, `이 쿼리는 굳이 개선하지 않아도 좋을 것 같다` 등 여러가지 의견 모두 환영합니다.

그리고 대부분 @Query를 이용해서 해결했는데, 이 해결방법 자체가 괜찮은지도 의견이 궁금합니다.

<br><br>

## 관련 이슈

- Close #526 

<br><br>
