### PR TITLE
refactor: CSS 순서 컨벤션 적용 및 import 문 정렬

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -7,9 +7,6 @@
     "^@src/components/(.*)$",
     "^@src/hooks/(.*)$",
     "^@src/@(.*)",
-
-    "^@src/@styles/(.*)$",
-    "^@src/@types/(.*)$",
     "^@src/api/(.*)$",
     "^@src/mocks/(.*)$",
     "^[./]"

--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,4 +1,19 @@
 {
   "printWidth": 80,
-  "singleQuote": false
+  "singleQuote": false,
+  "importOrder": [
+    "<THIRD_PARTY_MODULES>",
+    "^@public/(.*)$",
+    "^@src/components/(.*)$",
+    "^@src/hooks/(.*)$",
+    "^@src/@(.*)",
+
+    "^@src/@styles/(.*)$",
+    "^@src/@types/(.*)$",
+    "^@src/api/(.*)$",
+    "^@src/mocks/(.*)$",
+    "^[./]"
+  ],
+  "importOrderSeparation": true,
+  "importOrderSortSpecifiers": true
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@storybook/react": "^6.5.9",
         "@storybook/testing-library": "^0.0.13",
         "@svgr/webpack": "^6.2.1",
+        "@trivago/prettier-plugin-sort-imports": "^3.3.0",
         "@types/jest": "^28.1.3",
         "@types/react": "^18.0.14",
         "@types/react-dom": "^18.0.5",
@@ -14826,6 +14827,123 @@
         "@testing-library/dom": ">=7.21.4"
       }
     },
