### PR TITLE
test: 인수 테스트 코드 구조 변경 및 인증인가 인수테스트 리팩터링

### DIFF
--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -6,26 +6,17 @@ import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.support.DatabaseCleaner;
 import com.slack.api.methods.MethodsClient;
 import io.restassured.RestAssured;
-import io.restassured.response.ExtractableResponse;
-import io.restassured.response.Response;
-import io.restassured.specification.RequestSpecification;
 import java.time.Clock;
-import java.util.Map;
-import java.util.function.Function;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-@SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
@@ -34,7 +25,7 @@ public class AcceptanceTest {
     int port;
 
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    protected RestHandler restHandler;
 
     @SpyBean
     protected Clock clock;
@@ -45,24 +36,6 @@ public class AcceptanceTest {
     @Autowired
     private DatabaseCleaner databaseCleaner;
 
-    @Value("${log}")
-    private boolean showLog;
-
-    private ExtractableResponse<Response> request(Function<RequestSpecification, Response> function) {
-        if (showLog) {
-            RequestSpecification given = RestAssured.given().log().all();
-            return function.apply(given)
-                    .then()
-                    .log().all()
-                    .extract();
-        }
-        
-        RequestSpecification given = RestAssured.given();
-        return function.apply(given)
-                .then()
-                .extract();
-    }
-
     @BeforeEach
     public void setUp() {
         RestAssured.port = port;
@@ -71,113 +44,5 @@ public class AcceptanceTest {
     @AfterEach
     void tearDown() {
         databaseCleaner.clear();
-    }
-
-    protected ExtractableResponse<Response> post(final String uri, final Object object) {
-        return request(given -> given
-                .body(object)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> postWithCreateToken(final String uri, final Object object,
-                                                                final Long memberId) {
-        String token = createToken(memberId);
-
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .body(object)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .post(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> get(final String uri) {
-        return request(given -> given
-                .when()
-                .get(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
-        return request(given -> given
-                .queryParams(queryParams)
-                .log().all()
-                .when()
-                .get(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> getWithToken(final String uri, final String token) {
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .log().all()
-                .when()
-                .get(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId) {
-        String token = createToken(memberId);
-
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId,
-                                                               final Map<String, Object> request) {
-        String token = createToken(memberId);
-
-        return request(given -> given
-                .queryParams(request)
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object,
-                                                               final Long memberId) {
-        String token = createToken(memberId);
-
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .body(object)
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .when()
-                .put(uri)
-        );
-    }
-
-    protected ExtractableResponse<Response> deleteWithCreateToken(final String uri, final Long memberId) {
-        String token = createToken(memberId);
-
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .delete(uri)
-        );
-    }
-
-    private String createToken(final Long memberId) {
-        return jwtTokenProvider.createToken(String.valueOf(memberId));
-    }
-
-    protected void 상태코드_200_확인(final ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    protected void 상태코드_400_확인(final ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
-    }
-
-    protected void 상태코드_확인(final ExtractableResponse<Response> response, final HttpStatus httpStatus) {
-        assertThat(response.statusCode()).isEqualTo(httpStatus.value());
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -1,7 +1,5 @@
 package com.pickpick.acceptance;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.support.DatabaseCleaner;
 import com.slack.api.methods.MethodsClient;
@@ -29,6 +27,9 @@ public class AcceptanceTest {
 
     @MockBean
     protected MethodsClient slackClient;
+
+    @Autowired
+    protected JwtTokenProvider jwtTokenProvider;
 
     @Autowired
     private DatabaseCleaner databaseCleaner;

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -22,6 +22,7 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+@SuppressWarnings("NonAsciiCharacters")
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 public class AcceptanceTest {
@@ -86,6 +87,16 @@ public class AcceptanceTest {
     protected ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
         return RestAssured.given()
                 .queryParams(queryParams)
+                .log().all()
+                .when()
+                .get(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    protected ExtractableResponse<Response> getWithToken(final String uri, final String token) {
+        return RestAssured.given()
+                .header("Authorization", "Bearer " + token)
                 .log().all()
                 .when()
                 .get(uri)

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -24,9 +24,6 @@ public class AcceptanceTest {
     @LocalServerPort
     int port;
 
-    @Autowired
-    protected RestHandler restHandler;
-
     @SpyBean
     protected Clock clock;
 

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.support.DatabaseCleaner;
+import com.slack.api.methods.MethodsClient;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.time.Clock;
 import java.util.Map;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -14,6 +16,8 @@ import org.junit.jupiter.api.DisplayNameGeneration;
 import org.junit.jupiter.api.DisplayNameGenerator;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -24,8 +28,15 @@ public class AcceptanceTest {
 
     @LocalServerPort
     int port;
+
     @Autowired
     private JwtTokenProvider jwtTokenProvider;
+
+    @SpyBean
+    protected Clock clock;
+
+    @MockBean
+    protected MethodsClient slackClient;
 
     @Autowired
     private DatabaseCleaner databaseCleaner;

--- a/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
@@ -71,8 +71,8 @@ public class RestHandler {
         );
     }
 
-    public static ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object,
-                                                                   final String token) {
+    public static ExtractableResponse<Response> putWithToken(final String uri, final Object object,
+                                                             final String token) {
         return request(given -> given
                 .header("Authorization", "Bearer " + token)
                 .body(object)
@@ -82,7 +82,7 @@ public class RestHandler {
         );
     }
 
-    public static ExtractableResponse<Response> deleteWithCreateToken(final String uri, final String token) {
+    public static ExtractableResponse<Response> deleteWithToken(final String uri, final String token) {
         return request(given -> given
                 .header("Authorization", "Bearer " + token)
                 .when()

--- a/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
@@ -117,7 +117,8 @@ public class RestHandler {
         assertThat(response.statusCode()).isEqualTo(httpStatus.value());
     }
 
-    public static String 에러_코드(final ExtractableResponse<Response> response) {
-        return response.jsonPath().getObject("", ErrorResponse.class).getCode();
+    public static void 에러코드_확인(final ExtractableResponse<Response> response, final String errorCode) {
+        String responseErrorCode = response.jsonPath().getObject("", ErrorResponse.class).getCode();
+        assertThat(responseErrorCode).isEqualTo(errorCode);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
@@ -3,6 +3,7 @@ package com.pickpick.acceptance;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.auth.support.JwtTokenProvider;
+import com.pickpick.config.dto.ErrorResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -146,5 +147,9 @@ public class RestHandler {
 
     public void 상태코드_확인(final ExtractableResponse<Response> response, final HttpStatus httpStatus) {
         assertThat(response.statusCode()).isEqualTo(httpStatus.value());
+    }
+
+    public String 에러_코드(final ExtractableResponse<Response> response) {
+        return response.jsonPath().getObject("", ErrorResponse.class).getCode();
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
@@ -20,13 +20,19 @@ import org.springframework.stereotype.Component;
 @Component
 public class RestHandler {
 
+    private static JwtTokenProvider jwtTokenProvider;
+    private static boolean showLog;
+
     @Autowired
-    private JwtTokenProvider jwtTokenProvider;
+    public void setJwtTokenProvider(final JwtTokenProvider provider) {
+        jwtTokenProvider = provider;
+    }
 
-    @Value("${log}")
-    private boolean showLog;
+    public void setShowLog(@Value("${log}") boolean value) {
+        showLog = value;
+    }
 
-    public ExtractableResponse<Response> post(final String uri, final Object object) {
+    public static ExtractableResponse<Response> post(final String uri, final Object object) {
         return request(given -> given
                 .body(object)
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -35,8 +41,8 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> postWithCreateToken(final String uri, final Object object,
-                                                             final Long memberId) {
+    public static ExtractableResponse<Response> postWithCreateToken(final String uri, final Object object,
+                                                                    final Long memberId) {
         String token = createToken(memberId);
 
         return request(given -> given
@@ -48,14 +54,14 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> get(final String uri) {
+    public static ExtractableResponse<Response> get(final String uri) {
         return request(given -> given
                 .when()
                 .get(uri)
         );
     }
 
-    public ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
+    public static ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
         return request(given -> given
                 .queryParams(queryParams)
                 .log().all()
@@ -64,7 +70,7 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> getWithToken(final String uri, final String token) {
+    public static ExtractableResponse<Response> getWithToken(final String uri, final String token) {
         return request(given -> given
                 .header("Authorization", "Bearer " + token)
                 .log().all()
@@ -73,7 +79,7 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId) {
+    public static ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId) {
         String token = createToken(memberId);
 
         return request(given -> given
@@ -83,8 +89,8 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId,
-                                                            final Map<String, Object> request) {
+    public static ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId,
+                                                                   final Map<String, Object> request) {
         String token = createToken(memberId);
 
         return request(given -> given
@@ -95,8 +101,8 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object,
-                                                            final Long memberId) {
+    public static ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object,
+                                                                   final Long memberId) {
         String token = createToken(memberId);
 
         return request(given -> given
@@ -108,7 +114,7 @@ public class RestHandler {
         );
     }
 
-    public ExtractableResponse<Response> deleteWithCreateToken(final String uri, final Long memberId) {
+    public static ExtractableResponse<Response> deleteWithCreateToken(final String uri, final Long memberId) {
         String token = createToken(memberId);
 
         return request(given -> given
@@ -118,7 +124,7 @@ public class RestHandler {
         );
     }
 
-    private ExtractableResponse<Response> request(Function<RequestSpecification, Response> function) {
+    private static ExtractableResponse<Response> request(Function<RequestSpecification, Response> function) {
         if (showLog) {
             RequestSpecification given = RestAssured.given().log().all();
             return function.apply(given)
@@ -133,23 +139,23 @@ public class RestHandler {
                 .extract();
     }
 
-    private String createToken(final Long memberId) {
+    private static String createToken(final Long memberId) {
         return jwtTokenProvider.createToken(String.valueOf(memberId));
     }
 
-    public void 상태코드_200_확인(final ExtractableResponse<Response> response) {
+    public static void 상태코드_200_확인(final ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
-    public void 상태코드_400_확인(final ExtractableResponse<Response> response) {
+    public static void 상태코드_400_확인(final ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    public void 상태코드_확인(final ExtractableResponse<Response> response, final HttpStatus httpStatus) {
+    public static void 상태코드_확인(final ExtractableResponse<Response> response, final HttpStatus httpStatus) {
         assertThat(response.statusCode()).isEqualTo(httpStatus.value());
     }
 
-    public String 에러_코드(final ExtractableResponse<Response> response) {
+    public static String 에러_코드(final ExtractableResponse<Response> response) {
         return response.jsonPath().getObject("", ErrorResponse.class).getCode();
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
@@ -1,0 +1,150 @@
+package com.pickpick.acceptance;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.pickpick.auth.support.JwtTokenProvider;
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import java.util.Map;
+import java.util.function.Function;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+@SuppressWarnings("NonAsciiCharacters")
+@Component
+public class RestHandler {
+
+    @Autowired
+    private JwtTokenProvider jwtTokenProvider;
+
+    @Value("${log}")
+    private boolean showLog;
+
+    public ExtractableResponse<Response> post(final String uri, final Object object) {
+        return request(given -> given
+                .body(object)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> postWithCreateToken(final String uri, final Object object,
+                                                             final Long memberId) {
+        String token = createToken(memberId);
+
+        return request(given -> given
+                .header("Authorization", "Bearer " + token)
+                .body(object)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .post(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> get(final String uri) {
+        return request(given -> given
+                .when()
+                .get(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
+        return request(given -> given
+                .queryParams(queryParams)
+                .log().all()
+                .when()
+                .get(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> getWithToken(final String uri, final String token) {
+        return request(given -> given
+                .header("Authorization", "Bearer " + token)
+                .log().all()
+                .when()
+                .get(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId) {
+        String token = createToken(memberId);
+
+        return request(given -> given
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId,
+                                                            final Map<String, Object> request) {
+        String token = createToken(memberId);
+
+        return request(given -> given
+                .queryParams(request)
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .get(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object,
+                                                            final Long memberId) {
+        String token = createToken(memberId);
+
+        return request(given -> given
+                .header("Authorization", "Bearer " + token)
+                .body(object)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .when()
+                .put(uri)
+        );
+    }
+
+    public ExtractableResponse<Response> deleteWithCreateToken(final String uri, final Long memberId) {
+        String token = createToken(memberId);
+
+        return request(given -> given
+                .header("Authorization", "Bearer " + token)
+                .when()
+                .delete(uri)
+        );
+    }
+
+    private ExtractableResponse<Response> request(Function<RequestSpecification, Response> function) {
+        if (showLog) {
+            RequestSpecification given = RestAssured.given().log().all();
+            return function.apply(given)
+                    .then()
+                    .log().all()
+                    .extract();
+        }
+
+        RequestSpecification given = RestAssured.given();
+        return function.apply(given)
+                .then()
+                .extract();
+    }
+
+    private String createToken(final Long memberId) {
+        return jwtTokenProvider.createToken(String.valueOf(memberId));
+    }
+
+    public void 상태코드_200_확인(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public void 상태코드_400_확인(final ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
+    }
+
+    public void 상태코드_확인(final ExtractableResponse<Response> response, final HttpStatus httpStatus) {
+        assertThat(response.statusCode()).isEqualTo(httpStatus.value());
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/RestHandler.java
@@ -2,7 +2,6 @@ package com.pickpick.acceptance;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.config.dto.ErrorResponse;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
@@ -10,7 +9,6 @@ import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import java.util.Map;
 import java.util.function.Function;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -20,15 +18,10 @@ import org.springframework.stereotype.Component;
 @Component
 public class RestHandler {
 
-    private static JwtTokenProvider jwtTokenProvider;
     private static boolean showLog;
 
-    @Autowired
-    public void setJwtTokenProvider(final JwtTokenProvider provider) {
-        jwtTokenProvider = provider;
-    }
-
-    public void setShowLog(@Value("${log}") boolean value) {
+    @Value("${log}")
+    public void setShowLog(boolean value) {
         showLog = value;
     }
 
@@ -41,10 +34,8 @@ public class RestHandler {
         );
     }
 
-    public static ExtractableResponse<Response> postWithCreateToken(final String uri, final Object object,
-                                                                    final Long memberId) {
-        String token = createToken(memberId);
-
+    public static ExtractableResponse<Response> postWithToken(final String uri, final Object object,
+                                                              final String token) {
         return request(given -> given
                 .header("Authorization", "Bearer " + token)
                 .body(object)
@@ -55,44 +46,23 @@ public class RestHandler {
     }
 
     public static ExtractableResponse<Response> get(final String uri) {
-        return request(given -> given
-                .when()
-                .get(uri)
-        );
+        return get(uri, Map.of());
     }
 
     public static ExtractableResponse<Response> get(final String uri, final Map<String, Object> queryParams) {
         return request(given -> given
                 .queryParams(queryParams)
-                .log().all()
                 .when()
                 .get(uri)
         );
     }
 
     public static ExtractableResponse<Response> getWithToken(final String uri, final String token) {
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .log().all()
-                .when()
-                .get(uri)
-        );
+        return getWithToken(uri, token, Map.of());
     }
 
-    public static ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId) {
-        String token = createToken(memberId);
-
-        return request(given -> given
-                .header("Authorization", "Bearer " + token)
-                .when()
-                .get(uri)
-        );
-    }
-
-    public static ExtractableResponse<Response> getWithCreateToken(final String uri, final Long memberId,
-                                                                   final Map<String, Object> request) {
-        String token = createToken(memberId);
-
+    public static ExtractableResponse<Response> getWithToken(final String uri, final String token,
+                                                             final Map<String, Object> request) {
         return request(given -> given
                 .queryParams(request)
                 .header("Authorization", "Bearer " + token)
@@ -102,9 +72,7 @@ public class RestHandler {
     }
 
     public static ExtractableResponse<Response> putWithCreateToken(final String uri, final Object object,
-                                                                   final Long memberId) {
-        String token = createToken(memberId);
-
+                                                                   final String token) {
         return request(given -> given
                 .header("Authorization", "Bearer " + token)
                 .body(object)
@@ -114,9 +82,7 @@ public class RestHandler {
         );
     }
 
-    public static ExtractableResponse<Response> deleteWithCreateToken(final String uri, final Long memberId) {
-        String token = createToken(memberId);
-
+    public static ExtractableResponse<Response> deleteWithCreateToken(final String uri, final String token) {
         return request(given -> given
                 .header("Authorization", "Bearer " + token)
                 .when()
@@ -137,10 +103,6 @@ public class RestHandler {
         return function.apply(given)
                 .then()
                 .extract();
-    }
-
-    private static String createToken(final Long memberId) {
-        return jwtTokenProvider.createToken(String.valueOf(memberId));
     }
 
     public static void 상태코드_200_확인(final ExtractableResponse<Response> response) {

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -7,7 +7,6 @@ import static org.mockito.BDDMockito.given;
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.config.dto.ErrorResponse;
-import com.slack.api.methods.MethodsClient;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.slack.api.methods.request.users.UsersIdentityRequest;
@@ -23,7 +22,6 @@ import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/member.sql"})
@@ -38,16 +36,13 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;
 
-    @MockBean
-    private MethodsClient slackClient;
-
     @Test
     void 정상_로그인() throws SlackApiException, IOException {
         // given
         given(slackClient.oauthV2Access(any(OAuthV2AccessRequest.class)))
                 .willReturn(generateOAuthV2AccessResponse());
         given(slackClient.usersIdentity(any(UsersIdentityRequest.class)))
-                .willReturn(generateUsersIdentityResponse(MEMBER_SLACK_ID));
+                .willReturn(generateUsersIdentityResponse());
 
         // when
         ExtractableResponse<Response> response = get(LOGIN_API_URL, Map.of("code", "1234"));
@@ -65,10 +60,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         return response;
     }
 
-    private UsersIdentityResponse generateUsersIdentityResponse(final String slackId) {
+    private UsersIdentityResponse generateUsersIdentityResponse() {
         UsersIdentityResponse usersIdentityResponse = new UsersIdentityResponse();
         User user = new User();
-        user.setId(slackId);
+        user.setId(MEMBER_SLACK_ID);
         usersIdentityResponse.setUser(user);
         return usersIdentityResponse;
     }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -6,7 +6,6 @@ import static org.mockito.BDDMockito.given;
 
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.auth.support.JwtTokenProvider;
-import com.pickpick.config.dto.ErrorResponse;
 import com.slack.api.methods.SlackApiException;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
 import com.slack.api.methods.request.users.UsersIdentityRequest;
@@ -17,21 +16,22 @@ import com.slack.api.methods.response.users.UsersIdentityResponse.User;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.io.IOException;
-import java.util.Map;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayName("인증 & 인가 인수 테스트")
 public class AuthAcceptanceTest extends AcceptanceTest {
 
-    private static final String LOGIN_API_URL = "/api/slack-login";
-    private static final String CERTIFICATION_API_URL = "/api/certification";
     private static final String MEMBER_SLACK_ID = "U03MC231";
 
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;
+
+    @Autowired
+    private AuthHandler authHandler;
 
     @Test
     void 정상_로그인() throws SlackApiException, IOException {
@@ -41,32 +41,14 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         given(slackClient.usersIdentity(any(UsersIdentityRequest.class)))
                 .willReturn(generateUsersIdentityResponse());
 
-        회원가입();
+        authHandler.회원가입(MEMBER_SLACK_ID);
 
         // when
-        ExtractableResponse<Response> response = restHandler.get(LOGIN_API_URL, Map.of("code", "1234"));
+        ExtractableResponse<Response> response = authHandler.로그인("1234");
 
         // then
         restHandler.상태코드_200_확인(response);
         응답_바디에_토큰_존재(response);
-    }
-
-    private void 회원가입() {
-        Map<String, Object> request = Map.of(
-                "event", Map.of(
-                        "type", "team_join",
-                        "user", Map.of(
-                                "id", MEMBER_SLACK_ID,
-                                "profile", Map.of(
-                                        "real_name", "봄",
-                                        "display_name", "가을",
-                                        "image_48", "bom.png"
-                                )
-                        )
-                ));
-
-        ExtractableResponse<Response> response = restHandler.post("/api/event", request);
-        restHandler.상태코드_200_확인(response);
     }
 
     private OAuthV2AccessResponse generateOAuthV2AccessResponse() {
@@ -92,7 +74,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 유효한_토큰_검증() {
         // given & when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(CERTIFICATION_API_URL, 2L);
+        ExtractableResponse<Response> response = authHandler.토큰_검증(2L);
 
         // then
         restHandler.상태코드_200_확인(response);
@@ -104,11 +86,11 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = "abcde12345";
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithToken(CERTIFICATION_API_URL, invalidToken);
+        ExtractableResponse<Response> response = authHandler.토큰_검증(invalidToken);
 
         // then
         restHandler.상태코드_400_확인(response);
-        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo("INVALID_TOKEN");
+        assertThat(restHandler.에러_코드(response)).isEqualTo("INVALID_TOKEN");
     }
 
     @Test
@@ -118,7 +100,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithToken(CERTIFICATION_API_URL, invalidToken);
+        ExtractableResponse<Response> response = authHandler.토큰_검증(invalidToken);
 
         // then
         restHandler.상태코드_400_확인(response);
@@ -131,10 +113,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithToken(CERTIFICATION_API_URL, invalidToken);
+        ExtractableResponse<Response> response = authHandler.토큰_검증(invalidToken);
 
         // then
         restHandler.상태코드_400_확인(response);
-        assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo("INVALID_TOKEN");
+        assertThat(restHandler.에러_코드(response)).isEqualTo("INVALID_TOKEN");
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -30,7 +30,6 @@ import org.springframework.beans.factory.annotation.Value;
 @DisplayName("인증 & 인가 인수 테스트")
 public class AuthAcceptanceTest extends AcceptanceTest {
 
-
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;
 
@@ -76,8 +75,11 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 유효한_토큰_검증() {
-        // given & when
-        ExtractableResponse<Response> response = 토큰_검증(2L);
+        // given
+        String token = jwtTokenProvider.createToken("2");
+
+        // when
+        ExtractableResponse<Response> response = 토큰_검증(token);
 
         // then
         상태코드_200_확인(response);

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -2,7 +2,7 @@ package com.pickpick.acceptance.auth;
 
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
-import static com.pickpick.acceptance.RestHandler.에러_코드;
+import static com.pickpick.acceptance.RestHandler.에러코드_확인;
 import static com.pickpick.acceptance.auth.AuthRestHandler.로그인;
 import static com.pickpick.acceptance.auth.AuthRestHandler.토큰_검증;
 import static com.pickpick.acceptance.auth.AuthRestHandler.회원가입;
@@ -95,7 +95,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         // then
         상태코드_400_확인(response);
-        assertThat(에러_코드(response)).isEqualTo("INVALID_TOKEN");
+        에러코드_확인(response, "INVALID_TOKEN");
     }
 
     @Test
@@ -122,6 +122,6 @@ public class AuthAcceptanceTest extends AcceptanceTest {
 
         // then
         상태코드_400_확인(response);
-        assertThat(에러_코드(response)).isEqualTo("INVALID_TOKEN");
+        에러코드_확인(response, "INVALID_TOKEN");
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -1,5 +1,11 @@
 package com.pickpick.acceptance.auth;
 
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
+import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
+import static com.pickpick.acceptance.RestHandler.에러_코드;
+import static com.pickpick.acceptance.auth.AuthRestHandler.로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.토큰_검증;
+import static com.pickpick.acceptance.auth.AuthRestHandler.회원가입;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
@@ -18,36 +24,33 @@ import io.restassured.response.Response;
 import java.io.IOException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayName("인증 & 인가 인수 테스트")
 public class AuthAcceptanceTest extends AcceptanceTest {
 
-    private static final String MEMBER_SLACK_ID = "U03MC231";
 
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;
 
-    @Autowired
-    private AuthHandler authHandler;
-
     @Test
     void 정상_로그인() throws SlackApiException, IOException {
         // given
+        String memberSlackId = "U03MC231";
+
         given(slackClient.oauthV2Access(any(OAuthV2AccessRequest.class)))
                 .willReturn(generateOAuthV2AccessResponse());
         given(slackClient.usersIdentity(any(UsersIdentityRequest.class)))
-                .willReturn(generateUsersIdentityResponse());
+                .willReturn(generateUsersIdentityResponse(memberSlackId));
 
-        authHandler.회원가입(MEMBER_SLACK_ID);
+        회원가입(memberSlackId);
 
         // when
-        ExtractableResponse<Response> response = authHandler.로그인("1234");
+        ExtractableResponse<Response> response = 로그인("1234");
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         응답_바디에_토큰_존재(response);
     }
 
@@ -59,10 +62,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         return response;
     }
 
-    private UsersIdentityResponse generateUsersIdentityResponse() {
+    private UsersIdentityResponse generateUsersIdentityResponse(final String slackId) {
         UsersIdentityResponse usersIdentityResponse = new UsersIdentityResponse();
         User user = new User();
-        user.setId(MEMBER_SLACK_ID);
+        user.setId(slackId);
         usersIdentityResponse.setUser(user);
         return usersIdentityResponse;
     }
@@ -74,10 +77,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 유효한_토큰_검증() {
         // given & when
-        ExtractableResponse<Response> response = authHandler.토큰_검증(2L);
+        ExtractableResponse<Response> response = 토큰_검증(2L);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
@@ -86,11 +89,11 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = "abcde12345";
 
         // when
-        ExtractableResponse<Response> response = authHandler.토큰_검증(invalidToken);
+        ExtractableResponse<Response> response = 토큰_검증(invalidToken);
 
         // then
-        restHandler.상태코드_400_확인(response);
-        assertThat(restHandler.에러_코드(response)).isEqualTo("INVALID_TOKEN");
+        상태코드_400_확인(response);
+        assertThat(에러_코드(response)).isEqualTo("INVALID_TOKEN");
     }
 
     @Test
@@ -100,10 +103,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = authHandler.토큰_검증(invalidToken);
+        ExtractableResponse<Response> response = 토큰_검증(invalidToken);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
     }
 
     @Test
@@ -113,10 +116,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = authHandler.토큰_검증(invalidToken);
+        ExtractableResponse<Response> response = 토큰_검증(invalidToken);
 
         // then
-        restHandler.상태코드_400_확인(response);
-        assertThat(restHandler.에러_코드(response)).isEqualTo("INVALID_TOKEN");
+        상태코드_400_확인(response);
+        assertThat(에러_코드(response)).isEqualTo("INVALID_TOKEN");
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -53,26 +53,6 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         응답_바디에_토큰_존재(response);
     }
 
-    private OAuthV2AccessResponse generateOAuthV2AccessResponse() {
-        OAuthV2AccessResponse response = new OAuthV2AccessResponse();
-        AuthedUser authedUser = new AuthedUser();
-        authedUser.setAccessToken("token");
-        response.setAuthedUser(authedUser);
-        return response;
-    }
-
-    private UsersIdentityResponse generateUsersIdentityResponse(final String slackId) {
-        UsersIdentityResponse usersIdentityResponse = new UsersIdentityResponse();
-        User user = new User();
-        user.setId(slackId);
-        usersIdentityResponse.setUser(user);
-        return usersIdentityResponse;
-    }
-
-    private void 응답_바디에_토큰_존재(final ExtractableResponse<Response> response) {
-        assertThat(response.jsonPath().getString("token")).isNotBlank();
-    }
-
     @Test
     void 유효한_토큰_검증() {
         // given
@@ -123,5 +103,25 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         // then
         상태코드_400_확인(response);
         에러코드_확인(response, "INVALID_TOKEN");
+    }
+
+    private OAuthV2AccessResponse generateOAuthV2AccessResponse() {
+        OAuthV2AccessResponse response = new OAuthV2AccessResponse();
+        AuthedUser authedUser = new AuthedUser();
+        authedUser.setAccessToken("token");
+        response.setAuthedUser(authedUser);
+        return response;
+    }
+
+    private UsersIdentityResponse generateUsersIdentityResponse(final String slackId) {
+        UsersIdentityResponse usersIdentityResponse = new UsersIdentityResponse();
+        User user = new User();
+        user.setId(slackId);
+        usersIdentityResponse.setUser(user);
+        return usersIdentityResponse;
+    }
+
+    private void 응답_바디에_토큰_존재(final ExtractableResponse<Response> response) {
+        assertThat(response.jsonPath().getString("token")).isNotBlank();
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -86,7 +86,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 유효하지_않은_토큰_검증() {
+    void 유효하지_않은_토큰_검증_시_예외_처리() {
         // given
         String invalidToken = "abcde12345";
 
@@ -99,7 +99,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 만료된_토큰_검증() {
+    void 만료된_토큰_검증_시_예외_처리() {
         // given
         JwtTokenProvider jwtTokenProvider = new JwtTokenProvider(secretKey, 0);
         String invalidToken = jwtTokenProvider.createToken("1");
@@ -112,7 +112,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     }
 
     @Test
-    void 시그니처가_다른_토큰_검증() {
+    void 시그니처가_다른_토큰_검증_시_예외_처리() {
         // given
         JwtTokenProvider jwtTokenProvider = new JwtTokenProvider("other" + secretKey, 60000);
         String invalidToken = jwtTokenProvider.createToken("1");

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -44,10 +44,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         회원가입();
 
         // when
-        ExtractableResponse<Response> response = get(LOGIN_API_URL, Map.of("code", "1234"));
+        ExtractableResponse<Response> response = restHandler.get(LOGIN_API_URL, Map.of("code", "1234"));
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         응답_바디에_토큰_존재(response);
     }
 
@@ -65,8 +65,8 @@ public class AuthAcceptanceTest extends AcceptanceTest {
                         )
                 ));
 
-        ExtractableResponse<Response> response = post("/api/event", request);
-        상태코드_200_확인(response);
+        ExtractableResponse<Response> response = restHandler.post("/api/event", request);
+        restHandler.상태코드_200_확인(response);
     }
 
     private OAuthV2AccessResponse generateOAuthV2AccessResponse() {
@@ -92,10 +92,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @Test
     void 유효한_토큰_검증() {
         // given & when
-        ExtractableResponse<Response> response = getWithCreateToken(CERTIFICATION_API_URL, 2L);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(CERTIFICATION_API_URL, 2L);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
@@ -104,10 +104,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = "abcde12345";
 
         // when
-        ExtractableResponse<Response> response = getWithToken(CERTIFICATION_API_URL, invalidToken);
+        ExtractableResponse<Response> response = restHandler.getWithToken(CERTIFICATION_API_URL, invalidToken);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo("INVALID_TOKEN");
     }
 
@@ -118,10 +118,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithToken(CERTIFICATION_API_URL, invalidToken);
+        ExtractableResponse<Response> response = restHandler.getWithToken(CERTIFICATION_API_URL, invalidToken);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
     }
 
     @Test
@@ -131,10 +131,10 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         String invalidToken = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithToken(CERTIFICATION_API_URL, invalidToken);
+        ExtractableResponse<Response> response = restHandler.getWithToken(CERTIFICATION_API_URL, invalidToken);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo("INVALID_TOKEN");
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthHandler.java
@@ -1,0 +1,51 @@
+package com.pickpick.acceptance.auth;
+
+import com.pickpick.acceptance.RestHandler;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@SuppressWarnings("NonAsciiCharacters")
+@Component
+public class AuthHandler {
+
+    private static final String LOGIN_API_URL = "/api/slack-login";
+    private static final String CERTIFICATION_API_URL = "/api/certification";
+    private static final String SLACK_EVENT_API_URL = "/api/event";
+
+    @Autowired
+    private RestHandler restHandler;
+
+    public void 회원가입(final String slackId) {
+        Map<String, Object> request = Map.of(
+                "event", Map.of(
+                        "type", "team_join",
+                        "user", Map.of(
+                                "id", slackId,
+                                "profile", Map.of(
+                                        "real_name", "봄",
+                                        "display_name", "가을",
+                                        "image_48", "bom.png"
+                                )
+                        )
+                ));
+
+        ExtractableResponse<Response> response = restHandler.post(SLACK_EVENT_API_URL, request);
+        restHandler.상태코드_200_확인(response);
+    }
+
+    public ExtractableResponse<Response> 로그인(final String code) {
+        Map<String, Object> request = Map.of("code", code);
+        return restHandler.get(LOGIN_API_URL, request);
+    }
+
+    public ExtractableResponse<Response> 토큰_검증(final long memberId) {
+        return restHandler.getWithCreateToken(CERTIFICATION_API_URL, memberId);
+    }
+
+    public ExtractableResponse<Response> 토큰_검증(final String token) {
+        return restHandler.getWithToken(CERTIFICATION_API_URL, token);
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
@@ -1,24 +1,23 @@
 package com.pickpick.acceptance.auth;
 
-import com.pickpick.acceptance.RestHandler;
+import static com.pickpick.acceptance.RestHandler.get;
+import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.getWithToken;
+import static com.pickpick.acceptance.RestHandler.post;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
+
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.Map;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.stereotype.Component;
 
 @SuppressWarnings("NonAsciiCharacters")
-@Component
-public class AuthHandler {
+public class AuthRestHandler {
 
     private static final String LOGIN_API_URL = "/api/slack-login";
     private static final String CERTIFICATION_API_URL = "/api/certification";
     private static final String SLACK_EVENT_API_URL = "/api/event";
 
-    @Autowired
-    private RestHandler restHandler;
-
-    public void 회원가입(final String slackId) {
+    public static void 회원가입(final String slackId) {
         Map<String, Object> request = Map.of(
                 "event", Map.of(
                         "type", "team_join",
@@ -32,20 +31,20 @@ public class AuthHandler {
                         )
                 ));
 
-        ExtractableResponse<Response> response = restHandler.post(SLACK_EVENT_API_URL, request);
-        restHandler.상태코드_200_확인(response);
+        ExtractableResponse<Response> response = post(SLACK_EVENT_API_URL, request);
+        상태코드_200_확인(response);
     }
 
-    public ExtractableResponse<Response> 로그인(final String code) {
+    public static ExtractableResponse<Response> 로그인(final String code) {
         Map<String, Object> request = Map.of("code", code);
-        return restHandler.get(LOGIN_API_URL, request);
+        return get(LOGIN_API_URL, request);
     }
 
-    public ExtractableResponse<Response> 토큰_검증(final long memberId) {
-        return restHandler.getWithCreateToken(CERTIFICATION_API_URL, memberId);
+    public static ExtractableResponse<Response> 토큰_검증(final long memberId) {
+        return getWithCreateToken(CERTIFICATION_API_URL, memberId);
     }
 
-    public ExtractableResponse<Response> 토큰_검증(final String token) {
-        return restHandler.getWithToken(CERTIFICATION_API_URL, token);
+    public static ExtractableResponse<Response> 토큰_검증(final String token) {
+        return getWithToken(CERTIFICATION_API_URL, token);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
@@ -3,7 +3,6 @@ package com.pickpick.acceptance.auth;
 import static com.pickpick.acceptance.RestHandler.get;
 import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.post;
-import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
@@ -30,8 +29,7 @@ public class AuthRestHandler {
                         )
                 ));
 
-        ExtractableResponse<Response> response = post(SLACK_EVENT_API_URL, request);
-        상태코드_200_확인(response);
+        post(SLACK_EVENT_API_URL, request);
     }
 
     public static ExtractableResponse<Response> 로그인(final String code) {

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
@@ -1,7 +1,6 @@
 package com.pickpick.acceptance.auth;
 
 import static com.pickpick.acceptance.RestHandler.get;
-import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
 import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.post;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
@@ -38,10 +37,6 @@ public class AuthRestHandler {
     public static ExtractableResponse<Response> 로그인(final String code) {
         Map<String, Object> request = Map.of("code", code);
         return get(LOGIN_API_URL, request);
-    }
-
-    public static ExtractableResponse<Response> 토큰_검증(final long memberId) {
-        return getWithCreateToken(CERTIFICATION_API_URL, memberId);
     }
 
     public static ExtractableResponse<Response> 토큰_검증(final String token) {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -1,18 +1,14 @@
 package com.pickpick.acceptance.channel;
 
-import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
-import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
-import static com.pickpick.acceptance.RestHandler.postWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.channel.ui.dto.ChannelResponse;
-import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import java.util.List;
-import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.jdbc.Sql;
@@ -22,41 +18,20 @@ import org.springframework.test.context.jdbc.Sql;
 @SuppressWarnings("NonAsciiCharacters")
 public class ChannelAcceptanceTest extends AcceptanceTest {
 
-    protected static final String CHANNEL_SUBSCRIPTION_API_URL = "/api/channel-subscription";
-
     @Test
     void 유저_전체_채널_목록_조회() {
         // given & when
         ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
 
         // then
+        List<ChannelResponse> channels = response.jsonPath().getList("channels.", ChannelResponse.class);
+        
         상태코드_200_확인(response);
-        조회된_채널_목록_개수_확인(response, 6);
+        assertThat(channels).hasSize(6);
     }
 
     protected ExtractableResponse<Response> 유저_전체_채널_목록_조회_요청() {
-        return getWithCreateToken("/api/channels", 2L);
-    }
-
-    protected List<Long> 구독중이_아닌_채널_id_목록_추출(final ExtractableResponse<Response> response) {
-        return response.jsonPath()
-                .getList("channels.", ChannelResponse.class)
-                .stream()
-                .filter(it -> !it.isSubscribed())
-                .map(ChannelResponse::getId)
-                .collect(Collectors.toList());
-    }
-
-    protected ExtractableResponse<Response> 구독_요청(final Long channelId) {
-        ChannelSubscriptionRequest channelSubscriptionRequest = new ChannelSubscriptionRequest(channelId);
-        return postWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, channelSubscriptionRequest, 2L);
-    }
-
-    protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, 2L);
-    }
-
-    private void 조회된_채널_목록_개수_확인(final ExtractableResponse<Response> response, final int expectedSize) {
-        assertThat(response.jsonPath().getList("channels.", ChannelResponse.class)).hasSize(expectedSize);
+        String token = jwtTokenProvider.createToken("2");
+        return getWithToken("/api/channels", token);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -1,5 +1,9 @@
 package com.pickpick.acceptance.channel;
 
+import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.postWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.acceptance.AcceptanceTest;
@@ -26,12 +30,12 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         조회된_채널_목록_개수_확인(response, 6);
     }
 
     protected ExtractableResponse<Response> 유저_전체_채널_목록_조회_요청() {
-        return restHandler.getWithCreateToken("/api/channels", 2L);
+        return getWithCreateToken("/api/channels", 2L);
     }
 
     protected List<Long> 구독중이_아닌_채널_id_목록_추출(final ExtractableResponse<Response> response) {
@@ -45,11 +49,11 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
 
     protected ExtractableResponse<Response> 구독_요청(final Long channelId) {
         ChannelSubscriptionRequest channelSubscriptionRequest = new ChannelSubscriptionRequest(channelId);
-        return restHandler.postWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, channelSubscriptionRequest, 2L);
+        return postWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, channelSubscriptionRequest, 2L);
     }
 
     protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return restHandler.deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, 2L);
+        return deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, 2L);
     }
 
     private void 조회된_채널_목록_개수_확인(final ExtractableResponse<Response> response, final int expectedSize) {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -26,12 +26,12 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         조회된_채널_목록_개수_확인(response, 6);
     }
 
     protected ExtractableResponse<Response> 유저_전체_채널_목록_조회_요청() {
-        return getWithCreateToken("/api/channels", 2L);
+        return restHandler.getWithCreateToken("/api/channels", 2L);
     }
 
     protected List<Long> 구독중이_아닌_채널_id_목록_추출(final ExtractableResponse<Response> response) {
@@ -45,11 +45,11 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
 
     protected ExtractableResponse<Response> 구독_요청(final Long channelId) {
         ChannelSubscriptionRequest channelSubscriptionRequest = new ChannelSubscriptionRequest(channelId);
-        return postWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, channelSubscriptionRequest, 2L);
+        return restHandler.postWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, channelSubscriptionRequest, 2L);
     }
 
     protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, 2L);
+        return restHandler.deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, 2L);
     }
 
     private void 조회된_채널_목록_개수_확인(final ExtractableResponse<Response> response, final int expectedSize) {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -30,41 +30,6 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
         조회된_채널_목록_개수_확인(response, 6);
     }
 
-    @Test
-    void 채널_구독() {
-        // given
-        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
-        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
-        Long channelIdToSubscribe = unsubscribedChannelIds.get(0);
-
-        // when
-        ExtractableResponse<Response> subscriptionResponse = 구독_요청(channelIdToSubscribe);
-
-        // then
-        상태코드_200_확인(subscriptionResponse);
-        채널_구독_완료_확인(channelIdToSubscribe);
-    }
-
-    @Test
-    void 채널_구독_취소() {
-        // given
-        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
-        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
-
-        Long channelIdToSubscribe = unsubscribedChannelIds.get(0);
-        Long channelIdToUnSubscribe = unsubscribedChannelIds.get(1);
-
-        구독_요청(channelIdToSubscribe);
-        구독_요청(channelIdToUnSubscribe);
-
-        // when
-        ExtractableResponse<Response> unsubscribeResponse = 구독_취소_요청(channelIdToUnSubscribe);
-
-        // then
-        상태코드_200_확인(unsubscribeResponse);
-        채널_구독_취소_확인(channelIdToUnSubscribe);
-    }
-
     protected ExtractableResponse<Response> 유저_전체_채널_목록_조회_요청() {
         return getWithCreateToken("/api/channels", 2L);
     }
@@ -85,20 +50,6 @@ public class ChannelAcceptanceTest extends AcceptanceTest {
 
     protected ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
         return deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, 2L);
-    }
-
-    private void 채널_구독_완료_확인(final Long channelIdToSubscribe) {
-        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
-        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
-
-        assertThat(unsubscribedChannelIds).doesNotContain(channelIdToSubscribe);
-    }
-
-    private void 채널_구독_취소_확인(final Long channelIdToUnSubscribe) {
-        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
-        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
-
-        assertThat(unsubscribedChannelIds).contains(channelIdToUnSubscribe);
     }
 
     private void 조회된_채널_목록_개수_확인(final ExtractableResponse<Response> response, final int expectedSize) {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -1,9 +1,9 @@
 package com.pickpick.acceptance.channel;
 
-import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.deleteWithToken;
 import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.postWithToken;
-import static com.pickpick.acceptance.RestHandler.putWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.putWithToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -54,7 +54,6 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         구독_요청(channelIdToSubscribe1);
         구독_요청(channelIdToSubscribe2);
     }
-
 
     @Test
     void 채널_구독() {
@@ -246,7 +245,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
     }
 
     private ExtractableResponse<Response> 구독_채널_순서_변경_요청(final List<ChannelOrderRequest> request) {
-        return putWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, request, token);
+        return putWithToken(CHANNEL_SUBSCRIPTION_API_URL, request, token);
     }
 
     private ExtractableResponse<Response> 올바른_구독_채널_순서_변경_요청() {
@@ -273,6 +272,6 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
     }
 
     private ExtractableResponse<Response> 구독_취소_요청(final Long channelId) {
-        return deleteWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, token);
+        return deleteWithToken(CHANNEL_SUBSCRIPTION_API_URL + "?channelId=" + channelId, token);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -1,5 +1,9 @@
 package com.pickpick.acceptance.channel;
 
+import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.putWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
+import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -48,7 +52,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> subscriptionResponse = 구독_요청(channelIdToSubscribe);
 
         // then
-        restHandler.상태코드_200_확인(subscriptionResponse);
+        상태코드_200_확인(subscriptionResponse);
         채널_구독_완료_확인(channelIdToSubscribe);
     }
 
@@ -75,7 +79,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> unsubscribeResponse = 구독_취소_요청(channelIdToUnSubscribe);
 
         // then
-        restHandler.상태코드_200_확인(unsubscribeResponse);
+        상태코드_200_확인(unsubscribeResponse);
         채널_구독_취소_확인(channelIdToUnSubscribe);
     }
 
@@ -92,7 +96,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 유저_구독_채널_목록_조회_요청();
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         구독이_올바른_순서로_조회됨(response, channelIdToSubscribe1, channelIdToSubscribe2);
     }
 
@@ -102,7 +106,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 올바른_구독_채널_순서_변경_요청();
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
 
         ExtractableResponse<Response> subscriptionResponse = 유저_구독_채널_목록_조회_요청();
         구독이_올바른_순서로_조회됨(subscriptionResponse, channelIdToSubscribe2, channelIdToSubscribe1);
@@ -121,7 +125,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_INVALID_ORDER");
     }
@@ -138,7 +142,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_DUPLICATE");
     }
@@ -157,7 +161,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_NOT_EXIST");
     }
@@ -173,7 +177,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_NOT_EXIST");
     }
@@ -184,7 +188,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_요청(channelIdToSubscribe1);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_DUPLICATE");
     }
@@ -198,14 +202,14 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_취소_요청(channelIdToSubscribe1);
 
         // then
-        restHandler.상태코드_400_확인(response);
+        상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_NOT_EXIST");
     }
 
 
     private ExtractableResponse<Response> 유저_구독_채널_목록_조회_요청() {
-        return restHandler.getWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, 2L);
+        return getWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, 2L);
     }
 
     private void 구독이_올바른_순서로_조회됨(
@@ -226,7 +230,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
     }
 
     private ExtractableResponse<Response> 구독_채널_순서_변경_요청(final List<ChannelOrderRequest> request) {
-        return restHandler.putWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, request, 2L);
+        return putWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, request, 2L);
     }
 
     private ExtractableResponse<Response> 올바른_구독_채널_순서_변경_요청() {

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -36,6 +36,56 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         구독_요청(channelIdToSubscribe2);
     }
 
+
+    @Test
+    void 채널_구독() {
+        // given
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+        Long channelIdToSubscribe = unsubscribedChannelIds.get(0);
+
+        // when
+        ExtractableResponse<Response> subscriptionResponse = 구독_요청(channelIdToSubscribe);
+
+        // then
+        상태코드_200_확인(subscriptionResponse);
+        채널_구독_완료_확인(channelIdToSubscribe);
+    }
+
+    private void 채널_구독_완료_확인(final Long channelIdToSubscribe) {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        assertThat(unsubscribedChannelIds).doesNotContain(channelIdToSubscribe);
+    }
+
+    @Test
+    void 채널_구독_취소() {
+        // given
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        Long channelIdToSubscribe = unsubscribedChannelIds.get(0);
+        Long channelIdToUnSubscribe = unsubscribedChannelIds.get(1);
+
+        구독_요청(channelIdToSubscribe);
+        구독_요청(channelIdToUnSubscribe);
+
+        // when
+        ExtractableResponse<Response> unsubscribeResponse = 구독_취소_요청(channelIdToUnSubscribe);
+
+        // then
+        상태코드_200_확인(unsubscribeResponse);
+        채널_구독_취소_확인(channelIdToUnSubscribe);
+    }
+
+    private void 채널_구독_취소_확인(final Long channelIdToUnSubscribe) {
+        ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
+        List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
+
+        assertThat(unsubscribedChannelIds).contains(channelIdToUnSubscribe);
+    }
+
     @Test
     void 채널_구독_조회() {
         // given & when

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -75,6 +75,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 유저_전체_채널_목록_조회_요청();
         List<Long> unsubscribedChannelIds = 구독중이_아닌_채널_id_목록_추출(response);
 
+        assertThat(unsubscribedChannelIds).isNotEmpty();
         assertThat(unsubscribedChannelIds).doesNotContain(channelIdToSubscribe);
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -48,7 +48,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> subscriptionResponse = 구독_요청(channelIdToSubscribe);
 
         // then
-        상태코드_200_확인(subscriptionResponse);
+        restHandler.상태코드_200_확인(subscriptionResponse);
         채널_구독_완료_확인(channelIdToSubscribe);
     }
 
@@ -75,7 +75,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> unsubscribeResponse = 구독_취소_요청(channelIdToUnSubscribe);
 
         // then
-        상태코드_200_확인(unsubscribeResponse);
+        restHandler.상태코드_200_확인(unsubscribeResponse);
         채널_구독_취소_확인(channelIdToUnSubscribe);
     }
 
@@ -92,7 +92,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 유저_구독_채널_목록_조회_요청();
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         구독이_올바른_순서로_조회됨(response, channelIdToSubscribe1, channelIdToSubscribe2);
     }
 
@@ -102,7 +102,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 올바른_구독_채널_순서_변경_요청();
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
 
         ExtractableResponse<Response> subscriptionResponse = 유저_구독_채널_목록_조회_요청();
         구독이_올바른_순서로_조회됨(subscriptionResponse, channelIdToSubscribe2, channelIdToSubscribe1);
@@ -121,7 +121,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_INVALID_ORDER");
     }
@@ -138,7 +138,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_DUPLICATE");
     }
@@ -157,7 +157,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_NOT_EXIST");
     }
@@ -173,7 +173,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_채널_순서_변경_요청(request);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_NOT_EXIST");
     }
@@ -184,7 +184,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_요청(channelIdToSubscribe1);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_DUPLICATE");
     }
@@ -198,14 +198,14 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
         ExtractableResponse<Response> response = 구독_취소_요청(channelIdToSubscribe1);
 
         // then
-        상태코드_400_확인(response);
+        restHandler.상태코드_400_확인(response);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "SUBSCRIPTION_NOT_EXIST");
     }
 
 
     private ExtractableResponse<Response> 유저_구독_채널_목록_조회_요청() {
-        return getWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, 2L);
+        return restHandler.getWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, 2L);
     }
 
     private void 구독이_올바른_순서로_조회됨(
@@ -226,7 +226,7 @@ class ChannelSubscriptionAcceptanceTest extends ChannelAcceptanceTest {
     }
 
     private ExtractableResponse<Response> 구독_채널_순서_변경_요청(final List<ChannelOrderRequest> request) {
-        return putWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, request, 2L);
+        return restHandler.putWithCreateToken(CHANNEL_SUBSCRIPTION_API_URL, request, 2L);
     }
 
     private ExtractableResponse<Response> 올바른_구독_채널_순서_변경_요청() {

--- a/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
@@ -1,5 +1,7 @@
 package com.pickpick.acceptance.member;
 
+import static com.pickpick.acceptance.RestHandler.post;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -33,7 +35,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         Map<String, Object> teamJoinEvent = createTeamJoinEvent("진짜이름", "표시이름", "https://somebody.png");
 
         // when
-        ExtractableResponse<Response> teamJoinEventResponse = restHandler.post(SLACK_EVENT_API_URL, teamJoinEvent);
+        ExtractableResponse<Response> teamJoinEventResponse = post(SLACK_EVENT_API_URL, teamJoinEvent);
         List<Member> 신규_참여_후_전체_멤버 = members.findAll();
         int 신규_참여_후_멤버_수 = 신규_참여_후_전체_멤버.size();
         Optional<Member> 신규_참여_멤버 = 신규_참여_후_전체_멤버.stream()
@@ -41,7 +43,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-                () -> restHandler.상태코드_200_확인(teamJoinEventResponse),
+                () -> 상태코드_200_확인(teamJoinEventResponse),
                 () -> assertThat(신규_참여_전_멤버_수 + 1).isEqualTo(신규_참여_후_멤버_수),
                 () -> assertThat(신규_참여_멤버).isPresent(),
                 () -> assertThat(신규_참여_멤버.get().getSlackId()).isEqualTo(SLACK_ID)

--- a/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/member/MemberAcceptanceTest.java
@@ -33,7 +33,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         Map<String, Object> teamJoinEvent = createTeamJoinEvent("진짜이름", "표시이름", "https://somebody.png");
 
         // when
-        ExtractableResponse<Response> teamJoinEventResponse = post(SLACK_EVENT_API_URL, teamJoinEvent);
+        ExtractableResponse<Response> teamJoinEventResponse = restHandler.post(SLACK_EVENT_API_URL, teamJoinEvent);
         List<Member> 신규_참여_후_전체_멤버 = members.findAll();
         int 신규_참여_후_멤버_수 = 신규_참여_후_전체_멤버.size();
         Optional<Member> 신규_참여_멤버 = 신규_참여_후_전체_멤버.stream()
@@ -41,7 +41,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
         // then
         assertAll(
-                () -> 상태코드_200_확인(teamJoinEventResponse),
+                () -> restHandler.상태코드_200_확인(teamJoinEventResponse),
                 () -> assertThat(신규_참여_전_멤버_수 + 1).isEqualTo(신규_참여_후_멤버_수),
                 () -> assertThat(신규_참여_멤버).isPresent(),
                 () -> assertThat(신규_참여_멤버.get().getSlackId()).isEqualTo(SLACK_ID)

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -1,5 +1,9 @@
 package com.pickpick.acceptance.message;
 
+import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.postWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.상태코드_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.acceptance.AcceptanceTest;
@@ -26,11 +30,11 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
     @Test
     void 북마크_생성() {
         // given & when
-        ExtractableResponse<Response> response = restHandler.postWithCreateToken(BOOKMARK_API_URL,
+        ExtractableResponse<Response> response = postWithCreateToken(BOOKMARK_API_URL,
                 Map.of("messageId", 1), 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.CREATED);
+        상태코드_확인(response, HttpStatus.CREATED);
     }
 
     @Test
@@ -41,10 +45,10 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(BOOKMARK_API_URL, 2L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 2L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
         assertThat(bookmarkResponses.hasPast()).isEqualTo(expectedHasPast);
@@ -60,10 +64,10 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = true;
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(BOOKMARK_API_URL, 1L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 1L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
         assertThat(bookmarkResponses.hasPast()).isEqualTo(expectedHasPast);
@@ -83,12 +87,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithCreateToken(
                 BOOKMARK_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.NO_CONTENT);
+        상태코드_확인(response, HttpStatus.NO_CONTENT);
     }
 
     @Test
@@ -97,12 +101,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithCreateToken(
                 BOOKMARK_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        상태코드_확인(response, HttpStatus.BAD_REQUEST);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "BOOKMARK_DELETE_FAILURE");
     }

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -26,10 +26,11 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
     @Test
     void 북마크_생성() {
         // given & when
-        ExtractableResponse<Response> response = postWithCreateToken(BOOKMARK_API_URL, Map.of("messageId", 1), 1L);
+        ExtractableResponse<Response> response = restHandler.postWithCreateToken(BOOKMARK_API_URL,
+                Map.of("messageId", 1), 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.CREATED);
+        restHandler.상태코드_확인(response, HttpStatus.CREATED);
     }
 
     @Test
@@ -40,10 +41,10 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 2L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(BOOKMARK_API_URL, 2L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
         assertThat(bookmarkResponses.hasPast()).isEqualTo(expectedHasPast);
@@ -59,10 +60,10 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = true;
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 1L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(BOOKMARK_API_URL, 1L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         BookmarkResponses bookmarkResponses = response.jsonPath().getObject("", BookmarkResponses.class);
         assertThat(bookmarkResponses.hasPast()).isEqualTo(expectedHasPast);
@@ -82,11 +83,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId,
+        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+                BOOKMARK_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.NO_CONTENT);
+        restHandler.상태코드_확인(response, HttpStatus.NO_CONTENT);
     }
 
     @Test
@@ -95,11 +97,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(BOOKMARK_API_URL + "?messageId=" + messageId,
+        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+                BOOKMARK_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        restHandler.상태코드_확인(response, HttpStatus.BAD_REQUEST);
         assertThat(response.jsonPath().getObject("", ErrorResponse.class).getCode()).isEqualTo(
                 "BOOKMARK_DELETE_FAILURE");
     }

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -1,6 +1,6 @@
 package com.pickpick.acceptance.message;
 
-import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.deleteWithToken;
 import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.postWithToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_확인;
@@ -93,7 +93,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithToken(
                 BOOKMARK_API_URL + "?messageId=" + messageId,
                 token);
 
@@ -108,7 +108,7 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithToken(
                 BOOKMARK_API_URL + "?messageId=" + messageId,
                 token);
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -1,8 +1,8 @@
 package com.pickpick.acceptance.message;
 
 import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
-import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
-import static com.pickpick.acceptance.RestHandler.postWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.getWithToken;
+import static com.pickpick.acceptance.RestHandler.postWithToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,9 +29,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
 
     @Test
     void 북마크_생성() {
-        // given & when
-        ExtractableResponse<Response> response = postWithCreateToken(BOOKMARK_API_URL,
-                Map.of("messageId", 1), 1L);
+        // given
+        String token = jwtTokenProvider.createToken("1");
+
+        // when
+        ExtractableResponse<Response> response = postWithToken(BOOKMARK_API_URL,
+                Map.of("messageId", 1), token);
 
         // then
         상태코드_확인(response, HttpStatus.CREATED);
@@ -43,9 +46,10 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("bookmarkId", "");
         List<Long> expectedIds = List.of(1L);
         boolean expectedHasPast = false;
+        String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 2L, request);
+        ExtractableResponse<Response> response = getWithToken(BOOKMARK_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -62,9 +66,10 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
         List<Long> expectedIds = List.of(22L, 21L, 20L, 19L, 18L, 17L, 16L, 15L, 14L, 13L, 12L, 11L, 10L, 9L, 8L, 7L,
                 6L, 5L, 4L, 3L);
         boolean expectedHasPast = true;
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(BOOKMARK_API_URL, 1L, request);
+        ExtractableResponse<Response> response = getWithToken(BOOKMARK_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -85,11 +90,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
     void 북마크_정상_삭제() {
         // given
         long messageId = 2L;
+        String token = jwtTokenProvider.createToken("1");
 
         // when
         ExtractableResponse<Response> response = deleteWithCreateToken(
                 BOOKMARK_API_URL + "?messageId=" + messageId,
-                1L);
+                token);
 
         // then
         상태코드_확인(response, HttpStatus.NO_CONTENT);
@@ -99,11 +105,12 @@ public class BookmarkAcceptanceTest extends AcceptanceTest {
     void 사용자에게_존재하지_않는_북마크_삭제() {
         // given
         long messageId = 1L;
+        String token = jwtTokenProvider.createToken("1");
 
         // when
         ExtractableResponse<Response> response = deleteWithCreateToken(
                 BOOKMARK_API_URL + "?messageId=" + messageId,
-                1L);
+                token);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -1,12 +1,12 @@
 package com.pickpick.acceptance.message;
 
-import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
 import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.RestHandler;
 import com.pickpick.message.ui.dto.MessageResponse;
 import com.pickpick.message.ui.dto.MessageResponses;
 import io.restassured.response.ExtractableResponse;
@@ -32,7 +32,7 @@ import org.springframework.test.context.jdbc.Sql;
 class MessageAcceptanceTest extends AcceptanceTest {
 
     private static final String MESSAGE_API_URL = "/api/messages";
-    private static final long MEMBER_ID = 1L;
+    private static final String MEMBER_ID = "1";
 
 
     private static Stream<Arguments> methodSource() {
@@ -111,17 +111,20 @@ class MessageAcceptanceTest extends AcceptanceTest {
 
     @MethodSource("methodSource")
     @ParameterizedTest(name = "{0}")
-    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedhasPast,
+    void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedHasPast,
                     final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
-        // given & when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        // given
+        String token = jwtTokenProvider.createToken(MEMBER_ID);
+
+        // when
+        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
 
         // then
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         assertAll(
                 () -> 상태코드_200_확인(response),
-                () -> assertThat(messageResponses.hasPast()).isEqualTo(expectedhasPast),
+                () -> assertThat(messageResponses.hasPast()).isEqualTo(expectedHasPast),
                 () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
                         .extracting("id")
@@ -133,10 +136,11 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @ParameterizedTest
     void 메시지_조회_시_needPastMessage_true_응답_확인(final String needPastMessage) {
         // given
+        String token = jwtTokenProvider.createToken(MEMBER_ID);
         Map<String, Object> request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
@@ -147,10 +151,11 @@ class MessageAcceptanceTest extends AcceptanceTest {
     @Test
     void 메시지_조회_시_needPastMessage가_False일_경우_응답_확인() {
         // given
+        String token = jwtTokenProvider.createToken(MEMBER_ID);
         Map<String, Object> request = createQueryParams("jupjup", "", "5", "false", "", "");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
@@ -163,10 +168,12 @@ class MessageAcceptanceTest extends AcceptanceTest {
         // given
         given(clock.instant())
                 .willReturn(Instant.parse("2022-08-13T00:00:00Z"));
+
+        String token = jwtTokenProvider.createToken(MEMBER_ID);
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);
@@ -184,10 +191,12 @@ class MessageAcceptanceTest extends AcceptanceTest {
         // given
         given(clock.instant())
                 .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
+
+        String token = jwtTokenProvider.createToken(MEMBER_ID);
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -1,12 +1,12 @@
 package com.pickpick.acceptance.message;
 
+import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
 import com.pickpick.acceptance.AcceptanceTest;
-import com.pickpick.acceptance.RestHandler;
 import com.pickpick.message.ui.dto.MessageResponse;
 import com.pickpick.message.ui.dto.MessageResponses;
 import io.restassured.response.ExtractableResponse;
@@ -117,7 +117,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken(MEMBER_ID);
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(MESSAGE_API_URL, token, request);
 
         // then
         MessageResponses messageResponses = response.as(MessageResponses.class);
@@ -140,7 +140,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(MESSAGE_API_URL, token, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
@@ -155,7 +155,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("jupjup", "", "5", "false", "", "");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(MESSAGE_API_URL, token, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
@@ -173,7 +173,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(MESSAGE_API_URL, token, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);
@@ -196,7 +196,7 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(MESSAGE_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(MESSAGE_API_URL, token, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -9,7 +9,6 @@ import com.pickpick.message.ui.dto.MessageResponse;
 import com.pickpick.message.ui.dto.MessageResponses;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.Clock;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
@@ -23,7 +22,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.junit.jupiter.params.provider.ValueSource;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/message.sql"})
@@ -35,8 +33,6 @@ class MessageAcceptanceTest extends AcceptanceTest {
     private static final String MESSAGE_API_URL = "/api/messages";
     private static final long MEMBER_ID = 1L;
 
-    @SpyBean
-    private Clock clock;
 
     private static Stream<Arguments> methodSource() {
         return Stream.of(

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -1,5 +1,7 @@
 package com.pickpick.acceptance.message;
 
+import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
@@ -25,7 +27,6 @@ import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.test.context.jdbc.Sql;
 
 @Sql({"/message.sql"})
-
 @DisplayName("메시지 기능")
 @SuppressWarnings("NonAsciiCharacters")
 class MessageAcceptanceTest extends AcceptanceTest {
@@ -113,13 +114,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
     void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedhasPast,
                     final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
         // given & when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
 
         // then
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         assertAll(
-                () -> restHandler.상태코드_200_확인(response),
+                () -> 상태코드_200_확인(response),
                 () -> assertThat(messageResponses.hasPast()).isEqualTo(expectedhasPast),
                 () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
@@ -135,11 +136,11 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         assertThat(messageResponses.isNeedPastMessage()).isTrue();
     }
 
@@ -149,11 +150,11 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("jupjup", "", "5", "false", "", "");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         assertThat(messageResponses.isNeedPastMessage()).isFalse();
     }
 
@@ -165,13 +166,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         assertAll(
                 () -> assertThat(messageResponse.isSetReminded()).isFalse(),
                 () -> assertThat(messageResponse.getRemindDate()).isNull()
@@ -186,13 +187,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         assertAll(
                 () -> assertThat(messageResponse.isSetReminded()).isTrue(),
                 () -> assertThat(messageResponse.getRemindDate()).isNotNull()

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -113,13 +113,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
     void 메시지_조회_API(final String description, final Map<String, Object> request, final boolean expectedhasPast,
                     final List<Long> expectedMessageIds, final boolean expectedNeedPastMessage) {
         // given & when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
 
         // then
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         assertAll(
-                () -> 상태코드_200_확인(response),
+                () -> restHandler.상태코드_200_확인(response),
                 () -> assertThat(messageResponses.hasPast()).isEqualTo(expectedhasPast),
                 () -> assertThat(messageResponses.isNeedPastMessage()).isEqualTo(expectedNeedPastMessage),
                 () -> assertThat(messageResponses.getMessages())
@@ -135,11 +135,11 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("jupjup", "", "5", needPastMessage, "", "");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         assertThat(messageResponses.isNeedPastMessage()).isTrue();
     }
 
@@ -149,11 +149,11 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("jupjup", "", "5", "false", "", "");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponses messageResponses = response.as(MessageResponses.class);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         assertThat(messageResponses.isNeedPastMessage()).isFalse();
     }
 
@@ -165,13 +165,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         assertAll(
                 () -> assertThat(messageResponse.isSetReminded()).isFalse(),
                 () -> assertThat(messageResponse.getRemindDate()).isNull()
@@ -186,13 +186,13 @@ class MessageAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = createQueryParams("", "", "5", "true", "", "1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(MESSAGE_API_URL, MEMBER_ID, request);
         MessageResponse messageResponse = response.as(MessageResponses.class)
                 .getMessages()
                 .get(0);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         assertAll(
                 () -> assertThat(messageResponse.isSetReminded()).isTrue(),
                 () -> assertThat(messageResponse.getRemindDate()).isNotNull()

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -30,11 +30,11 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     @Test
     void 리마인더_생성() {
         // given & when
-        ExtractableResponse<Response> response = postWithCreateToken(REMINDER_API_URL,
+        ExtractableResponse<Response> response = restHandler.postWithCreateToken(REMINDER_API_URL,
                 Map.of("messageId", 1, "reminderDate", "2022-08-10T19:21:55"), 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.CREATED);
+        restHandler.상태코드_확인(response, HttpStatus.CREATED);
     }
 
     @Test
@@ -43,10 +43,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
         ReminderResponse reminderResponse = response.jsonPath().getObject("", ReminderResponse.class);
         assertThat(reminderResponse.getId()).isEqualTo(1L);
     }
@@ -57,10 +57,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "100");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.NOT_FOUND);
+        restHandler.상태코드_확인(response, HttpStatus.NOT_FOUND);
     }
 
     @Test
@@ -74,10 +74,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -97,10 +97,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -120,10 +120,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -144,10 +144,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = true;
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -172,10 +172,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         int size = response.jsonPath()
                 .getObject("", ReminderResponses.class)
@@ -195,10 +195,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "", "count", count);
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
 
         int size = response.jsonPath()
                 .getObject("", ReminderResponses.class)
@@ -214,10 +214,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "2", "reminderDate", LocalDateTime.now().toString());
 
         // when
-        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
+        ExtractableResponse<Response> response = restHandler.putWithCreateToken(REMINDER_API_URL, request, 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.OK);
+        restHandler.상태코드_확인(response, HttpStatus.OK);
     }
 
     @Test
@@ -226,10 +226,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "1", "reminderDate", LocalDateTime.now().toString());
 
         // when
-        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
+        ExtractableResponse<Response> response = restHandler.putWithCreateToken(REMINDER_API_URL, request, 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        restHandler.상태코드_확인(response, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -238,11 +238,12 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(REMINDER_API_URL + "?messageId=" + messageId,
+        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+                REMINDER_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.NO_CONTENT);
+        restHandler.상태코드_확인(response, HttpStatus.NO_CONTENT);
     }
 
     @Test
@@ -251,10 +252,11 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(REMINDER_API_URL + "?messageId=" + messageId,
+        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+                REMINDER_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        restHandler.상태코드_확인(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -10,7 +10,6 @@ import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
-import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -18,7 +17,6 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -28,9 +26,6 @@ import org.springframework.test.context.jdbc.Sql;
 public class ReminderAcceptanceTest extends AcceptanceTest {
 
     private static final String REMINDER_API_URL = "/api/reminders";
-
-    @SpyBean
-    private Clock clock;
 
     @Test
     void 리마인더_생성() {

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -1,8 +1,9 @@
 package com.pickpick.acceptance.message;
 
-import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.deleteWithToken;
+import static com.pickpick.acceptance.RestHandler.getWithToken;
 import static com.pickpick.acceptance.RestHandler.postWithToken;
-import static com.pickpick.acceptance.RestHandler.putWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.putWithToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_확인;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -10,7 +11,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
 import com.pickpick.acceptance.AcceptanceTest;
-import com.pickpick.acceptance.RestHandler;
 import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
 import io.restassured.response.ExtractableResponse;
@@ -50,7 +50,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_200_확인(response);
@@ -65,7 +65,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.NOT_FOUND);
@@ -83,7 +83,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -107,7 +107,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -131,7 +131,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -156,7 +156,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -185,7 +185,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -209,7 +209,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
+        ExtractableResponse<Response> response = getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -229,7 +229,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, token);
+        ExtractableResponse<Response> response = putWithToken(REMINDER_API_URL, request, token);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -242,7 +242,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, token);
+        ExtractableResponse<Response> response = putWithToken(REMINDER_API_URL, request, token);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);
@@ -255,7 +255,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithToken(
                 REMINDER_API_URL + "?messageId=" + messageId,
                 token);
 
@@ -270,7 +270,7 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithToken(
                 REMINDER_API_URL + "?messageId=" + messageId,
                 token);
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -1,8 +1,7 @@
 package com.pickpick.acceptance.message;
 
 import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
-import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
-import static com.pickpick.acceptance.RestHandler.postWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.postWithToken;
 import static com.pickpick.acceptance.RestHandler.putWithCreateToken;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_확인;
@@ -11,6 +10,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
 
 import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.RestHandler;
 import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
 import io.restassured.response.ExtractableResponse;
@@ -35,8 +35,9 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     @Test
     void 리마인더_생성() {
         // given & when
-        ExtractableResponse<Response> response = postWithCreateToken(REMINDER_API_URL,
-                Map.of("messageId", 1, "reminderDate", "2022-08-10T19:21:55"), 1L);
+        ExtractableResponse<Response> response = postWithToken(REMINDER_API_URL,
+                Map.of("messageId", 1, "reminderDate", "2022-08-10T19:21:55"),
+                jwtTokenProvider.createToken("1"));
 
         // then
         상태코드_확인(response, HttpStatus.CREATED);
@@ -46,9 +47,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     void 리마인더_단건_조회_정상_응답() {
         // given
         Map<String, Object> request = Map.of("messageId", "1");
+        String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_200_확인(response);
@@ -60,9 +62,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     void 존재하지_않는_리마인더_조회시_404_응답() {
         // given
         Map<String, Object> request = Map.of("messageId", "100");
+        String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.NOT_FOUND);
@@ -77,9 +80,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "");
         List<Long> expectedIds = List.of(1L);
         boolean expectedHasPast = false;
+        String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -100,9 +104,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "10");
         List<Long> expectedIds = List.of(11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L);
         boolean expectedHasPast = false;
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -123,9 +128,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "");
         List<Long> expectedIds = List.of(1L);
         boolean expectedHasPast = false;
+        String token = jwtTokenProvider.createToken("2");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -147,9 +153,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         List<Long> expectedIds = List.of(
                 3L, 4L, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L);
         boolean expectedHasPast = true;
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -175,9 +182,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
                 .willReturn(Instant.parse("2022-08-10T00:00:00Z"));
 
         Map<String, Object> request = Map.of("reminderId", "");
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -198,9 +206,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
 
         int count = 10;
         Map<String, Object> request = Map.of("reminderId", "", "count", count);
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = RestHandler.getWithToken(REMINDER_API_URL, token, request);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -217,9 +226,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     void 리마인더_정상_수정() {
         // given
         Map<String, Object> request = Map.of("messageId", "2", "reminderDate", LocalDateTime.now().toString());
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
+        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, token);
 
         // then
         상태코드_확인(response, HttpStatus.OK);
@@ -229,9 +239,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     void 사용자에게_존재하지_않는_리마인더_수정() {
         // given
         Map<String, Object> request = Map.of("messageId", "1", "reminderDate", LocalDateTime.now().toString());
+        String token = jwtTokenProvider.createToken("1");
 
         // when
-        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
+        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, token);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);
@@ -240,12 +251,13 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     @Test
     void 리마인더_정상_삭제() {
         // given
-        long messageId = 2L;
+        long messageId = 1L;
+        String token = jwtTokenProvider.createToken("2");
 
         // when
         ExtractableResponse<Response> response = deleteWithCreateToken(
                 REMINDER_API_URL + "?messageId=" + messageId,
-                1L);
+                token);
 
         // then
         상태코드_확인(response, HttpStatus.NO_CONTENT);
@@ -255,11 +267,12 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     void 사용자에게_존재하지_않는_리마인더_삭제() {
         // given
         long messageId = 1L;
+        String token = jwtTokenProvider.createToken("1");
 
         // when
         ExtractableResponse<Response> response = deleteWithCreateToken(
                 REMINDER_API_URL + "?messageId=" + messageId,
-                1L);
+                token);
 
         // then
         상태코드_확인(response, HttpStatus.BAD_REQUEST);

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -1,6 +1,11 @@
 package com.pickpick.acceptance.message;
 
-
+import static com.pickpick.acceptance.RestHandler.deleteWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.getWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.postWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.putWithCreateToken;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
+import static com.pickpick.acceptance.RestHandler.상태코드_확인;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.mockito.BDDMockito.given;
@@ -30,11 +35,11 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
     @Test
     void 리마인더_생성() {
         // given & when
-        ExtractableResponse<Response> response = restHandler.postWithCreateToken(REMINDER_API_URL,
+        ExtractableResponse<Response> response = postWithCreateToken(REMINDER_API_URL,
                 Map.of("messageId", 1, "reminderDate", "2022-08-10T19:21:55"), 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.CREATED);
+        상태코드_확인(response, HttpStatus.CREATED);
     }
 
     @Test
@@ -43,10 +48,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "1");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
         ReminderResponse reminderResponse = response.jsonPath().getObject("", ReminderResponse.class);
         assertThat(reminderResponse.getId()).isEqualTo(1L);
     }
@@ -57,10 +62,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "100");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.NOT_FOUND);
+        상태코드_확인(response, HttpStatus.NOT_FOUND);
     }
 
     @Test
@@ -74,10 +79,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -97,10 +102,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -120,10 +125,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = false;
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 2L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 2L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -144,10 +149,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         boolean expectedHasPast = true;
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         ReminderResponses reminderResponses = response.jsonPath().getObject("", ReminderResponses.class);
         assertAll(
@@ -172,10 +177,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "");
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         int size = response.jsonPath()
                 .getObject("", ReminderResponses.class)
@@ -195,10 +200,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("reminderId", "", "count", count);
 
         // when
-        ExtractableResponse<Response> response = restHandler.getWithCreateToken(REMINDER_API_URL, 1L, request);
+        ExtractableResponse<Response> response = getWithCreateToken(REMINDER_API_URL, 1L, request);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
 
         int size = response.jsonPath()
                 .getObject("", ReminderResponses.class)
@@ -214,10 +219,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "2", "reminderDate", LocalDateTime.now().toString());
 
         // when
-        ExtractableResponse<Response> response = restHandler.putWithCreateToken(REMINDER_API_URL, request, 1L);
+        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.OK);
+        상태코드_확인(response, HttpStatus.OK);
     }
 
     @Test
@@ -226,10 +231,10 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         Map<String, Object> request = Map.of("messageId", "1", "reminderDate", LocalDateTime.now().toString());
 
         // when
-        ExtractableResponse<Response> response = restHandler.putWithCreateToken(REMINDER_API_URL, request, 1L);
+        ExtractableResponse<Response> response = putWithCreateToken(REMINDER_API_URL, request, 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        상태코드_확인(response, HttpStatus.BAD_REQUEST);
     }
 
     @Test
@@ -238,12 +243,12 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         long messageId = 2L;
 
         // when
-        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithCreateToken(
                 REMINDER_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.NO_CONTENT);
+        상태코드_확인(response, HttpStatus.NO_CONTENT);
     }
 
     @Test
@@ -252,11 +257,11 @@ public class ReminderAcceptanceTest extends AcceptanceTest {
         long messageId = 1L;
 
         // when
-        ExtractableResponse<Response> response = restHandler.deleteWithCreateToken(
+        ExtractableResponse<Response> response = deleteWithCreateToken(
                 REMINDER_API_URL + "?messageId=" + messageId,
                 1L);
 
         // then
-        restHandler.상태코드_확인(response, HttpStatus.BAD_REQUEST);
+        상태코드_확인(response, HttpStatus.BAD_REQUEST);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
@@ -22,10 +22,11 @@ class MemberEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> memberUpdatedRequest = createEventRequest("실제이름", "표시이름", "test.png");
 
         // when
-        ExtractableResponse<Response> memberChangedResponse = post(MEMBER_EVENT_API_URL, memberUpdatedRequest);
+        ExtractableResponse<Response> memberChangedResponse = restHandler.post(MEMBER_EVENT_API_URL,
+                memberUpdatedRequest);
 
         // then
-        상태코드_200_확인(memberChangedResponse);
+        restHandler.상태코드_200_확인(memberChangedResponse);
     }
 
     private Map<String, Object> createEventRequest(final String realName, final String displayName,

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.pickpick.acceptance.slackevent;
 
+import static com.pickpick.acceptance.RestHandler.post;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
+
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.slackevent.application.SlackEvent;
 import io.restassured.response.ExtractableResponse;
@@ -22,11 +25,11 @@ class MemberEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> memberUpdatedRequest = createEventRequest("실제이름", "표시이름", "test.png");
 
         // when
-        ExtractableResponse<Response> memberChangedResponse = restHandler.post(MEMBER_EVENT_API_URL,
+        ExtractableResponse<Response> memberChangedResponse = post(MEMBER_EVENT_API_URL,
                 memberUpdatedRequest);
 
         // then
-        restHandler.상태코드_200_확인(memberChangedResponse);
+        상태코드_200_확인(memberChangedResponse);
     }
 
     private Map<String, Object> createEventRequest(final String realName, final String displayName,

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -1,5 +1,8 @@
 package com.pickpick.acceptance.slackevent;
 
+import static com.pickpick.acceptance.RestHandler.post;
+import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
+
 import com.pickpick.acceptance.AcceptanceTest;
 import com.pickpick.slackevent.application.SlackEvent;
 import io.restassured.response.ExtractableResponse;
@@ -81,10 +84,10 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, String> request = Map.of("token", token, "type", type, "challenge", challenge);
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, request);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, request);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
@@ -93,40 +96,40 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageCreatedRequest = createEventRequest("");
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
     void 메시지_수정_요청_시_메시지_내용과_수정_시간이_업데이트_된다() {
         // given
         Map<String, Object> messageCreatedRequest = createEventRequest("");
-        restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         Map<String, Object> messageChangedRequest = createEventRequest(SlackEvent.MESSAGE_CHANGED.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageChangedRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageChangedRequest);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
     void 메시지_삭제_요청_시_메시지가_삭제_된다() {
         // given
         Map<String, Object> messageCreatedRequest = createEventRequest("");
-        restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         Map<String, Object> messageDeletedRequest = createEventRequest(SlackEvent.MESSAGE_DELETED.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageDeletedRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageDeletedRequest);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
@@ -135,10 +138,10 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageThreadBroadcastRequest = createEventRequest("thread_broadcast");
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
@@ -147,24 +150,24 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageThreadBroadcastRequest = createThreadBroadcastEventRequest();
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 
     @Test
     void 파일_공유_메시지_요청_시_메시지가_저장된다() {
         // given
         Map<String, Object> messageCreatedRequest = createEventRequest("");
-        restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         Map<String, Object> fileShareMessageRequest = createEventRequest(SlackEvent.MESSAGE_FILE_SHARE.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, fileShareMessageRequest);
+        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, fileShareMessageRequest);
 
         // then
-        restHandler.상태코드_200_확인(response);
+        상태코드_200_확인(response);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -81,10 +81,10 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, String> request = Map.of("token", token, "type", type, "challenge", challenge);
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, request);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, request);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
@@ -93,40 +93,40 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageCreatedRequest = createEventRequest("");
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
     void 메시지_수정_요청_시_메시지_내용과_수정_시간이_업데이트_된다() {
         // given
         Map<String, Object> messageCreatedRequest = createEventRequest("");
-        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         Map<String, Object> messageChangedRequest = createEventRequest(SlackEvent.MESSAGE_CHANGED.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageChangedRequest);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageChangedRequest);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
     void 메시지_삭제_요청_시_메시지가_삭제_된다() {
         // given
         Map<String, Object> messageCreatedRequest = createEventRequest("");
-        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         Map<String, Object> messageDeletedRequest = createEventRequest(SlackEvent.MESSAGE_DELETED.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageDeletedRequest);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageDeletedRequest);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
@@ -135,10 +135,10 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageThreadBroadcastRequest = createEventRequest("thread_broadcast");
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
@@ -147,24 +147,24 @@ class MessageEventAcceptanceTest extends AcceptanceTest {
         Map<String, Object> messageThreadBroadcastRequest = createThreadBroadcastEventRequest();
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, messageThreadBroadcastRequest);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 
     @Test
     void 파일_공유_메시지_요청_시_메시지가_저장된다() {
         // given
         Map<String, Object> messageCreatedRequest = createEventRequest("");
-        post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
+        restHandler.post(MESSAGE_EVENT_API_URL, messageCreatedRequest);
 
         Map<String, Object> fileShareMessageRequest = createEventRequest(SlackEvent.MESSAGE_FILE_SHARE.getSubtype());
 
         // when
-        ExtractableResponse<Response> response = post(MESSAGE_EVENT_API_URL, fileShareMessageRequest);
+        ExtractableResponse<Response> response = restHandler.post(MESSAGE_EVENT_API_URL, fileShareMessageRequest);
 
         // then
-        상태코드_200_확인(response);
+        restHandler.상태코드_200_확인(response);
     }
 }

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,3 +1,5 @@
+log: &log-option false
+
 spring:
   datasource:
     driver-class-name: org.h2.Driver
@@ -7,15 +9,15 @@ spring:
 
   h2:
     console:
-      enabled: true
+      enabled: *log-option
 
   jpa:
     hibernate:
       ddl-auto: create
     properties:
       hibernate:
-        show_sql: true
-        format_sql: true
+        show_sql: *log-option
+        format_sql: *log-option
         jdbc:
           time_zone: Asia/Seoul
 


### PR DESCRIPTION
## 요약

- 인수 테스트 코드 구조 변경
- 인증인가 인수테스트 리팩터링

<br><br>

## 작업 내용

### 속도 개선
1. JPA, H2 로그 on/off 설정 가능
    - `application.yml`에서 $log-option 참고

2. Rest API 로그 on/off 설정 가능
    - `RestHandler`의 request 메서드 참고
    - `application.yml`의 `log` 값이 true이면 콘솔에 로그가 남음

3. `@MockBean`, `@SpyBean`을 `AcceptanceTest`에서 주입
    - 모든 AcceptanceTest가 테스트 컨텍스트 공유

### 가독성 개선
1. `RestHandler` 생성
    - Rest 요청을 보내주는 `RestHandler` 생성
    - `AcceptanceTest`에서는 어떤 코드를 보내는지 보는게 아니라 어떤 행위를 하는지만 보여줌

### 테스트 코드 개선
- 전체: `RestHandler` 적용
- `AuthAcceptanceTest`: `@Sql` 제거 

<br><br>

## 참고 사항

인수 테스트 전체 구조에 변경 사항이 생겨서 files changed가 좀 많은데요
`AcceptanceTest`, `RestHandler`, `AuthAcceptanceTest` 이 세 개만 봐주시면 될 것 같아요😃

<br><br>

## 관련 이슈

- Close #565

<br><br>