+    "node_modules/@trivago/prettier-plugin-sort-imports": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.0.tgz",
+      "integrity": "sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/core": "7.17.8",
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "7.17.8",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "peerDependencies": {
+        "prettier": "2.x"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/core": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+      "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.1.0",
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.7",
+        "@babel/helper-compilation-targets": "^7.17.7",
+        "@babel/helper-module-transforms": "^7.17.7",
+        "@babel/helpers": "^7.17.8",
+        "@babel/parser": "^7.17.8",
+        "@babel/template": "^7.16.7",
+        "@babel/traverse": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "convert-source-map": "^1.7.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.1.2",
+        "semver": "^6.3.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/generator": {
+      "version": "7.17.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+      "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.17.0",
+        "jsesc": "^2.5.1",
+        "source-map": "^0.5.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/parser": {
+      "version": "7.17.8",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+      "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+      "dev": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/traverse": {
+      "version": "7.17.3",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+      "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.16.7",
+        "@babel/generator": "^7.17.3",
+        "@babel/helper-environment-visitor": "^7.16.7",
+        "@babel/helper-function-name": "^7.16.7",
+        "@babel/helper-hoist-variables": "^7.16.7",
+        "@babel/helper-split-export-declaration": "^7.16.7",
+        "@babel/parser": "^7.17.3",
+        "@babel/types": "^7.17.0",
+        "debug": "^4.1.0",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/@babel/types": {
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+      "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.16.7",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@trivago/prettier-plugin-sort-imports/node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -23897,6 +24015,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "node_modules/jest": {
       "version": "28.1.1",
@@ -46351,6 +46475,97 @@
         "@babel/runtime": "^7.12.5"
       }
     },
+    "@trivago/prettier-plugin-sort-imports": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@trivago/prettier-plugin-sort-imports/-/prettier-plugin-sort-imports-3.3.0.tgz",
+      "integrity": "sha512-1y44bVZuIN0RsS3oIiGd5k8Vm3IZXYZnp4VsP2Z/S5L9WAOw43HE2clso66M2S/dDeJ+8sKPqnHsEfh39Vjs3w==",
+      "dev": true,
+      "requires": {
+        "@babel/core": "7.17.8",
+        "@babel/generator": "7.17.7",
+        "@babel/parser": "7.17.8",
+        "@babel/traverse": "7.17.3",
+        "@babel/types": "7.17.0",
+        "javascript-natural-sort": "0.7.1",
+        "lodash": "4.17.21"
+      },
+      "dependencies": {
+        "@babel/core": {
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.17.8.tgz",
+          "integrity": "sha512-OdQDV/7cRBtJHLSOBqqbYNkOcydOgnX59TZx4puf41fzcVtN3e/4yqY8lMQsK+5X2lJtAdmA+6OHqsj1hBJ4IQ==",
+          "dev": true,
+          "requires": {
+            "@ampproject/remapping": "^2.1.0",
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.7",
+            "@babel/helper-compilation-targets": "^7.17.7",
+            "@babel/helper-module-transforms": "^7.17.7",
+            "@babel/helpers": "^7.17.8",
+            "@babel/parser": "^7.17.8",
+            "@babel/template": "^7.16.7",
+            "@babel/traverse": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "convert-source-map": "^1.7.0",
+            "debug": "^4.1.0",
+            "gensync": "^1.0.0-beta.2",
+            "json5": "^2.1.2",
+            "semver": "^6.3.0"
+          }
+        },
+        "@babel/generator": {
+          "version": "7.17.7",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.17.7.tgz",
+          "integrity": "sha512-oLcVCTeIFadUoArDTwpluncplrYBmTCCZZgXCbgNGvOBBiSDDK3eWO4b/+eOTli5tKv1lg+a5/NAXg+nTcei1w==",
+          "dev": true,
+          "requires": {
+            "@babel/types": "^7.17.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.17.8",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.17.8.tgz",
+          "integrity": "sha512-BoHhDJrJXqcg+ZL16Xv39H9n+AqJ4pcDrQBGZN+wHxIysrLZ3/ECwCBUch/1zUNhnsXULcONU3Ei5Hmkfk6kiQ==",
+          "dev": true
+        },
+        "@babel/traverse": {
+          "version": "7.17.3",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.17.3.tgz",
+          "integrity": "sha512-5irClVky7TxRWIRtxlh2WPUUOLhcPN06AGgaQSB8AEwuyEBgJVuJ5imdHm5zxk8w0QS5T+tDfnDxAlhWjpb7cw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.16.7",
+            "@babel/generator": "^7.17.3",
+            "@babel/helper-environment-visitor": "^7.16.7",
+            "@babel/helper-function-name": "^7.16.7",
+            "@babel/helper-hoist-variables": "^7.16.7",
+            "@babel/helper-split-export-declaration": "^7.16.7",
+            "@babel/parser": "^7.17.3",
+            "@babel/types": "^7.17.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.17.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+          "integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.16.7",
+            "to-fast-properties": "^2.0.0"
+          }
+        },
+        "source-map": {
+          "version": "0.5.7",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+          "dev": true
+        }
+      }
+    },
     "@trysound/sax": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@trysound/sax/-/sax-0.2.0.tgz",
@@ -53474,6 +53689,12 @@
         "es-get-iterator": "^1.0.2",
         "iterate-iterator": "^1.0.1"
       }
+    },
+    "javascript-natural-sort": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/javascript-natural-sort/-/javascript-natural-sort-0.7.1.tgz",
+      "integrity": "sha512-nO6jcEfZWQXDhOiBtG2KvKyEptz7RVbpGP4vTD2hLBdmNQSsCiicO2Ioinv6UI4y9ukqnBpy+XZ9H6uLNgJTlw==",
+      "dev": true
     },
     "jest": {
       "version": "28.1.1",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -35,6 +35,7 @@
     "@storybook/react": "^6.5.9",
     "@storybook/testing-library": "^0.0.13",
     "@svgr/webpack": "^6.2.1",
+    "@trivago/prettier-plugin-sort-imports": "^3.3.0",
     "@types/jest": "^28.1.3",
     "@types/react": "^18.0.14",
     "@types/react-dom": "^18.0.5",

--- a/frontend/src/@atoms/index.ts
+++ b/frontend/src/@atoms/index.ts
@@ -1,6 +1,7 @@
+import { atom } from "recoil";
+
 import { SNACKBAR_STATUS, THEME_KIND } from "@src/@constants";
 import { SnackbarStatus, ThemeKind } from "@src/@types/shared";
-import { atom } from "recoil";
 
 interface SnackbarState {
   isOpened: boolean;

--- a/frontend/src/@styles/GlobalStyle.ts
+++ b/frontend/src/@styles/GlobalStyle.ts
@@ -1,20 +1,18 @@
-import RobotoBoldWoff2 from "@public/assets/fonts/Roboto-Bold.woff2";
-import RobotoBoldWoff from "@public/assets/fonts/Roboto-Bold.woff";
-import RobotoBoldTtf from "@public/assets/fonts/Roboto-Bold.ttf";
-
-import RobotoRegularWoff2 from "@public/assets/fonts/Roboto-Regular.woff2";
-import RobotoRegularWoff from "@public/assets/fonts/Roboto-Regular.woff";
-import RobotoRegularTtf from "@public/assets/fonts/Roboto-Regular.ttf";
-
-import RobotoLightWoff2 from "@public/assets/fonts/Roboto-Light.woff2";
-import RobotoLightWoff from "@public/assets/fonts/Roboto-Light.woff";
-import RobotoLightTtf from "@public/assets/fonts/Roboto-Light.ttf";
-
-import TwayairWoff2 from "@public/assets/fonts/tway_air.woff2";
-import TwayairWoff from "@public/assets/fonts/tway_air.woff";
-import TwayairTtf from "@public/assets/fonts/tway_air.ttf";
-
 import { createGlobalStyle, css } from "styled-components";
+
+import RobotoBoldTtf from "@public/assets/fonts/Roboto-Bold.ttf";
+import RobotoBoldWoff from "@public/assets/fonts/Roboto-Bold.woff";
+import RobotoBoldWoff2 from "@public/assets/fonts/Roboto-Bold.woff2";
+import RobotoLightTtf from "@public/assets/fonts/Roboto-Light.ttf";
+import RobotoLightWoff from "@public/assets/fonts/Roboto-Light.woff";
+import RobotoLightWoff2 from "@public/assets/fonts/Roboto-Light.woff2";
+import RobotoRegularTtf from "@public/assets/fonts/Roboto-Regular.ttf";
+import RobotoRegularWoff from "@public/assets/fonts/Roboto-Regular.woff";
+import RobotoRegularWoff2 from "@public/assets/fonts/Roboto-Regular.woff2";
+import TwayairTtf from "@public/assets/fonts/tway_air.ttf";
+import TwayairWoff from "@public/assets/fonts/tway_air.woff";
+import TwayairWoff2 from "@public/assets/fonts/tway_air.woff2";
+
 import { Theme } from "@src/@types/shared";
 
 const GlobalStyle = createGlobalStyle<{ theme: Theme }>`

--- a/frontend/src/@styles/shared.ts
+++ b/frontend/src/@styles/shared.ts
@@ -1,7 +1,7 @@
-import React from "react";
+import { CSSProperties } from "react";
 import styled, { css } from "styled-components";
 
-type FlexStyle = Omit<React.CSSProperties, "display" | "flexDirection">;
+type FlexStyle = Omit<CSSProperties, "display" | "flexDirection">;
 
 export const FlexRow = styled.div`
   display: flex;

--- a/frontend/src/@types/shared.ts
+++ b/frontend/src/@types/shared.ts
@@ -1,6 +1,6 @@
 import {
-  SNACKBAR_STATUS,
   ERROR_MESSAGE_BY_CODE,
+  SNACKBAR_STATUS,
   THEME_KIND,
 } from "@src/@constants";
 import { LIGHT_MODE_THEME } from "@src/@styles/theme";

--- a/frontend/src/@utils/index.ts
+++ b/frontend/src/@utils/index.ts
@@ -1,3 +1,5 @@
+import { InfiniteData } from "react-query";
+
 import { CONVERTER_SUFFIX, DATE, DAY, TIME } from "@src/@constants";
 import {
   Bookmark,
@@ -7,7 +9,6 @@ import {
   ResponseMessages,
   ResponseReminders,
 } from "@src/@types/shared";
-import { InfiniteData } from "react-query";
 
 export const getMeridiemTime = (time: number) => {
   if (time < TIME.NOON) return { meridiem: TIME.AM, hour: time.toString() };

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,16 +1,19 @@
-import GlobalStyle from "@src/@styles/GlobalStyle";
-import Snackbar from "@src/components/Snackbar";
-import useApiError from "@src/hooks/useApiError";
 import routes from "@src/Routes";
 import queryClient from "@src/queryClient";
-import useModeTheme from "@src/hooks/useModeTheme";
+import { useEffect } from "react";
+import { QueryClientProvider } from "react-query";
+import { ReactQueryDevtools } from "react-query/devtools";
 import { useRoutes } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
-import { DARK_MODE_THEME, LIGHT_MODE_THEME } from "@src/@styles/theme";
-import { QueryClientProvider } from "react-query";
-import { useEffect } from "react";
-import { ReactQueryDevtools } from "react-query/devtools";
+
+import Snackbar from "@src/components/Snackbar";
+
+import useApiError from "@src/hooks/useApiError";
+import useModeTheme from "@src/hooks/useModeTheme";
+
 import { THEME_KIND } from "@src/@constants";
+import GlobalStyle from "@src/@styles/GlobalStyle";
+import { DARK_MODE_THEME, LIGHT_MODE_THEME } from "@src/@styles/theme";
 
 function App() {
   const { handleError } = useApiError();

--- a/frontend/src/Routes.tsx
+++ b/frontend/src/Routes.tsx
@@ -1,18 +1,20 @@
-import NotFound from "@src/pages/NotFound";
-import { PATH_NAME } from "@src/@constants";
-import LayoutContainer from "@src/components/@layouts/LayoutContainer";
-import PrivateRouter from "@src/components/Router/PrivateRouter";
-import PublicRouter from "@src/components/Router/PublicRouter";
 import {
   AddChannel,
   Bookmark,
-  Reminder,
-  Feed,
-  SpecificDateFeed,
-  Home,
   Certification,
+  Feed,
+  Home,
+  Reminder,
   SearchResult,
+  SpecificDateFeed,
 } from "@src/pages";
+import NotFound from "@src/pages/NotFound";
+
+import LayoutContainer from "@src/components/@layouts/LayoutContainer";
+import PrivateRouter from "@src/components/Router/PrivateRouter";
+import PublicRouter from "@src/components/Router/PublicRouter";
+
+import { PATH_NAME } from "@src/@constants";
 
 const routes = [
   {

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,6 +1,8 @@
-import { API_ENDPOINT } from "@src/@constants";
 import { fetcher } from "@src/api";
+
+import { API_ENDPOINT } from "@src/@constants";
 import { ResponseToken } from "@src/@types/shared";
+
 import { getPrivateHeaders, getPublicHeaders } from "@src/api/utils";
 
 export const isCertificated = async () => {

--- a/frontend/src/api/bookmarks.ts
+++ b/frontend/src/api/bookmarks.ts
@@ -1,6 +1,8 @@
+import { fetcher } from "@src/api";
+
 import { API_ENDPOINT } from "@src/@constants";
 import { ResponseBookmarks } from "@src/@types/shared";
-import { fetcher } from  "@src/api";
+
 import { getPrivateHeaders } from "@src/api/utils";
 
 interface GetBookmarkParam {

--- a/frontend/src/api/channels.ts
+++ b/frontend/src/api/channels.ts
@@ -1,9 +1,11 @@
+import { fetcher } from "@src/api";
+
 import { API_ENDPOINT } from "@src/@constants";
 import {
   ResponseChannels,
   ResponseSubscribedChannels,
 } from "@src/@types/shared";
-import { fetcher } from "@src/api";
+
 import { getPrivateHeaders } from "@src/api/utils";
 
 export const getChannels = async () => {

--- a/frontend/src/api/messages.ts
+++ b/frontend/src/api/messages.ts
@@ -1,6 +1,8 @@
+import { fetcher } from "@src/api";
+
 import { API_ENDPOINT } from "@src/@constants";
 import { ResponseMessages } from "@src/@types/shared";
-import { fetcher } from  "@src/api";
+
 import { getPrivateHeaders } from "@src/api/utils";
 
 interface PageParam {

--- a/frontend/src/api/reminders.ts
+++ b/frontend/src/api/reminders.ts
@@ -1,6 +1,8 @@
+import { fetcher } from "@src/api";
+
 import { API_ENDPOINT } from "@src/@constants";
 import { ResponseReminders } from "@src/@types/shared";
-import { fetcher } from  "@src/api";
+
 import { getPrivateHeaders } from "@src/api/utils";
 
 interface ReminderProps {

--- a/frontend/src/components/@layouts/Header/index.tsx
+++ b/frontend/src/components/@layouts/Header/index.tsx
@@ -1,5 +1,6 @@
-import * as Styled from "./style";
 import { SLACK_LOGIN_URL } from "@src/@constants";
+
+import * as Styled from "./style";
 
 function Header() {
   return (

--- a/frontend/src/components/@layouts/Header/style.ts
+++ b/frontend/src/components/@layouts/Header/style.ts
@@ -2,16 +2,18 @@ import styled, { css } from "styled-components";
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.header`
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+
+  padding: 20px;
+  background-color: ${({ theme }: StyledDefaultProps) =>
+    theme.COLOR.BACKGROUND.SECONDARY};
+
   position: fixed;
   top: 0;
   left: 0;
   right: 0;
-  background-color: ${({ theme }: StyledDefaultProps) =>
-    theme.COLOR.BACKGROUND.SECONDARY};
-  padding: 20px;
-  display: flex;
-  justify-content: space-between;
-  align-items: flex-start;
 `;
 
 export const Title = styled.h1`

--- a/frontend/src/components/@layouts/Header/style.ts
+++ b/frontend/src/components/@layouts/Header/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.header`

--- a/frontend/src/components/@layouts/LayoutContainer/index.tsx
+++ b/frontend/src/components/@layouts/LayoutContainer/index.tsx
@@ -13,11 +13,11 @@ function LayoutContainer({ children }: PropsWithChildren) {
     pathname !== PATH_NAME.HOME && pathname !== PATH_NAME.ADD_CHANNEL;
 
   return (
-    <Styled.Container>
+    <div>
       {hasHeader() && <Header />}
       <Styled.Main hasMarginTop={hasHeader()}>{children}</Styled.Main>
       {hasNavBar() && <Navigation />}
-    </Styled.Container>
+    </div>
   );
 }
 

--- a/frontend/src/components/@layouts/LayoutContainer/index.tsx
+++ b/frontend/src/components/@layouts/LayoutContainer/index.tsx
@@ -1,9 +1,12 @@
 import { PropsWithChildren } from "react";
-import * as Styled from "./style";
+import { useLocation } from "react-router-dom";
+
 import Header from "@src/components/@layouts/Header";
 import Navigation from "@src/components/@layouts/Navigation";
-import { useLocation } from "react-router-dom";
+
 import { PATH_NAME } from "@src/@constants";
+
+import * as Styled from "./style";
 
 function LayoutContainer({ children }: PropsWithChildren) {
   const { pathname } = useLocation();

--- a/frontend/src/components/@layouts/LayoutContainer/style.ts
+++ b/frontend/src/components/@layouts/LayoutContainer/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
 
 interface StyledProps extends StyledDefaultProps {

--- a/frontend/src/components/@layouts/LayoutContainer/style.ts
+++ b/frontend/src/components/@layouts/LayoutContainer/style.ts
@@ -5,15 +5,14 @@ interface StyledProps extends StyledDefaultProps {
   hasMarginTop: boolean;
 }
 
-export const Container = styled.div``;
-
 export const Main = styled.main`
   display: flex;
   flex-direction: column;
-  justify-content: center;
   align-items: center;
-  padding-bottom: 100px;
+  justify-content: center;
+
   height: auto;
+  padding-bottom: 100px;
 
   ${({ theme, hasMarginTop }: StyledProps) => css`
     background-color: ${theme.COLOR.BACKGROUND.PRIMARY};

--- a/frontend/src/components/@layouts/Navigation/index.tsx
+++ b/frontend/src/components/@layouts/Navigation/index.tsx
@@ -1,23 +1,27 @@
-import * as Styled from "./style";
-import { PATH_NAME } from "@src/@constants";
-import StarIcon from "@src/components/@svgIcons/StarIcon";
-import MenuIcon from "@src/components/@svgIcons/MenuIcon";
-import HomeIcon from "@src/components/@svgIcons/HomeIcon";
-import InfoIcon from "@src/components/@svgIcons/InfoIcon";
-import ReminderIconInactive from "@src/components/@svgIcons/ReminderIconInactive";
-import WrapperButton from "@src/components/@shared/WrapperButton";
+import { useTheme } from "styled-components";
+
+import Button from "@src/components/@shared/Button";
 import Dimmer from "@src/components/@shared/Dimmer";
 import Portal from "@src/components/@shared/Portal";
+import WrapperButton from "@src/components/@shared/WrapperButton";
 import WrapperLink from "@src/components/@shared/WrapperLink";
+import HomeIcon from "@src/components/@svgIcons/HomeIcon";
+import InfoIcon from "@src/components/@svgIcons/InfoIcon";
+import MenuIcon from "@src/components/@svgIcons/MenuIcon";
+import ReminderIconInactive from "@src/components/@svgIcons/ReminderIconInactive";
+import StarIcon from "@src/components/@svgIcons/StarIcon";
 import ChannelsDrawer from "@src/components/ChannelsDrawer";
-import useModal from "@src/hooks/useModal";
-import Button from "@src/components/@shared/Button";
-import useAuthentication from "@src/hooks/useAuthentication";
-import { useTheme } from "styled-components";
-import { Theme } from "@src/@types/shared";
+
 import useGetSubscribedChannels from "@src/hooks/query/useGetSubscribedChannels";
-import useRecentFeedPath from "@src/hooks/useRecentFeedPath";
+import useAuthentication from "@src/hooks/useAuthentication";
+import useModal from "@src/hooks/useModal";
 import useOuterClick from "@src/hooks/useOuterClick";
+import useRecentFeedPath from "@src/hooks/useRecentFeedPath";
+
+import { PATH_NAME } from "@src/@constants";
+import { Theme } from "@src/@types/shared";
+
+import * as Styled from "./style";
 
 function Navigation() {
   const { logout } = useAuthentication();

--- a/frontend/src/components/@layouts/Navigation/style.ts
+++ b/frontend/src/components/@layouts/Navigation/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.nav`

--- a/frontend/src/components/@layouts/Navigation/style.ts
+++ b/frontend/src/components/@layouts/Navigation/style.ts
@@ -2,14 +2,17 @@ import styled, { css } from "styled-components";
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.nav`
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
   display: flex;
   justify-content: space-around;
+
   padding: 5px;
-  z-index: 999;
+
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  z-index: 10;
 
   ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.BACKGROUND.SECONDARY}};
@@ -18,7 +21,8 @@ export const Container = styled.nav`
 
 export const LogoutButtonContainer = styled.div`
   position: fixed;
-  bottom: 90px;
   right: 10px;
+  bottom: 90px;
+
   z-index: 2;
 `;

--- a/frontend/src/components/@shared/Button/index.tsx
+++ b/frontend/src/components/@shared/Button/index.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, PropsWithChildren } from "react";
+
 import * as Styled from "./style";
 
 export type Size = "small" | "medium" | "large";

--- a/frontend/src/components/@shared/Button/style.ts
+++ b/frontend/src/components/@shared/Button/style.ts
@@ -1,5 +1,7 @@
-import styled, { css, CSSProp } from "styled-components";
+import styled, { CSSProp, css } from "styled-components";
+
 import { StyledDefaultProps, Theme } from "@src/@types/shared";
+
 import { Props, Size } from ".";
 
 const sizeTable: Record<Size, CSSProp<Theme>> = {

--- a/frontend/src/components/@shared/Dimmer/style.ts
+++ b/frontend/src/components/@shared/Dimmer/style.ts
@@ -1,5 +1,7 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
+
 import { Props } from ".";
 
 interface StyledProps extends StyledDefaultProps {

--- a/frontend/src/components/@shared/Dimmer/style.ts
+++ b/frontend/src/components/@shared/Dimmer/style.ts
@@ -12,6 +12,7 @@ export const Container = styled.div<Props>`
   left: 0;
   right: 0;
   bottom: 0;
+
   z-index: 2;
 
   ${({ theme, hasBackgroundColor }: StyledProps) => css`

--- a/frontend/src/components/@shared/IconButton/index.tsx
+++ b/frontend/src/components/@shared/IconButton/index.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, PropsWithChildren } from "react";
+
 import * as Styled from "./style";
 
 export type Icon = "star" | "alarm";

--- a/frontend/src/components/@shared/IconButton/style.ts
+++ b/frontend/src/components/@shared/IconButton/style.ts
@@ -1,5 +1,7 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
+
 import { Props } from ".";
 
 const iconColorTable = {

--- a/frontend/src/components/@shared/InfiniteScroll/@hooks/useIntersectionObserver.ts
+++ b/frontend/src/components/@shared/InfiniteScroll/@hooks/useIntersectionObserver.ts
@@ -1,4 +1,5 @@
 import { RefObject, useEffect, useRef } from "react";
+
 import { Props as InfiniteScrollProps } from "@src/components/@shared/InfiniteScroll";
 
 type Props = Omit<InfiniteScrollProps, "children">;

--- a/frontend/src/components/@shared/InfiniteScroll/index.tsx
+++ b/frontend/src/components/@shared/InfiniteScroll/index.tsx
@@ -1,4 +1,5 @@
 import { PropsWithChildren } from "react";
+
 import useIntersectionObserver from "@src/components/@shared/InfiniteScroll/@hooks/useIntersectionObserver";
 
 export interface Props {

--- a/frontend/src/components/@shared/WrapperButton/index.stories.js
+++ b/frontend/src/components/@shared/WrapperButton/index.stories.js
@@ -1,5 +1,6 @@
-import WrapperButton from ".";
 import GithubIcon from "@src/components/@svgIcons/GithubIcon";
+
+import WrapperButton from ".";
 
 export default {
   title: "@shared/WrapperButton",

--- a/frontend/src/components/@shared/WrapperButton/index.tsx
+++ b/frontend/src/components/@shared/WrapperButton/index.tsx
@@ -1,4 +1,5 @@
-import { PropsWithChildren, ButtonHTMLAttributes } from "react";
+import { ButtonHTMLAttributes, PropsWithChildren } from "react";
+
 import * as Styled from "./style";
 
 export type Kind = "bigIcon" | "smallIcon" | "text";

--- a/frontend/src/components/@shared/WrapperLink/index.tsx
+++ b/frontend/src/components/@shared/WrapperLink/index.tsx
@@ -1,6 +1,8 @@
 import { ReactNode } from "react";
 import { NavLinkProps } from "react-router-dom";
+
 import { Kind } from "@src/components/@shared/WrapperButton";
+
 import * as Styled from "./style";
 
 interface Props extends NavLinkProps {

--- a/frontend/src/components/@shared/WrapperLink/style.ts
+++ b/frontend/src/components/@shared/WrapperLink/style.ts
@@ -4,8 +4,8 @@ import styled from "styled-components";
 import { Kind } from "../WrapperButton";
 
 export const Container = styled(NavLink)`
-  cursor: pointer;
   background-color: inherit;
+  cursor: pointer;
 
   ${({ kind }: { kind?: Kind }) => kind && kindTable[kind]}
 `;

--- a/frontend/src/components/@shared/WrapperLink/style.ts
+++ b/frontend/src/components/@shared/WrapperLink/style.ts
@@ -1,7 +1,8 @@
-import { kindTable } from "../WrapperButton/style";
 import { NavLink } from "react-router-dom";
 import styled from "styled-components";
+
 import { Kind } from "../WrapperButton";
+import { kindTable } from "../WrapperButton/style";
 
 export const Container = styled(NavLink)`
   background-color: inherit;

--- a/frontend/src/components/Calendar/index.tsx
+++ b/frontend/src/components/Calendar/index.tsx
@@ -1,10 +1,13 @@
-import * as Styled from "./style";
-import ArrowIconRight from "@src/components/@svgIcons/ArrowIconRight";
-import ArrowIconLeft from "@src/components/@svgIcons/ArrowIconLeft";
-import useCalendar from "@src/components/Calendar/@hooks/useCalendar";
-import WrapperButton from "@src/components/@shared/WrapperButton";
 import { Link } from "react-router-dom";
+
+import WrapperButton from "@src/components/@shared/WrapperButton";
+import ArrowIconLeft from "@src/components/@svgIcons/ArrowIconLeft";
+import ArrowIconRight from "@src/components/@svgIcons/ArrowIconRight";
+import useCalendar from "@src/components/Calendar/@hooks/useCalendar";
+
 import { ISOConverter } from "@src/@utils";
+
+import * as Styled from "./style";
 
 const WEEKDAYS = ["일", "월", "화", "수", "목", "금", "토"] as const;
 const MONTHS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12] as const;

--- a/frontend/src/components/Calendar/style.ts
+++ b/frontend/src/components/Calendar/style.ts
@@ -8,15 +8,18 @@ interface StyledDayProps extends StyledDefaultProps {
 }
 
 export const Container = styled.div`
-  width: 280px;
-  height: 313px;
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  width: 280px;
+  height: 313px;
   padding: 18px;
+
   position: fixed;
   top: 40%;
   left: 50%;
+
   transform: translate(-50%, -50%);
   z-index: 2;
 
@@ -26,10 +29,11 @@ export const Container = styled.div`
 `;
 
 export const Month = styled.div`
-  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-between;
+
+  width: 100%;
 `;
 
 export const Title = styled.h1`
@@ -39,10 +43,11 @@ export const Title = styled.h1`
 `;
 
 export const Weekdays = styled.div`
-  width: 100%;
   display: flex;
   align-items: center;
   justify-content: space-around;
+
+  width: 100%;
 `;
 
 export const Weekday = styled.p`

--- a/frontend/src/components/Calendar/style.ts
+++ b/frontend/src/components/Calendar/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 interface StyledDayProps extends StyledDefaultProps {
   isBlank: boolean;

--- a/frontend/src/components/ChannelsDrawer/index.stories.js
+++ b/frontend/src/components/ChannelsDrawer/index.stories.js
@@ -1,5 +1,6 @@
-import ChannelsDrawer from ".";
 import { subscribedChannels } from "@src/mocks/data/channels";
+
+import ChannelsDrawer from ".";
 
 export default {
   title: "Component/ChannelsDrawer",

--- a/frontend/src/components/ChannelsDrawer/index.tsx
+++ b/frontend/src/components/ChannelsDrawer/index.tsx
@@ -1,12 +1,16 @@
-import * as Styled from "./style";
-import PlusIcon from "@src/components/@svgIcons/PlusIcon";
-import { FlexColumn, FlexRow } from "@src/@styles/shared";
-import WrapperLink from "@src/components/@shared/WrapperLink";
-import { PATH_NAME } from "@src/@constants";
-import { SubscribedChannel, Theme } from "@src/@types/shared";
-import { useTheme } from "styled-components";
-import ThemeToggler from "@src/components/ThemeToggler";
 import { useParams } from "react-router-dom";
+import { useTheme } from "styled-components";
+
+import WrapperLink from "@src/components/@shared/WrapperLink";
+import PlusIcon from "@src/components/@svgIcons/PlusIcon";
+import ThemeToggler from "@src/components/ThemeToggler";
+
+import { PATH_NAME } from "@src/@constants";
+import { FlexColumn, FlexRow } from "@src/@styles/shared";
+import { SubscribedChannel, Theme } from "@src/@types/shared";
+
+import * as Styled from "./style";
+
 interface Props {
   channels?: SubscribedChannel[];
   handleCloseDrawer: () => void;

--- a/frontend/src/components/ChannelsDrawer/style.ts
+++ b/frontend/src/components/ChannelsDrawer/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
 
 interface ChannelNameStyledProps extends StyledDefaultProps {

--- a/frontend/src/components/ChannelsDrawer/style.ts
+++ b/frontend/src/components/ChannelsDrawer/style.ts
@@ -6,13 +6,15 @@ interface ChannelNameStyledProps extends StyledDefaultProps {
 }
 
 export const Container = styled.div`
-  position: fixed;
-  top: 0;
-  left: 0;
   width: 228px;
   height: calc(100% - 78px);
   padding: 20px 0;
   border-radius: 0 4px 4px 0;
+
+  position: fixed;
+  top: 0;
+  left: 0;
+
   z-index: 2;
 
   ${({ theme }: StyledDefaultProps) => css`
@@ -21,8 +23,8 @@ export const Container = styled.div`
 `;
 
 export const Hr = styled.hr`
-  padding: 0 10px;
   height: 1px;
+  padding: 0 10px;
   border: 0;
 
   ${({ theme }: StyledDefaultProps) => css`
@@ -50,6 +52,6 @@ export const ChannelName = styled.p`
 
 export const ThemeTogglerContainer = styled.div`
   position: absolute;
-  bottom: 10px;
   left: 20px;
+  bottom: 10px;
 `;

--- a/frontend/src/components/DateDropdown/DateDropdownMenu/index.tsx
+++ b/frontend/src/components/DateDropdown/DateDropdownMenu/index.tsx
@@ -1,4 +1,5 @@
 import DateDropdownOption from "@src/components/DateDropdown/DateDropdownOption";
+
 import * as Styled from "./style";
 
 interface Props {

--- a/frontend/src/components/DateDropdown/DateDropdownMenu/style.ts
+++ b/frontend/src/components/DateDropdown/DateDropdownMenu/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.ul`

--- a/frontend/src/components/DateDropdown/DateDropdownMenu/style.ts
+++ b/frontend/src/components/DateDropdown/DateDropdownMenu/style.ts
@@ -2,13 +2,15 @@ import styled, { css } from "styled-components";
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.ul`
-  box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
-  border-radius: 4px;
   width: 125px;
   padding: 8px 12px;
+  border-radius: 4px;
+
   position: absolute;
   top: 22px;
   left: 0;
+  box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
+
   z-index: 1;
 
   ${({ theme }: StyledDefaultProps) => css`
@@ -27,9 +29,9 @@ export const Option = styled.li`
 `;
 
 export const Button = styled.button`
-  border: none;
-  cursor: pointer;
-  background-color: inherit;
   width: 100%;
+  border: none;
+  background-color: inherit;
   text-align: left;
+  cursor: pointer;
 `;

--- a/frontend/src/components/DateDropdown/DateDropdownOption/index.tsx
+++ b/frontend/src/components/DateDropdown/DateDropdownOption/index.tsx
@@ -1,7 +1,9 @@
+import { Link } from "react-router-dom";
+
+import * as Styled from "@src/components/DateDropdown/DateDropdownMenu/style";
+
 import { DATE } from "@src/@constants";
 import { ISOConverter } from "@src/@utils";
-import { Link } from "react-router-dom";
-import * as Styled from "@src/components/DateDropdown/DateDropdownMenu/style";
 
 interface Props {
   date: string;

--- a/frontend/src/components/DateDropdown/DateDropdownToggle/index.tsx
+++ b/frontend/src/components/DateDropdown/DateDropdownToggle/index.tsx
@@ -1,7 +1,10 @@
 import { ButtonHTMLAttributes } from "react";
-import * as Styled from "./style";
+
 import ArrowIconDown from "@src/components/@svgIcons/ArrowIconDown";
+
 import { FlexRow } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 interface Props extends ButtonHTMLAttributes<HTMLButtonElement> {
   text: string;

--- a/frontend/src/components/DateDropdown/DateDropdownToggle/style.ts
+++ b/frontend/src/components/DateDropdown/DateDropdownToggle/style.ts
@@ -4,12 +4,13 @@ import styled, { css } from "styled-components";
 export const Container = styled.button`
   display: flex;
   align-items: center;
-  border: none;
-  padding: 4px 12px;
+
   width: fit-content;
+  border: none;
+  border-radius: 50px;
+  padding: 4px 12px;
   background-color: ${({ theme }: StyledDefaultProps) =>
     theme.COLOR.BACKGROUND.SECONDARY};
-  border-radius: 50px;
   cursor: pointer;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
 `;

--- a/frontend/src/components/DateDropdown/index.tsx
+++ b/frontend/src/components/DateDropdown/index.tsx
@@ -1,7 +1,9 @@
-import { getMessagesDate } from "@src/@utils";
-import Dropdown from "@src/components/Dropdown";
-import DateDropdownToggle from "@src/components/DateDropdown/DateDropdownToggle";
 import DateDropdownMenu from "@src/components/DateDropdown/DateDropdownMenu";
+import DateDropdownToggle from "@src/components/DateDropdown/DateDropdownToggle";
+import Dropdown from "@src/components/Dropdown";
+
+import { getMessagesDate } from "@src/@utils";
+
 import * as Styled from "./style";
 
 interface Props {

--- a/frontend/src/components/DateDropdown/style.ts
+++ b/frontend/src/components/DateDropdown/style.ts
@@ -1,7 +1,8 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
-  margin-top: 10px;
-  position: relative;
   width: fit-content;
+  margin-top: 10px;
+
+  position: relative;
 `;

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -1,4 +1,4 @@
-import useDropdown from "@src/hooks/useDropdown";
+import useDropdown from "@src/components/Dropdown/@hooks/useDropdown";
 import useOuterClick from "@src/hooks/useOuterClick";
 import { RefObject, useEffect } from "react";
 

--- a/frontend/src/components/Dropdown/index.tsx
+++ b/frontend/src/components/Dropdown/index.tsx
@@ -1,6 +1,8 @@
-import useDropdown from "@src/components/Dropdown/@hooks/useDropdown";
-import useOuterClick from "@src/hooks/useOuterClick";
 import { RefObject, useEffect } from "react";
+
+import useDropdown from "@src/components/Dropdown/@hooks/useDropdown";
+
+import useOuterClick from "@src/hooks/useOuterClick";
 
 interface ChildrenProps {
   innerRef: RefObject<HTMLDivElement>;

--- a/frontend/src/components/EmptyStatus/index.tsx
+++ b/frontend/src/components/EmptyStatus/index.tsx
@@ -1,6 +1,8 @@
-import { FlexColumn } from "@src/@styles/shared";
-import usePushPreviousPage from "@src/hooks/usePushPreviousPage";
 import Button from "@src/components/@shared/Button";
+
+import usePushPreviousPage from "@src/hooks/usePushPreviousPage";
+
+import { FlexColumn } from "@src/@styles/shared";
 
 function EmptyStatus() {
   const pushPreviousPage = usePushPreviousPage();

--- a/frontend/src/components/ErrorBoundary/index.tsx
+++ b/frontend/src/components/ErrorBoundary/index.tsx
@@ -1,4 +1,4 @@
-import { Component, ReactNode, PropsWithChildren } from "react";
+import { Component, PropsWithChildren, ReactNode } from "react";
 
 interface Props {
   fallback: ReactNode;

--- a/frontend/src/components/Loader/style.ts
+++ b/frontend/src/components/Loader/style.ts
@@ -4,14 +4,16 @@ import styled, { css } from "styled-components";
 export const Container = styled.div`
   display: grid;
   justify-items: center;
+
   margin: 40vh 0;
 `;
 
 export const DefaultLoadingCSS = css`
+  grid-area: 1/1;
+
   width: 50px;
   height: 50px;
   border-radius: 100%;
-  grid-area: 1/1;
 `;
 
 export const LeftCircle = styled.div`

--- a/frontend/src/components/Loader/style.ts
+++ b/frontend/src/components/Loader/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   display: grid;

--- a/frontend/src/components/MessageCard/MessageCardSkeleton/index.tsx
+++ b/frontend/src/components/MessageCard/MessageCardSkeleton/index.tsx
@@ -1,4 +1,5 @@
 import { FlexColumn } from "@src/@styles/shared";
+
 import * as Styled from "./style";
 
 function MessageCardSkeleton() {

--- a/frontend/src/components/MessageCard/MessageCardSkeleton/style.ts
+++ b/frontend/src/components/MessageCard/MessageCardSkeleton/style.ts
@@ -1,5 +1,6 @@
+import styled, { css, keyframes } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
-import styled, { keyframes, css } from "styled-components";
 
 const refresh = keyframes`
   0% {

--- a/frontend/src/components/MessageCard/MessageCardSkeleton/style.ts
+++ b/frontend/src/components/MessageCard/MessageCardSkeleton/style.ts
@@ -15,10 +15,11 @@ const refresh = keyframes`
 
 export const Container = styled.div`
   display: flex;
-  padding: 14px;
   column-gap: 4px;
+
   width: 100%;
   height: auto;
+  padding: 14px;
   border-radius: 4px;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
 
@@ -39,6 +40,7 @@ export const WriterSkeleton = styled.div`
   width: 71px;
   height: 14px;
   border-radius: 4px;
+
   animation: ${refresh} 2s infinite ease-out;
 `;
 
@@ -46,6 +48,7 @@ export const LongLineSkeleton = styled.div`
   width: 90%;
   height: 10px;
   border-radius: 4px;
+
   animation: ${refresh} 2s infinite ease-out;
 `;
 
@@ -53,5 +56,6 @@ export const ShortLineSkeleton = styled.div`
   width: 60%;
   height: 10px;
   border-radius: 4px;
+
   animation: ${refresh} 2s infinite ease-out;
 `;

--- a/frontend/src/components/MessageCard/MessageIconButtons/@styles/style.ts
+++ b/frontend/src/components/MessageCard/MessageIconButtons/@styles/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const ButtonText = styled.p`
   ${({ theme }: StyledDefaultProps) => css`

--- a/frontend/src/components/MessageCard/MessageIconButtons/BookmarkButton/index.tsx
+++ b/frontend/src/components/MessageCard/MessageIconButtons/BookmarkButton/index.tsx
@@ -1,7 +1,10 @@
 import { MouseEventHandler } from "react";
+
 import IconButton from "@src/components/@shared/IconButton";
 import StarIcon from "@src/components/@svgIcons/StarIcon";
+
 import { FlexRow } from "@src/@styles/shared";
+
 import * as Styled from "../@styles/style";
 
 interface Props {

--- a/frontend/src/components/MessageCard/MessageIconButtons/ReminderButton/index.tsx
+++ b/frontend/src/components/MessageCard/MessageIconButtons/ReminderButton/index.tsx
@@ -1,8 +1,11 @@
 import { MouseEventHandler } from "react";
-import { FlexRow } from "@src/@styles/shared";
+
 import IconButton from "@src/components/@shared/IconButton";
-import * as Styled from "../@styles/style";
 import ReminderIconActive from "@src/components/@svgIcons/ReminderIconActive";
+
+import { FlexRow } from "@src/@styles/shared";
+
+import * as Styled from "../@styles/style";
 
 interface Props {
   isActive: boolean;

--- a/frontend/src/components/MessageCard/ProfileImage/index.stories.js
+++ b/frontend/src/components/MessageCard/ProfileImage/index.stories.js
@@ -1,5 +1,6 @@
-import ProfileImage from ".";
 import MockImage from "@public/assets/images/MockImage.png";
+
+import ProfileImage from ".";
 
 export default {
   title: "@Component/ProfileImage",

--- a/frontend/src/components/MessageCard/ProfileImage/index.tsx
+++ b/frontend/src/components/MessageCard/ProfileImage/index.tsx
@@ -1,10 +1,10 @@
-import React from "react";
+import { ImgHTMLAttributes } from "react";
 
 import DefaultProfileImage from "@public/assets/images/DefaultProfileImage.png";
 
 import * as Styled from "./style";
 
-interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {
+interface Props extends ImgHTMLAttributes<HTMLImageElement> {
   src?: string;
 }
 

--- a/frontend/src/components/MessageCard/ProfileImage/index.tsx
+++ b/frontend/src/components/MessageCard/ProfileImage/index.tsx
@@ -1,5 +1,7 @@
 import React from "react";
+
 import DefaultProfileImage from "@public/assets/images/DefaultProfileImage.png";
+
 import * as Styled from "./style";
 
 interface Props extends React.ImgHTMLAttributes<HTMLImageElement> {

--- a/frontend/src/components/MessageCard/ProfileImage/style.ts
+++ b/frontend/src/components/MessageCard/ProfileImage/style.ts
@@ -3,7 +3,7 @@ import styled from "styled-components";
 export const Container = styled.img`
   width: 35px;
   height: 35px;
+  border-radius: 50%;
   object-fit: contain;
   cursor: pointer;
-  border-radius: 50%;
 `;

--- a/frontend/src/components/MessageCard/index.stories.js
+++ b/frontend/src/components/MessageCard/index.stories.js
@@ -1,5 +1,6 @@
-import MessageCard from ".";
 import MockImage from "@public/assets/images/MockImage.png";
+
+import MessageCard from ".";
 
 export default {
   title: "@Component/MessageCard",

--- a/frontend/src/components/MessageCard/index.tsx
+++ b/frontend/src/components/MessageCard/index.tsx
@@ -1,7 +1,10 @@
 import { PropsWithChildren } from "react";
-import * as Styled from "./style";
+
 import ProfileImage from "@src/components/MessageCard/ProfileImage";
+
 import { FlexRow } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 interface Props {
   username: string;

--- a/frontend/src/components/MessageCard/style.ts
+++ b/frontend/src/components/MessageCard/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   display: flex;

--- a/frontend/src/components/MessageCard/style.ts
+++ b/frontend/src/components/MessageCard/style.ts
@@ -5,10 +5,11 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
+  column-gap: 4px;
+
+  width: 100%;
   height: auto;
   padding: 14px;
-  column-gap: 4px;
-  width: 100%;
   border-radius: 4px;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
 

--- a/frontend/src/components/ReminderModal/@hooks/useDatePicker.ts
+++ b/frontend/src/components/ReminderModal/@hooks/useDatePicker.ts
@@ -1,8 +1,11 @@
+import { useEffect, useRef, useState } from "react";
+
+import { parseDate } from "@src/components/ReminderModal/@utils";
+
+import useInput from "@src/hooks/useInput";
+
 import { PICKER_OPTION_SCROLL } from "@src/@constants";
 import { getDateInformation } from "@src/@utils";
-import { useEffect, useRef, useState } from "react";
-import useInput from "@src/hooks/useInput";
-import { parseDate } from "@src/components/ReminderModal/@utils";
 
 interface Props {
   remindDate: string;

--- a/frontend/src/components/ReminderModal/@hooks/useTimePicker.ts
+++ b/frontend/src/components/ReminderModal/@hooks/useTimePicker.ts
@@ -1,12 +1,15 @@
-import { PICKER_OPTION_SCROLL } from "@src/@constants";
-import { getDateInformation, getMeridiemTime } from "@src/@utils";
 import { useEffect, useRef, useState } from "react";
-import useInput from "@src/hooks/useInput";
+
 import {
   convertTimeToStepTenMinuteTime,
   invalidMeridiem,
   parseTime,
 } from "@src/components/ReminderModal/@utils";
+
+import useInput from "@src/hooks/useInput";
+
+import { PICKER_OPTION_SCROLL } from "@src/@constants";
+import { getDateInformation, getMeridiemTime } from "@src/@utils";
 
 interface Props {
   remindDate: string;

--- a/frontend/src/components/ReminderModal/DateTimePicker/DatePicker/index.tsx
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DatePicker/index.tsx
@@ -1,11 +1,14 @@
-import { RefObject, ChangeEventHandler } from "react";
-import { FlexColumn } from "@src/@styles/shared";
+import { ChangeEventHandler, RefObject } from "react";
+
 import CalendarIcon from "@src/components/@svgIcons/CalendarIcon";
+import Dropdown from "@src/components/Dropdown";
+import { generateDateOptions } from "@src/components/ReminderModal/@utils";
 import DateTimePickerOptions from "@src/components/ReminderModal/DateTimePicker/DateTimePickerOptions";
 import DateTimePickerToggle from "@src/components/ReminderModal/DateTimePicker/DateTimePickerToggle";
-import Dropdown from "@src/components/Dropdown";
+
+import { FlexColumn } from "@src/@styles/shared";
+
 import * as Styled from "./style";
-import { generateDateOptions } from "@src/components/ReminderModal/@utils";
 
 interface Props {
   yearRef: RefObject<HTMLDivElement>;

--- a/frontend/src/components/ReminderModal/DateTimePicker/DatePicker/style.ts
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DatePicker/style.ts
@@ -11,10 +11,13 @@ export const Subtitle = styled.h2`
 `;
 
 export const TextOptionContainer = styled.div`
-  height: 128px;
   display: flex;
+
+  height: 128px;
   border-radius: 4px;
+
   position: relative;
+
   z-index: 1;
 
   ${({ theme }: StyledDefaultProps) => css`
@@ -23,17 +26,20 @@ export const TextOptionContainer = styled.div`
   `}
 
   &::before {
-    content: "";
     display: block;
+
     width: 251px;
     height: 22px;
     border-radius: 3px;
+    opacity: 0.4;
+
     position: absolute;
     top: 53px;
     left: 0;
     right: 0;
-    opacity: 0.4;
+
     pointer-events: none;
+    content: "";
 
     ${({ theme }: StyledDefaultProps) => css`
       background-color: ${theme.COLOR.BACKGROUND.TERTIARY};
@@ -46,6 +52,7 @@ export const TextOptionsWrapper = styled.div`
   flex-grow: 1;
   flex-direction: column;
   align-items: center;
+
   overflow: auto;
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/frontend/src/components/ReminderModal/DateTimePicker/DatePicker/style.ts
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DatePicker/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Subtitle = styled.h2`
   font-weight: 600;

--- a/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerOptions/index.tsx
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerOptions/index.tsx
@@ -1,5 +1,7 @@
-import { parsedOptionText } from "@src/@utils";
 import { ChangeEventHandler } from "react";
+
+import { parsedOptionText } from "@src/@utils";
+
 import * as Styled from "./style";
 
 interface Props {

--- a/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerOptions/style.ts
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerOptions/style.ts
@@ -14,14 +14,17 @@ export const Container = styled.label`
 
 export const Radio = styled.input`
   display: none;
+
   position: absolute;
   opacity: 0;
 `;
 
 export const TextOption = styled.span`
   display: flex;
-  height: 22px;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
+
+  height: 22px;
+
   cursor: pointer;
 `;

--- a/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerToggle/index.tsx
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerToggle/index.tsx
@@ -1,6 +1,9 @@
 import { PropsWithChildren } from "react";
+
 import ArrowIconDown from "@src/components/@svgIcons/ArrowIconDown";
+
 import { FlexRow } from "@src/@styles/shared";
+
 import * as Styled from "./style";
 
 interface Props {

--- a/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerToggle/style.ts
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerToggle/style.ts
@@ -3,10 +3,11 @@ import styled, { css } from "styled-components";
 
 export const Container = styled.div`
   display: flex;
-  justify-content: space-between;
   align-items: center;
-  border-radius: 4px;
+  justify-content: space-between;
+
   padding: 2px 6px;
+  border-radius: 4px;
   cursor: pointer;
 
   ${({ theme }: StyledDefaultProps) => css`

--- a/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerToggle/style.ts
+++ b/frontend/src/components/ReminderModal/DateTimePicker/DateTimePickerToggle/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   display: flex;

--- a/frontend/src/components/ReminderModal/DateTimePicker/TimePicker/index.tsx
+++ b/frontend/src/components/ReminderModal/DateTimePicker/TimePicker/index.tsx
@@ -1,11 +1,13 @@
-import { RefObject, ChangeEventHandler } from "react";
-import { FlexColumn } from "@src/@styles/shared";
+import { ChangeEventHandler, RefObject } from "react";
+
+import ReminderIconActive from "@src/components/@svgIcons/ReminderIconActive";
+import Dropdown from "@src/components/Dropdown";
+import { generateTimeOptions } from "@src/components/ReminderModal/@utils";
+import * as Styled from "@src/components/ReminderModal/DateTimePicker/DatePicker/style";
 import DateTimePickerOptions from "@src/components/ReminderModal/DateTimePicker/DateTimePickerOptions";
 import DateTimePickerToggle from "@src/components/ReminderModal/DateTimePicker/DateTimePickerToggle";
-import Dropdown from "@src/components/Dropdown";
-import * as Styled from "@src/components/ReminderModal/DateTimePicker/DatePicker/style";
-import ReminderIconActive from "@src/components/@svgIcons/ReminderIconActive";
-import { generateTimeOptions } from "@src/components/ReminderModal/@utils";
+
+import { FlexColumn } from "@src/@styles/shared";
 
 interface Props {
   meridiemRef: RefObject<HTMLDivElement>;

--- a/frontend/src/components/ReminderModal/index.tsx
+++ b/frontend/src/components/ReminderModal/index.tsx
@@ -1,10 +1,13 @@
-import * as Styled from "./style";
-import { FlexRow } from "@src/@styles/shared";
-import useMutateReminder from "@src/hooks/query/useMutateReminder";
-import useTimePicker from "@src/components/ReminderModal/@hooks/useTimePicker";
 import useDatePicker from "@src/components/ReminderModal/@hooks/useDatePicker";
+import useTimePicker from "@src/components/ReminderModal/@hooks/useTimePicker";
 import DatePicker from "@src/components/ReminderModal/DateTimePicker/DatePicker";
 import TimePicker from "@src/components/ReminderModal/DateTimePicker/TimePicker";
+
+import useMutateReminder from "@src/hooks/query/useMutateReminder";
+
+import { FlexRow } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 export type ButtonText = "생성" | "수정" | "취소" | "삭제";
 

--- a/frontend/src/components/ReminderModal/style.ts
+++ b/frontend/src/components/ReminderModal/style.ts
@@ -1,5 +1,7 @@
+import styled, { CSSProp, css } from "styled-components";
+
 import { StyledDefaultProps, Theme } from "@src/@types/shared";
-import styled, { css, CSSProp } from "styled-components";
+
 import { ButtonText } from ".";
 
 export const Container = styled.div`

--- a/frontend/src/components/ReminderModal/style.ts
+++ b/frontend/src/components/ReminderModal/style.ts
@@ -7,9 +7,11 @@ export const Container = styled.div`
   padding: 14px;
   border-radius: 4px;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
+
   position: fixed;
   top: 25%;
   left: 50%;
+
   transform: translate(-50%);
   z-index: 2;
 
@@ -61,12 +63,13 @@ interface ButtonTextProps extends StyledDefaultProps {
 }
 
 export const Button = styled.button`
+  padding: 4px 12px;
   border: none;
   border-radius: 4px;
   white-space: nowrap;
-  cursor: pointer;
   background-color: inherit;
-  padding: 4px 12px;
+  cursor: pointer;
+
   z-index: 1;
 
   ${({ theme, text }: ButtonTextProps) => css`

--- a/frontend/src/components/Router/PrivateRouter/index.tsx
+++ b/frontend/src/components/Router/PrivateRouter/index.tsx
@@ -1,10 +1,13 @@
-import { PATH_NAME, QUERY_KEY } from "@src/@constants";
-import { isCertificated } from "@src/api/auth";
 import { useEffect } from "react";
 import { useQuery } from "react-query";
 import { useNavigate } from "react-router-dom";
 import { Outlet } from "react-router-dom";
+
 import Loader from "@src/components/Loader";
+
+import { PATH_NAME, QUERY_KEY } from "@src/@constants";
+
+import { isCertificated } from "@src/api/auth";
 
 function PrivateRouter() {
   const navigate = useNavigate();

--- a/frontend/src/components/Router/PublicRouter/index.tsx
+++ b/frontend/src/components/Router/PublicRouter/index.tsx
@@ -1,10 +1,13 @@
 import { PropsWithChildren } from "react";
-import { PATH_NAME, QUERY_KEY } from "@src/@constants";
-import { isCertificated } from "@src/api/auth";
 import { useEffect } from "react";
 import { useQuery } from "react-query";
 import { useNavigate } from "react-router-dom";
+
 import Loader from "@src/components/Loader";
+
+import { PATH_NAME, QUERY_KEY } from "@src/@constants";
+
+import { isCertificated } from "@src/api/auth";
 
 function PublicRouter({ children }: PropsWithChildren) {
   const navigate = useNavigate();

--- a/frontend/src/components/SearchForm/@hooks/useSelectChannels.ts
+++ b/frontend/src/components/SearchForm/@hooks/useSelectChannels.ts
@@ -1,6 +1,8 @@
-import { SubscribedChannel } from "@src/@types/shared";
 import { useCallback, useEffect, useMemo, useState } from "react";
+
 import useGetSubscribedChannels from "@src/hooks/query/useGetSubscribedChannels";
+
+import { SubscribedChannel } from "@src/@types/shared";
 
 interface Props {
   currentChannelIds: number[];

--- a/frontend/src/components/SearchForm/@hooks/useSubmitSearchForm.ts
+++ b/frontend/src/components/SearchForm/@hooks/useSubmitSearchForm.ts
@@ -1,12 +1,14 @@
 import {
-  ChangeEventHandler,
   ChangeEvent,
-  FormEventHandler,
+  ChangeEventHandler,
   FormEvent,
+  FormEventHandler,
   useState,
 } from "react";
 import { useNavigate } from "react-router-dom";
+
 import useSnackbar from "@src/hooks/useSnackbar";
+
 import { PATH_NAME } from "@src/@constants";
 
 interface Props {

--- a/frontend/src/components/SearchForm/SearchInput/index.tsx
+++ b/frontend/src/components/SearchForm/SearchInput/index.tsx
@@ -1,7 +1,10 @@
-import { PropsWithChildren, InputHTMLAttributes } from "react";
-import * as Styled from "./style";
+import { InputHTMLAttributes, PropsWithChildren } from "react";
+
 import SearchIcon from "@src/components/@svgIcons/SearchIcon";
+
 import { FlexRow } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 function SearchInput({
   children,

--- a/frontend/src/components/SearchForm/SearchInput/style.ts
+++ b/frontend/src/components/SearchForm/SearchInput/style.ts
@@ -1,4 +1,5 @@
 import styled, { css } from "styled-components";
+
 import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div``;

--- a/frontend/src/components/SearchForm/SearchInput/style.ts
+++ b/frontend/src/components/SearchForm/SearchInput/style.ts
@@ -5,9 +5,10 @@ export const Container = styled.div``;
 
 export const Input = styled.input`
   display: inline-block;
-  outline: none;
-  border: none;
+
   width: 100%;
+  border: none;
+  outline: none;
   background-color: transparent;
 
   ${({ theme }: StyledDefaultProps) => css`
@@ -24,11 +25,11 @@ export const Input = styled.input`
 `;
 
 export const SearchButton = styled.button`
+  padding: 0.25rem 0.938rem;
   border: none;
   border-radius: 4px;
   white-space: nowrap;
   cursor: pointer;
-  padding: 0.25rem 0.938rem;
 
   ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.CAPTION};

--- a/frontend/src/components/SearchForm/SearchOptions/index.tsx
+++ b/frontend/src/components/SearchForm/SearchOptions/index.tsx
@@ -1,6 +1,9 @@
-import { SubscribedChannel } from "@src/@types/shared";
-import Button from "@src/components/@shared/Button";
 import { memo } from "react";
+
+import Button from "@src/components/@shared/Button";
+
+import { SubscribedChannel } from "@src/@types/shared";
+
 import * as Styled from "./style";
 
 interface Props {

--- a/frontend/src/components/SearchForm/SearchOptions/style.ts
+++ b/frontend/src/components/SearchForm/SearchOptions/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   display: flex;

--- a/frontend/src/components/SearchForm/SearchOptions/style.ts
+++ b/frontend/src/components/SearchForm/SearchOptions/style.ts
@@ -5,12 +5,14 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   gap: 10px;
+
   margin-top: 20px;
 `;
 
 export const ScrollContainer = styled.div`
   display: flex;
   gap: 5px;
+
   overflow: scroll;
   scrollbar-width: none;
   -ms-overflow-style: none;

--- a/frontend/src/components/SearchForm/index.tsx
+++ b/frontend/src/components/SearchForm/index.tsx
@@ -1,9 +1,10 @@
-import SearchOptions from "@src/components/SearchForm/SearchOptions";
-import SearchInput from "@src/components/SearchForm/SearchInput";
-import * as Styled from "./style";
+import Dropdown from "@src/components/Dropdown";
 import useSelectChannels from "@src/components/SearchForm/@hooks/useSelectChannels";
 import useSubmitSearchForm from "@src/components/SearchForm/@hooks/useSubmitSearchForm";
-import Dropdown from "@src/components/Dropdown";
+import SearchInput from "@src/components/SearchForm/SearchInput";
+import SearchOptions from "@src/components/SearchForm/SearchOptions";
+
+import * as Styled from "./style";
 
 interface Props {
   currentKeyword?: string;

--- a/frontend/src/components/SearchForm/style.ts
+++ b/frontend/src/components/SearchForm/style.ts
@@ -5,16 +5,18 @@ export const Container = styled.form`
   display: flex;
   flex-direction: column;
   gap: 6px;
-  padding: 16px 34px;
-  width: 100%;
-  border-radius: 4px;
-  position: fixed;
+
   width: 100%;
   max-width: 960px;
+  padding: 16px 34px;
+  border-radius: 4px;
   box-shadow: 0.5px 0.5px 2px 0px rgba(0, 0, 0, 0.1);
+
+  position: fixed;
   top: 0;
   left: 50%;
   right: 0;
+
   transform: translate(-50%);
   z-index: 2;
 

--- a/frontend/src/components/SearchForm/style.ts
+++ b/frontend/src/components/SearchForm/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.form`
   display: flex;

--- a/frontend/src/components/Snackbar/index.tsx
+++ b/frontend/src/components/Snackbar/index.tsx
@@ -1,9 +1,11 @@
-import * as Styled from "./style";
+import { useEffect, useRef } from "react";
 import ReactDOM from "react-dom";
 import { useRecoilState } from "recoil";
+
 import { snackbarState } from "@src/@atoms";
-import { useEffect, useRef } from "react";
 import { SNACKBAR_STATUS } from "@src/@constants";
+
+import * as Styled from "./style";
 
 function Snackbar() {
   const [{ isOpened, message, status }, setState] =

--- a/frontend/src/components/Snackbar/style.ts
+++ b/frontend/src/components/Snackbar/style.ts
@@ -1,7 +1,8 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
-import { SnackbarStatus } from "@src/@types/shared";
+
 import { SNACKBAR_STATUS } from "@src/@constants";
+import { StyledDefaultProps } from "@src/@types/shared";
+import { SnackbarStatus } from "@src/@types/shared";
 
 interface StyledProps extends StyledDefaultProps {
   status: SnackbarStatus;

--- a/frontend/src/components/Snackbar/style.ts
+++ b/frontend/src/components/Snackbar/style.ts
@@ -8,17 +8,20 @@ interface StyledProps extends StyledDefaultProps {
 }
 
 export const Container = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
   position: fixed;
-  bottom: 100px;
   left: 50%;
-  transform: translate(-50%, 0);
+  bottom: 100px;
+
   width: 300px;
   min-height: 60px;
   padding: 16px;
   border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+
+  transform: translate(-50%, 0);
   z-index: 3;
 
   ${({ theme, status }: StyledProps) => css`

--- a/frontend/src/components/ThemeToggler/index.tsx
+++ b/frontend/src/components/ThemeToggler/index.tsx
@@ -1,7 +1,10 @@
-import { THEME_KIND } from "@src/@constants";
-import useModeTheme from "@src/hooks/useModeTheme";
 import MoonIcon from "@src/components/@svgIcons/MoonIcon";
 import SunIcon from "@src/components/@svgIcons/SunIcon";
+
+import useModeTheme from "@src/hooks/useModeTheme";
+
+import { THEME_KIND } from "@src/@constants";
+
 import * as Styled from "./style";
 
 function ThemeToggler() {

--- a/frontend/src/components/ThemeToggler/style.ts
+++ b/frontend/src/components/ThemeToggler/style.ts
@@ -4,20 +4,24 @@ import styled, { css } from "styled-components";
 export const Container = styled.label`
   width: 62px;
   height: 32px;
+
   position: relative;
 `;
 
 export const CheckBox = styled.input`
+  display: inline-block;
   appearance: none;
+
   width: 62px;
   height: 32px;
-  display: inline-block;
-  position: relative;
-  border-radius: 50px;
-  overflow: hidden;
-  outline: none;
   border: none;
+  outline: none;
+  border-radius: 50px;
   cursor: pointer;
+  overflow: hidden;
+
+  position: relative;
+
   ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.TEXT.DEFAULT};
   `}
@@ -28,24 +32,30 @@ interface IconContainerProps extends StyledDefaultProps {
 }
 
 export const LeftIconContainer = styled.div`
-  transform: scaleY(1);
+  cursor: pointer;
+
   position: absolute;
   top: -12px;
   left: 10px;
-  cursor: pointer;
+
+  transform: scaleY(1);
   transition: opacity cubic-bezier(0.3, 1.5, 0.7, 1) 0.5s;
+
   ${({ isVisible }: IconContainerProps) => css`
     opacity: ${isVisible ? "1" : "0"};
   `}
 `;
 
 export const RightIconContainer = styled.div`
-  transform: scaleY(1);
+  cursor: pointer;
+
   position: absolute;
   top: -12px;
   right: 10px;
-  cursor: pointer;
+
+  transform: scaleY(1);
   transition: all cubic-bezier(0.3, 1.5, 0.7, 1) 0.5s;
+
   ${({ isVisible }: IconContainerProps) => css`
     opacity: ${isVisible ? "1" : "0"};
   `}

--- a/frontend/src/components/ThemeToggler/style.ts
+++ b/frontend/src/components/ThemeToggler/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.label`
   width: 62px;

--- a/frontend/src/hooks/query/useGetCertification.ts
+++ b/frontend/src/hooks/query/useGetCertification.ts
@@ -1,7 +1,9 @@
+import { useQuery } from "react-query";
+
 import { QUERY_KEY } from "@src/@constants";
 import { CustomError, ResponseToken } from "@src/@types/shared";
+
 import { slackLogin } from "@src/api/auth";
-import { useQuery } from "react-query";
 
 interface Props {
   slackCode: string;

--- a/frontend/src/hooks/query/useGetChannels.ts
+++ b/frontend/src/hooks/query/useGetChannels.ts
@@ -1,7 +1,9 @@
+import { useQuery } from "react-query";
+
 import { QUERY_KEY } from "@src/@constants";
 import { CustomError, ResponseChannels } from "@src/@types/shared";
+
 import { getChannels } from "@src/api/channels";
-import { useQuery } from "react-query";
 
 function useGetChannels() {
   return useQuery<ResponseChannels, CustomError>(

--- a/frontend/src/hooks/query/useGetInfiniteBookmarks.ts
+++ b/frontend/src/hooks/query/useGetInfiniteBookmarks.ts
@@ -1,7 +1,9 @@
+import { useInfiniteQuery } from "react-query";
+
 import { QUERY_KEY } from "@src/@constants";
 import { CustomError, ResponseBookmarks } from "@src/@types/shared";
+
 import { getBookmarks } from "@src/api/bookmarks";
-import { useInfiniteQuery } from "react-query";
 
 function useGetInfiniteBookmarks() {
   return useInfiniteQuery<ResponseBookmarks, CustomError>(

--- a/frontend/src/hooks/query/useGetInfiniteMessages.ts
+++ b/frontend/src/hooks/query/useGetInfiniteMessages.ts
@@ -1,7 +1,9 @@
+import { useInfiniteQuery } from "react-query";
+
 import { QUERY_KEY } from "@src/@constants";
 import { CustomError, ResponseMessages } from "@src/@types/shared";
+
 import { getMessages } from "@src/api/messages";
-import { useInfiniteQuery } from "react-query";
 
 interface Props {
   queryKey: string[];

--- a/frontend/src/hooks/query/useGetInfiniteReminders.ts
+++ b/frontend/src/hooks/query/useGetInfiniteReminders.ts
@@ -1,7 +1,9 @@
+import { useInfiniteQuery } from "react-query";
+
 import { QUERY_KEY } from "@src/@constants";
 import { CustomError, ResponseReminders } from "@src/@types/shared";
+
 import { getReminders } from "@src/api/reminders";
-import { useInfiniteQuery } from "react-query";
 
 function useGetInfiniteReminders() {
   return useInfiniteQuery<ResponseReminders, CustomError>(

--- a/frontend/src/hooks/query/useGetSubscribedChannels.ts
+++ b/frontend/src/hooks/query/useGetSubscribedChannels.ts
@@ -1,7 +1,9 @@
+import { useQuery } from "react-query";
+
 import { QUERY_KEY } from "@src/@constants";
 import { CustomError, ResponseSubscribedChannels } from "@src/@types/shared";
+
 import { getSubscribedChannels } from "@src/api/channels";
-import { useQuery } from "react-query";
 
 function useGetSubscribedChannels() {
   return useQuery<ResponseSubscribedChannels, CustomError>(

--- a/frontend/src/hooks/query/useMutateBookmark.ts
+++ b/frontend/src/hooks/query/useMutateBookmark.ts
@@ -1,5 +1,6 @@
-import { postBookmark, deleteBookmark } from "@src/api/bookmarks";
 import { useMutation } from "react-query";
+
+import { deleteBookmark, postBookmark } from "@src/api/bookmarks";
 
 interface Props {
   handleSettleAddBookmark?: () => void;

--- a/frontend/src/hooks/query/useMutateChannels.ts
+++ b/frontend/src/hooks/query/useMutateChannels.ts
@@ -1,5 +1,6 @@
-import { subscribeChannel, unsubscribeChannel } from "@src/api/channels";
 import { useMutation } from "react-query";
+
+import { subscribeChannel, unsubscribeChannel } from "@src/api/channels";
 
 interface Props {
   handleSettleSubscribeChannel?: () => void;

--- a/frontend/src/hooks/query/useMutateReminder.ts
+++ b/frontend/src/hooks/query/useMutateReminder.ts
@@ -1,7 +1,10 @@
-import { deleteReminder, postReminder, putReminder } from "@src/api/reminders";
-import { getDateInformation, ISOConverter } from "@src/@utils";
 import { useMutation } from "react-query";
+
 import useSnackbar from "@src/hooks/useSnackbar";
+
+import { ISOConverter, getDateInformation } from "@src/@utils";
+
+import { deleteReminder, postReminder, putReminder } from "@src/api/reminders";
 
 interface IsInvalidateDateTimeProps {
   checkedYear: number;

--- a/frontend/src/hooks/useApiError.ts
+++ b/frontend/src/hooks/useApiError.ts
@@ -1,7 +1,9 @@
+import { useNavigate } from "react-router-dom";
+
+import useSnackbar from "@src/hooks/useSnackbar";
+
 import { ERROR_MESSAGE_BY_CODE, PATH_NAME } from "@src/@constants";
 import { CustomError } from "@src/@types/shared";
-import { useNavigate } from "react-router-dom";
-import useSnackbar from "@src/hooks/useSnackbar";
 
 interface ReturnType {
   handleError: (error: any) => void;

--- a/frontend/src/hooks/useAuthentication.ts
+++ b/frontend/src/hooks/useAuthentication.ts
@@ -1,14 +1,16 @@
-import {
-  ACCESS_TOKEN_KEY,
-  QUERY_KEY,
-  MESSAGES,
-  PATH_NAME,
-} from "@src/@constants";
-import { deleteCookie, setCookie } from "@src/@utils";
 import { useQueryClient } from "react-query";
 import { useNavigate } from "react-router-dom";
-import useSnackbar from "@src/hooks/useSnackbar";
+
 import useRecentFeedPath from "@src/hooks/useRecentFeedPath";
+import useSnackbar from "@src/hooks/useSnackbar";
+
+import {
+  ACCESS_TOKEN_KEY,
+  MESSAGES,
+  PATH_NAME,
+  QUERY_KEY,
+} from "@src/@constants";
+import { deleteCookie, setCookie } from "@src/@utils";
 
 interface ReturnType {
   login: (token: string, isFirstLogin: boolean) => void;

--- a/frontend/src/hooks/useInput.ts
+++ b/frontend/src/hooks/useInput.ts
@@ -1,4 +1,4 @@
-import { ChangeEvent, useState, ChangeEventHandler } from "react";
+import { ChangeEvent, ChangeEventHandler, useState } from "react";
 
 interface Props {
   initialValue: string;

--- a/frontend/src/hooks/useModal.ts
+++ b/frontend/src/hooks/useModal.ts
@@ -1,10 +1,11 @@
-import { ResponseSubscribedChannels } from "@src/@types/shared";
 import { useEffect, useState } from "react";
 import {
   QueryObserverResult,
   RefetchOptions,
   RefetchQueryFilters,
 } from "react-query";
+
+import { ResponseSubscribedChannels } from "@src/@types/shared";
 
 type Refetch = <TPageData>(
   options?: (RefetchOptions & RefetchQueryFilters<TPageData>) | undefined

--- a/frontend/src/hooks/useModeTheme.ts
+++ b/frontend/src/hooks/useModeTheme.ts
@@ -1,9 +1,12 @@
 import { useEffect } from "react";
-import useWebStorage, { STORAGE_KIND } from "@src/hooks/useWebStorage";
 import { useRecoilState } from "recoil";
+
+import useWebStorage, { STORAGE_KIND } from "@src/hooks/useWebStorage";
+
 import { themeState } from "@src/@atoms";
-import { ThemeKind } from "@src/@types/shared";
 import { THEME_KIND } from "@src/@constants";
+import { ThemeKind } from "@src/@types/shared";
+
 interface ReturnType {
   theme: ThemeKind;
   handleToggleTheme: () => void;

--- a/frontend/src/hooks/useRecentFeedPath.ts
+++ b/frontend/src/hooks/useRecentFeedPath.ts
@@ -1,6 +1,7 @@
-import { useLocation } from "react-router-dom";
-import useWebStorage, { STORAGE_KIND } from "@src/hooks/useWebStorage";
 import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+import useWebStorage, { STORAGE_KIND } from "@src/hooks/useWebStorage";
 
 function useRecentFeedPath() {
   const { key, pathname } = useLocation();

--- a/frontend/src/hooks/useSnackbar.ts
+++ b/frontend/src/hooks/useSnackbar.ts
@@ -1,5 +1,6 @@
-import { snackbarState } from "@src/@atoms";
 import { useSetRecoilState } from "recoil";
+
+import { snackbarState } from "@src/@atoms";
 
 type openHandler = (message: string) => void;
 

--- a/frontend/src/hooks/useTopScreenEventHandlers.ts
+++ b/frontend/src/hooks/useTopScreenEventHandlers.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, WheelEventHandler, TouchEventHandler } from "react";
+import { TouchEventHandler, WheelEventHandler, useEffect, useRef } from "react";
 
 interface Props {
   isCallable?: boolean;

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -1,10 +1,11 @@
-import ReactDOM from "react-dom/client";
 import App from "@src/App";
-import { BrowserRouter } from "react-router-dom";
-import ErrorBoundary from "@src/components/ErrorBoundary";
-import UnexpectedError from "@src/pages/UnexpectedError";
-import { RecoilRoot } from "recoil";
 import { initMSW } from "@src/mocks";
+import UnexpectedError from "@src/pages/UnexpectedError";
+import ReactDOM from "react-dom/client";
+import { BrowserRouter } from "react-router-dom";
+import { RecoilRoot } from "recoil";
+
+import ErrorBoundary from "@src/components/ErrorBoundary";
 
 initMSW();
 

--- a/frontend/src/mocks/browser.ts
+++ b/frontend/src/mocks/browser.ts
@@ -1,4 +1,5 @@
 import { setupWorker } from "msw";
+
 import handlers from "./handlers";
 
 export const worker = setupWorker(...handlers);

--- a/frontend/src/mocks/handlers/bookmarks.ts
+++ b/frontend/src/mocks/handlers/bookmarks.ts
@@ -1,6 +1,7 @@
-import { messages } from "../data/messages";
 import { rest } from "msw";
-import { SIZE, BODY_TYPE } from "../utils";
+
+import { messages } from "../data/messages";
+import { BODY_TYPE, SIZE } from "../utils";
 
 let bookmarks = [] as any;
 

--- a/frontend/src/mocks/handlers/channels.ts
+++ b/frontend/src/mocks/handlers/channels.ts
@@ -1,4 +1,5 @@
 import { rest } from "msw";
+
 import { channels, subscribedChannels } from "../data/channels";
 
 const handlers = [

--- a/frontend/src/mocks/handlers/index.ts
+++ b/frontend/src/mocks/handlers/index.ts
@@ -1,7 +1,7 @@
+import auth from "./auth";
 import bookmarks from "./bookmarks";
 import channels from "./channels";
 import messages from "./messages";
-import auth from "./auth";
 
 const handlers = [...bookmarks, ...channels, ...messages, ...auth];
 

--- a/frontend/src/mocks/handlers/messages.ts
+++ b/frontend/src/mocks/handlers/messages.ts
@@ -1,4 +1,5 @@
-import { DefaultBodyType, ResponseComposition, rest, RestContext } from "msw";
+import { DefaultBodyType, ResponseComposition, RestContext, rest } from "msw";
+
 import { messages } from "../data/messages";
 import { SIZE } from "../utils";
 

--- a/frontend/src/pages/AddChannel/index.tsx
+++ b/frontend/src/pages/AddChannel/index.tsx
@@ -1,10 +1,14 @@
-import * as Styled from "./style";
-import Button from "@src/components/@shared/Button";
-import { FlexColumn } from "@src/@styles/shared";
-import { PATH_NAME } from "@src/@constants";
 import { Link } from "react-router-dom";
-import useMutateChannels from "@src/hooks/query/useMutateChannels";
+
+import Button from "@src/components/@shared/Button";
+
 import useGetChannels from "@src/hooks/query/useGetChannels";
+import useMutateChannels from "@src/hooks/query/useMutateChannels";
+
+import { PATH_NAME } from "@src/@constants";
+import { FlexColumn } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 function AddChannel() {
   const { data, refetch } = useGetChannels();

--- a/frontend/src/pages/AddChannel/style.ts
+++ b/frontend/src/pages/AddChannel/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   display: flex;

--- a/frontend/src/pages/AddChannel/style.ts
+++ b/frontend/src/pages/AddChannel/style.ts
@@ -2,14 +2,16 @@ import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
 
 export const Container = styled.div`
-  padding: 20px;
   display: flex;
   flex-direction: column;
+
   min-width: 320px;
+  padding: 20px;
 `;
 
 export const Title = styled.h1`
   margin-bottom: 10px;
+
   ${({ theme }: StyledDefaultProps) => css`
     font-family: ${theme.FONT.SECONDARY};
     font-size: ${theme.FONT_SIZE.SUBTITLE};
@@ -24,9 +26,10 @@ export const Description = styled.p`
 
 export const ChannelListContainer = styled.div`
   display: flex;
-  flex-wrap: wrap;
   align-items: center;
   justify-content: center;
+  flex-wrap: wrap;
+
   width: 100%;
   min-width: 320px;
   gap: 10px;
@@ -35,12 +38,14 @@ export const ChannelListContainer = styled.div`
 
 export const Button = styled.button`
   display: block;
+
+  padding: 0.25rem 0.75rem;
+  background-color: inherit;
   border-radius: 50px;
   white-space: nowrap;
-  cursor: pointer;
-  background-color: inherit;
-  padding: 0.25rem 0.75rem;
+
   font-weight: 600;
+  cursor: pointer;
 
   ${({ theme }: StyledDefaultProps) => css`
     font-size: ${theme.FONT_SIZE.LARGE_BODY};

--- a/frontend/src/pages/Bookmark/index.tsx
+++ b/frontend/src/pages/Bookmark/index.tsx
@@ -1,14 +1,17 @@
-import { FlexColumn } from "@src/@styles/shared";
-import MessageCard from "@src/components/MessageCard";
 import * as Styled from "@src/pages/Feed/style";
+
 import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
-import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
-import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
 import EmptyStatus from "@src/components/EmptyStatus";
+import MessageCard from "@src/components/MessageCard";
 import BookmarkButton from "@src/components/MessageCard/MessageIconButtons/BookmarkButton";
-import { extractResponseBookmarks, parseMeridemTime } from "@src/@utils";
+import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
+
 import useGetInfiniteBookmarks from "@src/hooks/query/useGetInfiniteBookmarks";
+import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
 import useScrollToTop from "@src/hooks/useScrollToTop";
+
+import { FlexColumn } from "@src/@styles/shared";
+import { extractResponseBookmarks, parseMeridemTime } from "@src/@utils";
 
 function Bookmark() {
   const { data, isLoading, isSuccess, fetchNextPage, hasNextPage, refetch } =

--- a/frontend/src/pages/Certification/index.tsx
+++ b/frontend/src/pages/Certification/index.tsx
@@ -1,10 +1,13 @@
-import Loader from "@src/components/Loader";
-import { PATH_NAME } from "@src/@constants";
-import { useNavigate } from "react-router-dom";
 import { useEffect } from "react";
-import useGetSearchParam from "@src/hooks/useGetSearchParam";
-import useAuthentication from "@src/hooks/useAuthentication";
+import { useNavigate } from "react-router-dom";
+
+import Loader from "@src/components/Loader";
+
 import useGetCertification from "@src/hooks/query/useGetCertification";
+import useAuthentication from "@src/hooks/useAuthentication";
+import useGetSearchParam from "@src/hooks/useGetSearchParam";
+
+import { PATH_NAME } from "@src/@constants";
 
 function Certification() {
   const navigate = useNavigate();

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -1,26 +1,30 @@
-import { FlexColumn } from "@src/@styles/shared";
-import MessageCard from "@src/components/MessageCard";
-import * as Styled from "./style";
 import React from "react";
-import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
-import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
-import { extractResponseMessages, parseMeridemTime } from "@src/@utils";
-import useMessageDate from "@src/hooks/useMessageDate";
 import { useLocation, useParams } from "react-router-dom";
-import DateDropdown from "@src/components/DateDropdown";
-import useModal from "@src/hooks/useModal";
-import Portal from "@src/components/@shared/Portal";
+
 import Dimmer from "@src/components/@shared/Dimmer";
+import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
+import Portal from "@src/components/@shared/Portal";
 import Calendar from "@src/components/Calendar";
+import DateDropdown from "@src/components/DateDropdown";
 import EmptyStatus from "@src/components/EmptyStatus";
-import SearchForm from "@src/components/SearchForm";
-import ReminderModal from "@src/components/ReminderModal";
-import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+import MessageCard from "@src/components/MessageCard";
 import BookmarkButton from "@src/components/MessageCard/MessageIconButtons/BookmarkButton";
 import ReminderButton from "@src/components/MessageCard/MessageIconButtons/ReminderButton";
-import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
+import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
+import ReminderModal from "@src/components/ReminderModal";
+import SearchForm from "@src/components/SearchForm";
+
 import useGetInfiniteMessages from "@src/hooks/query/useGetInfiniteMessages";
+import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
+import useMessageDate from "@src/hooks/useMessageDate";
+import useModal from "@src/hooks/useModal";
 import useScrollToTop from "@src/hooks/useScrollToTop";
+import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+
+import { FlexColumn } from "@src/@styles/shared";
+import { extractResponseMessages, parseMeridemTime } from "@src/@utils";
+
+import * as Styled from "./style";
 
 function Feed() {
   const { channelId } = useParams();

--- a/frontend/src/pages/Feed/index.tsx
+++ b/frontend/src/pages/Feed/index.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import { Fragment } from "react";
 import { useLocation, useParams } from "react-router-dom";
 
 import Dimmer from "@src/components/@shared/Dimmer";
@@ -89,7 +89,7 @@ function Feed() {
               const parsedDate = postedDate.split("T")[0];
 
               return (
-                <React.Fragment key={id}>
+                <Fragment key={id}>
                   {isRenderDate(parsedDate) && (
                     <DateDropdown
                       postedDate={parsedDate}
@@ -122,7 +122,7 @@ function Feed() {
                       />
                     </>
                   </MessageCard>
-                </React.Fragment>
+                </Fragment>
               );
             }
           )}

--- a/frontend/src/pages/Feed/style.ts
+++ b/frontend/src/pages/Feed/style.ts
@@ -1,12 +1,13 @@
 import styled from "styled-components";
 
 export const Container = styled.div`
-  width: 100%;
-  min-width: 320px;
-  max-width: 1000px;
   display: flex;
   flex-direction: column;
   align-items: center;
+
+  width: 100%;
+  min-width: 320px;
+  max-width: 1000px;
   padding: 26px 20px;
   margin-top: 30px;
 `;

--- a/frontend/src/pages/Home/index.tsx
+++ b/frontend/src/pages/Home/index.tsx
@@ -1,8 +1,11 @@
-import * as Styled from "./style";
-import Button from "@src/components/@shared/Button";
-import { FlexRow } from "@src/@styles/shared";
 import LogoIcon from "@public/assets/icons/pickpick.svg";
+
+import Button from "@src/components/@shared/Button";
+
 import { SLACK_LOGIN_URL } from "@src/@constants";
+import { FlexRow } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 function Home() {
   const handleNavigateToAddChannel = () => {

--- a/frontend/src/pages/Home/style.ts
+++ b/frontend/src/pages/Home/style.ts
@@ -9,6 +9,7 @@ export const Container = styled.div`
 export const GreetingContainer = styled.section`
   display: flex;
   flex-direction: column;
+
   max-width: 600px;
   padding: 50px 40px 40px;
   margin: 0 auto;
@@ -17,10 +18,11 @@ export const GreetingContainer = styled.section`
 export const UsageContainer = styled.section`
   display: flex;
   flex-direction: column;
-  padding: 30px 43px;
-  justify-content: center;
   align-items: center;
+  justify-content: center;
   gap: 40px;
+
+  padding: 30px 43px;
 
   ${({ theme }: StyledDefaultProps) => css`
     background-color: ${theme.COLOR.BACKGROUND.SECONDARY};

--- a/frontend/src/pages/Home/style.ts
+++ b/frontend/src/pages/Home/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Container = styled.div`
   width: 100%;

--- a/frontend/src/pages/NotFound/index.tsx
+++ b/frontend/src/pages/NotFound/index.tsx
@@ -1,7 +1,10 @@
+import { Link } from "react-router-dom";
+
+import Button from "@src/components/@shared/Button";
+
 import { PATH_NAME } from "@src/@constants";
 import { FlexColumn } from "@src/@styles/shared";
-import Button from "@src/components/@shared/Button";
-import { Link } from "react-router-dom";
+
 import * as Styled from "./style";
 
 function NotFound() {

--- a/frontend/src/pages/NotFound/style.ts
+++ b/frontend/src/pages/NotFound/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Title = styled.h1`
   text-align: center;

--- a/frontend/src/pages/Reminder/index.tsx
+++ b/frontend/src/pages/Reminder/index.tsx
@@ -1,18 +1,21 @@
-import { FlexColumn } from "@src/@styles/shared";
-import MessageCard from "@src/components/MessageCard";
 import * as Styled from "@src/pages/Feed/style";
-import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
-import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
-import { extractResponseReminders, parseMeridemTime } from "@src/@utils";
-import EmptyStatus from "@src/components/EmptyStatus";
-import Portal from "@src/components/@shared/Portal";
+
 import Dimmer from "@src/components/@shared/Dimmer";
-import ReminderModal from "@src/components/ReminderModal";
-import useModal from "@src/hooks/useModal";
-import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
+import Portal from "@src/components/@shared/Portal";
+import EmptyStatus from "@src/components/EmptyStatus";
+import MessageCard from "@src/components/MessageCard";
 import ReminderButton from "@src/components/MessageCard/MessageIconButtons/ReminderButton";
+import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
+import ReminderModal from "@src/components/ReminderModal";
+
 import useGetInfiniteReminders from "@src/hooks/query/useGetInfiniteReminders";
+import useModal from "@src/hooks/useModal";
 import useScrollToTop from "@src/hooks/useScrollToTop";
+import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+
+import { FlexColumn } from "@src/@styles/shared";
+import { extractResponseReminders, parseMeridemTime } from "@src/@utils";
 
 function Reminder() {
   const {

--- a/frontend/src/pages/SearchResult/index.tsx
+++ b/frontend/src/pages/SearchResult/index.tsx
@@ -1,24 +1,27 @@
 import * as Styled from "@src/pages/Feed/style";
-import MessageCard from "@src/components/MessageCard";
-import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
-import { FlexColumn } from "@src/@styles/shared";
+
+import Dimmer from "@src/components/@shared/Dimmer";
 import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
+import Portal from "@src/components/@shared/Portal";
+import MessageCard from "@src/components/MessageCard";
+import BookmarkButton from "@src/components/MessageCard/MessageIconButtons/BookmarkButton";
+import ReminderButton from "@src/components/MessageCard/MessageIconButtons/ReminderButton";
+import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
+import ReminderModal from "@src/components/ReminderModal";
+import SearchForm from "@src/components/SearchForm";
+
+import useGetInfiniteMessages from "@src/hooks/query/useGetInfiniteMessages";
 import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
+import useGetSearchParam from "@src/hooks/useGetSearchParam";
+import useModal from "@src/hooks/useModal";
+import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+
+import { FlexColumn } from "@src/@styles/shared";
 import {
-  getChannelIdsParams,
   extractResponseMessages,
+  getChannelIdsParams,
   parseMeridemTime,
 } from "@src/@utils";
-import useModal from "@src/hooks/useModal";
-import Portal from "@src/components/@shared/Portal";
-import Dimmer from "@src/components/@shared/Dimmer";
-import ReminderModal from "@src/components/ReminderModal";
-import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
-import ReminderButton from "@src/components/MessageCard/MessageIconButtons/ReminderButton";
-import BookmarkButton from "@src/components/MessageCard/MessageIconButtons/BookmarkButton";
-import SearchForm from "@src/components/SearchForm";
-import useGetSearchParam from "@src/hooks/useGetSearchParam";
-import useGetInfiniteMessages from "@src/hooks/query/useGetInfiniteMessages";
 
 function SearchResult() {
   const keyword = useGetSearchParam("keyword");

--- a/frontend/src/pages/SpecificDateFeed/index.tsx
+++ b/frontend/src/pages/SpecificDateFeed/index.tsx
@@ -1,27 +1,30 @@
 import * as Styled from "@src/pages/Feed/style";
 import { Fragment } from "react";
-import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
-import { FlexColumn } from "@src/@styles/shared";
-import MessageCard from "@src/components/MessageCard";
 import { useLocation, useParams } from "react-router-dom";
-import useTopScreenEventHandler from "@src/hooks/useTopScreenEventHandlers";
-import useMessageDate from "@src/hooks/useMessageDate";
-import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
-import { extractResponseMessages, parseMeridemTime } from "@src/@utils";
-import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
-import DateDropdown from "@src/components/DateDropdown";
-import useModal from "@src/hooks/useModal";
-import Portal from "@src/components/@shared/Portal";
+
 import Dimmer from "@src/components/@shared/Dimmer";
+import InfiniteScroll from "@src/components/@shared/InfiniteScroll";
+import Portal from "@src/components/@shared/Portal";
 import Calendar from "@src/components/Calendar";
+import DateDropdown from "@src/components/DateDropdown";
 import EmptyStatus from "@src/components/EmptyStatus";
-import SearchForm from "@src/components/SearchForm";
-import ReminderModal from "@src/components/ReminderModal";
-import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+import MessageCard from "@src/components/MessageCard";
 import BookmarkButton from "@src/components/MessageCard/MessageIconButtons/BookmarkButton";
 import ReminderButton from "@src/components/MessageCard/MessageIconButtons/ReminderButton";
+import MessagesLoadingStatus from "@src/components/MessageCard/MessagesLoadingStatus";
+import ReminderModal from "@src/components/ReminderModal";
+import SearchForm from "@src/components/SearchForm";
+
 import useGetInfiniteMessages from "@src/hooks/query/useGetInfiniteMessages";
+import useMutateBookmark from "@src/hooks/query/useMutateBookmark";
+import useMessageDate from "@src/hooks/useMessageDate";
+import useModal from "@src/hooks/useModal";
 import useScrollToTop from "@src/hooks/useScrollToTop";
+import useSetReminderTargetMessage from "@src/hooks/useSetReminderTargetMessage";
+import useTopScreenEventHandler from "@src/hooks/useTopScreenEventHandlers";
+
+import { FlexColumn } from "@src/@styles/shared";
+import { extractResponseMessages, parseMeridemTime } from "@src/@utils";
 
 function SpecificDateFeed() {
   const { key: queryKey } = useLocation();

--- a/frontend/src/pages/UnexpectedError/index.tsx
+++ b/frontend/src/pages/UnexpectedError/index.tsx
@@ -1,9 +1,11 @@
-import { PATH_NAME } from "@src/@constants";
 import Header from "@src/components/@layouts/Header";
-import Button from "@src/components/@shared/Button";
 import * as LayoutStyled from "@src/components/@layouts/LayoutContainer/style";
-import * as Styled from "./style";
+import Button from "@src/components/@shared/Button";
+
+import { PATH_NAME } from "@src/@constants";
 import { FlexColumn } from "@src/@styles/shared";
+
+import * as Styled from "./style";
 
 function UnexpectedError() {
   return (

--- a/frontend/src/pages/UnexpectedError/index.tsx
+++ b/frontend/src/pages/UnexpectedError/index.tsx
@@ -7,7 +7,7 @@ import { FlexColumn } from "@src/@styles/shared";
 
 function UnexpectedError() {
   return (
-    <LayoutStyled.Container>
+    <div>
       <Header />
 
       <LayoutStyled.Main hasMarginTop={true}>
@@ -23,7 +23,7 @@ function UnexpectedError() {
           </a>
         </FlexColumn>
       </LayoutStyled.Main>
-    </LayoutStyled.Container>
+    </div>
   );
 }
 

--- a/frontend/src/pages/UnexpectedError/style.ts
+++ b/frontend/src/pages/UnexpectedError/style.ts
@@ -1,5 +1,6 @@
-import { StyledDefaultProps } from "@src/@types/shared";
 import styled, { css } from "styled-components";
+
+import { StyledDefaultProps } from "@src/@types/shared";
 
 export const Title = styled.h1`
   text-align: center;

--- a/frontend/src/pages/index.tsx
+++ b/frontend/src/pages/index.tsx
@@ -1,5 +1,6 @@
+import { LazyExoticComponent, Suspense, lazy } from "react";
+
 import Loader from "@src/components/Loader";
-import { lazy, LazyExoticComponent, Suspense } from "react";
 
 interface LoadableType {
   Component: LazyExoticComponent<() => JSX.Element>;


### PR DESCRIPTION
## 요약

- CSS 순서 컨벤션 적용
- prettier import 문 정렬 플러그인 설치 후 적용 


<br><br>

## 참고 사항

- [trivago/prettier-plugin-sort-imports](https://github.com/trivago/prettier-plugin-sort-imports) 사용하여 prettier 설정에 추가해주었습니다.
- 아까 같이 정했던 대로 정렬해주도록 설정했습니다 
```
  "importOrder": [
    "<THIRD_PARTY_MODULES>",
    "^@public/(.*)$",
    "^@src/components/(.*)$",
    "^@src/hooks/(.*)$",
    "^@src/@(.*)",
    "^@src/api/(.*)$",
    "^@src/mocks/(.*)$",
    "^[./]"
  ],
``` 

## 관련 이슈

- Close #561 
- Close #189 

<br><br>
