### PR TITLE
refactor: Exception 내부에 ErrorCode 필드가 빠진 것 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/exception/BadRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/BadRequestException.java
@@ -2,18 +2,20 @@ package com.pickpick.exception;
 
 public class BadRequestException extends RuntimeException {
 
-    private static final String ERROR_CODE = "BAD_REQUEST";
-    private static final String CLIENT_MESSAGE = "요청 값이 잘못되었습니다.";
+    private String errorCode = "BAD_REQUEST";
+    private String clientMessage = "요청 값이 잘못되었습니다.";
 
-    public BadRequestException(final String message) {
-        super(message);
+    public BadRequestException(final String serverMessage, final String clientMessage, final String errorCode) {
+        super(serverMessage);
+        this.clientMessage = clientMessage;
+        this.errorCode = errorCode;
     }
 
     public String getErrorCode() {
-        return ERROR_CODE;
+        return errorCode;
     }
 
     public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        return clientMessage;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/NotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/NotFoundException.java
@@ -2,18 +2,20 @@ package com.pickpick.exception;
 
 public class NotFoundException extends RuntimeException {
 
-    private static final String ERROR_CODE = "NOT_FOUND";
-    private static final String CLIENT_MESSAGE = "해당 정보를 조회하지 못했습니다.";
+    private String errorCode = "NOT_FOUND";
+    private String clientMessage = "해당 정보를 조회하지 못했습니다.";
 
     public NotFoundException(final String serverMessage, final String clientMessage, final String errorCode) {
         super(serverMessage);
+        this.clientMessage = clientMessage;
+        this.errorCode = errorCode;
     }
 
     public String getErrorCode() {
-        return ERROR_CODE;
+        return errorCode;
     }
 
     public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        return clientMessage;
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/NotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/NotFoundException.java
@@ -5,8 +5,8 @@ public class NotFoundException extends RuntimeException {
     private static final String ERROR_CODE = "NOT_FOUND";
     private static final String CLIENT_MESSAGE = "해당 정보를 조회하지 못했습니다.";
 
-    public NotFoundException(final String message) {
-        super(message);
+    public NotFoundException(final String serverMessage, final String clientMessage, final String errorCode) {
+        super(serverMessage);
     }
 
     public String getErrorCode() {

--- a/backend/src/main/java/com/pickpick/exception/auth/ExpiredTokenException.java
+++ b/backend/src/main/java/com/pickpick/exception/auth/ExpiredTokenException.java
@@ -4,15 +4,11 @@ import com.pickpick.exception.BadRequestException;
 
 public class ExpiredTokenException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "만료된 토큰으로 요청";
+    private static final String ERROR_CODE = "EXPIRED_TOKEN";
+    private static final String SERVER_MESSAGE = "만료된 토큰으로 요청";
     private static final String CLIENT_MESSAGE = "만료된 토큰입니다.";
 
     public ExpiredTokenException(String token) {
-        super(String.format("%s -> token: %s", DEFAULT_MESSAGE, token));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> token: %s", SERVER_MESSAGE, token), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/auth/InvalidTokenException.java
+++ b/backend/src/main/java/com/pickpick/exception/auth/InvalidTokenException.java
@@ -5,20 +5,10 @@ import com.pickpick.exception.BadRequestException;
 public class InvalidTokenException extends BadRequestException {
 
     private static final String ERROR_CODE = "INVALID_TOKEN";
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 토큰으로 요청";
+    private static final String SERVER_MESSAGE = "유효하지 않은 토큰으로 요청";
     private static final String CLIENT_MESSAGE = "유효하지 않은 토큰입니다.";
 
     public InvalidTokenException(String token) {
-        super(String.format("%s -> token: %s", DEFAULT_MESSAGE, token));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> token: %s", SERVER_MESSAGE, token), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/ChannelInvalidNameException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/ChannelInvalidNameException.java
@@ -4,15 +4,11 @@ import com.pickpick.exception.BadRequestException;
 
 public class ChannelInvalidNameException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 채널 이름";
+    private static final String ERROR_CODE = "CHANNEL_INVALID_NAME";
+    private static final String SERVER_MESSAGE = "유효하지 않은 채널 이름";
     private static final String CLIENT_MESSAGE = "유효하지 않은 채널 이름입니다.";
 
     public ChannelInvalidNameException(final String name) {
-        super(String.format("%s -> channel name: %s", DEFAULT_MESSAGE, name));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> channel name: %s", SERVER_MESSAGE, name), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/ChannelNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/ChannelNotFoundException.java
@@ -5,24 +5,14 @@ import com.pickpick.exception.NotFoundException;
 public class ChannelNotFoundException extends NotFoundException {
 
     private static final String ERROR_CODE = "CHANNEL_NOT_FOUND";
-    private static final String DEFAULT_MESSAGE = "존재하지 않는 채널 조회";
+    private static final String SERVER_MESSAGE = "존재하지 않는 채널 조회";
     private static final String CLIENT_MESSAGE = "채널을 찾지 못했습니다.";
 
     public ChannelNotFoundException(final Long id) {
-        super(String.format("%s -> channel id: %d", DEFAULT_MESSAGE, id));
+        super(String.format("%s -> channel id: %d", SERVER_MESSAGE, id), CLIENT_MESSAGE, ERROR_CODE);
     }
 
     public ChannelNotFoundException(final String slackId) {
-        super(String.format("%s -> channel slack id: %s", DEFAULT_MESSAGE, slackId));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> channel slack id: %s", SERVER_MESSAGE, slackId), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionDuplicateException.java
@@ -5,20 +5,11 @@ import com.pickpick.exception.BadRequestException;
 public class SubscriptionDuplicateException extends BadRequestException {
 
     private static final String ERROR_CODE = "SUBSCRIPTION_DUPLICATE";
-    private static final String DEFAULT_MESSAGE = "구독 중인 채널 중복 구독 시도";
+    private static final String SERVER_MESSAGE = "구독 중인 채널 중복 구독 시도";
     private static final String CLIENT_MESSAGE = "이미 구독 중인 채널입니다.";
 
     public SubscriptionDuplicateException(final Long channelId) {
-        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, channelId));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> subscription channel id: %d", SERVER_MESSAGE, channelId), CLIENT_MESSAGE,
+                ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionInvalidOrderException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionInvalidOrderException.java
@@ -5,20 +5,10 @@ import com.pickpick.exception.BadRequestException;
 public class SubscriptionInvalidOrderException extends BadRequestException {
 
     private static final String ERROR_CODE = "SUBSCRIPTION_INVALID_ORDER";
-    private static final String DEFAULT_MESSAGE = "구독 순서에 0 이하의 수 입력";
+    private static final String SERVER_MESSAGE = "구독 순서에 0 이하의 수 입력";
     private static final String CLIENT_MESSAGE = "구독 순서는 1 이상이여야합니다.";
 
     public SubscriptionInvalidOrderException(int order) {
-        super(String.format("%s -> order: %d", DEFAULT_MESSAGE, order));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> order: %d", SERVER_MESSAGE, order), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotExistException.java
@@ -5,24 +5,15 @@ import com.pickpick.exception.BadRequestException;
 public class SubscriptionNotExistException extends BadRequestException {
 
     private static final String ERROR_CODE = "SUBSCRIPTION_NOT_EXIST";
-    private static final String DEFAULT_MESSAGE = "구독 중이 아닌 채널을 구독 조회";
+    private static final String SERVER_MESSAGE = "구독 중이 아닌 채널을 구독 조회";
     private static final String CLIENT_MESSAGE = "구독 중인 채널이 아니라 취소할 수 없습니다.";
 
     public SubscriptionNotExistException(final Long channelId) {
-        super(String.format("%s -> subscription channel id: %d", DEFAULT_MESSAGE, channelId));
+        super(String.format("%s -> subscription channel id: %d", SERVER_MESSAGE, channelId), CLIENT_MESSAGE,
+                ERROR_CODE);
     }
 
     public SubscriptionNotExistException(final String message) {
-        super(message);
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(message, CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionNotFoundException.java
@@ -5,20 +5,10 @@ import com.pickpick.exception.NotFoundException;
 public class SubscriptionNotFoundException extends NotFoundException {
 
     private static final String ERROR_CODE = "SUBSCRIPTION_NOT_FOUND";
-    private static final String DEFAULT_MESSAGE = "채널 구독이 0개인 멤버로 구독 목록 조회";
+    private static final String SERVER_MESSAGE = "채널 구독이 0개인 멤버로 구독 목록 조회";
     private static final String CLIENT_MESSAGE = "해당 멤버가 구독 중인 채널이 없습니다.";
 
     public SubscriptionNotFoundException(final Long memberId) {
-        super(String.format("%s -> subscription member id: %d", DEFAULT_MESSAGE, memberId));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> subscription member id: %d", SERVER_MESSAGE, memberId), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/channel/SubscriptionOrderDuplicateException.java
+++ b/backend/src/main/java/com/pickpick/exception/channel/SubscriptionOrderDuplicateException.java
@@ -5,20 +5,10 @@ import com.pickpick.exception.BadRequestException;
 public class SubscriptionOrderDuplicateException extends BadRequestException {
 
     private static final String ERROR_CODE = "SUBSCRIPTION_DUPLICATE";
-    private static final String DEFAULT_MESSAGE = "중복된 구독 순서 요청";
+    private static final String SERVER_MESSAGE = "중복된 구독 순서 요청";
     private static final String CLIENT_MESSAGE = "요청한 구독 순서 내부에 중복이 존재합니다.";
 
     public SubscriptionOrderDuplicateException() {
-        super(DEFAULT_MESSAGE);
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(SERVER_MESSAGE, CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/member/MemberInvalidThumbnailUrlException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberInvalidThumbnailUrlException.java
@@ -4,15 +4,12 @@ import com.pickpick.exception.BadRequestException;
 
 public class MemberInvalidThumbnailUrlException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 이미지 주소";
+    private static final String ERROR_CODE = "MEMBER_INVALID_THUMBNAIL_URL";
+    private static final String SERVER_MESSAGE = "유효하지 않은 이미지 주소";
     private static final String CLIENT_MESSAGE = "유효하지 않은 이미지 주소입니다.";
 
     public MemberInvalidThumbnailUrlException(final String thumbnailUrl) {
-        super(String.format("%s -> member thumbnail url: %s", DEFAULT_MESSAGE, thumbnailUrl));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> member thumbnail url: %s", SERVER_MESSAGE, thumbnailUrl), CLIENT_MESSAGE,
+                ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/member/MemberInvalidUsernameException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberInvalidUsernameException.java
@@ -4,15 +4,11 @@ import com.pickpick.exception.BadRequestException;
 
 public class MemberInvalidUsernameException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 사용자 이름";
+    private static final String ERROR_CODE = "MEMBER_INVALID_USERNAME";
+    private static final String SERVER_MESSAGE = "유효하지 않은 사용자 이름";
     private static final String CLIENT_MESSAGE = "유효하지 않은 사용자 이름입니다.";
 
     public MemberInvalidUsernameException(final String username) {
-        super(String.format("%s -> member username: %s", DEFAULT_MESSAGE, username));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> member username: %s", SERVER_MESSAGE, username), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/member/MemberNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/member/MemberNotFoundException.java
@@ -5,24 +5,14 @@ import com.pickpick.exception.NotFoundException;
 public class MemberNotFoundException extends NotFoundException {
 
     private static final String ERROR_CODE = "MEMBER_NOT_FOUND";
-    private static final String DEFAULT_MESSAGE = "존재하지 않는 멤버 조회";
+    private static final String SERVER_MESSAGE = "존재하지 않는 멤버 조회";
     private static final String CLIENT_MESSAGE = "사용자를 찾지 못했습니다.";
 
     public MemberNotFoundException(final Long id) {
-        super(String.format("%s -> member id: %d", DEFAULT_MESSAGE, id));
+        super(String.format("%s -> member id: %d", SERVER_MESSAGE, id), CLIENT_MESSAGE, ERROR_CODE);
     }
 
     public MemberNotFoundException(final String slackId) {
-        super(String.format("%s -> member slack id: %s", DEFAULT_MESSAGE, slackId));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> member slack id: %s", SERVER_MESSAGE, slackId), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkDeleteFailureException.java
@@ -5,20 +5,11 @@ import com.pickpick.exception.BadRequestException;
 public class BookmarkDeleteFailureException extends BadRequestException {
 
     private static final String ERROR_CODE = "BOOKMARK_DELETE_FAILURE";
-    private static final String DEFAULT_MESSAGE = "외래키가 일치하는 북마크가 없어 삭제 목적 조회 실패";
+    private static final String SERVER_MESSAGE = "외래키가 일치하는 북마크가 없어 삭제 목적 조회 실패";
     private static final String CLIENT_MESSAGE = "해당 북마크를 삭제할 수 없습니다.";
 
     public BookmarkDeleteFailureException(final Long messageId, final Long memberId) {
-        super(String.format("%s -> bookmark message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> bookmark message id: %d, member id: %d", SERVER_MESSAGE, messageId, memberId),
+                CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/BookmarkNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/BookmarkNotFoundException.java
@@ -5,20 +5,10 @@ import com.pickpick.exception.NotFoundException;
 public class BookmarkNotFoundException extends NotFoundException {
 
     private static final String ERROR_CODE = "BOOKMARK_NOT_FOUND";
-    private static final String DEFAULT_MESSAGE = "존재하지 않는 북마크 조회";
+    private static final String SERVER_MESSAGE = "존재하지 않는 북마크 조회";
     private static final String CLIENT_MESSAGE = "북마크를 찾지 못했습니다.";
 
     public BookmarkNotFoundException(final Long id) {
-        super(String.format("%s -> bookmark id: %d", DEFAULT_MESSAGE, id));
-    }
-
-    @Override
-    public String getErrorCode() {
-        return ERROR_CODE;
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> bookmark id: %d", SERVER_MESSAGE, id), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/MessageNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/MessageNotFoundException.java
@@ -4,19 +4,15 @@ import com.pickpick.exception.NotFoundException;
 
 public class MessageNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "존재하지 않는 메시지 조회";
+    private static final String ERROR_CODE = "MESSAGE_NOT_FOUND";
+    private static final String SERVER_MESSAGE = "존재하지 않는 메시지 조회";
     private static final String CLIENT_MESSAGE = "메시지를 찾지 못했습니다.";
 
     public MessageNotFoundException(final Long id) {
-        super(String.format("%s -> message id: %d", DEFAULT_MESSAGE, id));
+        super(String.format("%s -> message id: %d", SERVER_MESSAGE, id), CLIENT_MESSAGE, ERROR_CODE);
     }
 
     public MessageNotFoundException(final String slackId) {
-        super(String.format("%s -> message slack id: %s", DEFAULT_MESSAGE, slackId));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> message slack id: %s", SERVER_MESSAGE, slackId), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/ReminderDeleteFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/ReminderDeleteFailureException.java
@@ -4,15 +4,12 @@ import com.pickpick.exception.BadRequestException;
 
 public class ReminderDeleteFailureException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "외래키가 일치하는 리마인더가 없어 삭제 목적 조회 실패";
+    private static final String ERROR_CODE = "REMINDER_DELETE_FAILURE";
+    private static final String SERVER_MESSAGE = "외래키가 일치하는 리마인더가 없어 삭제 목적 조회 실패";
     private static final String CLIENT_MESSAGE = "해당 리마인더를 삭제할 수 없습니다.";
 
     public ReminderDeleteFailureException(final Long messageId, final Long memberId) {
-        super(String.format("%s -> reminder message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> reminder message id: %d, member id: %d", SERVER_MESSAGE, messageId, memberId),
+                CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/ReminderNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/ReminderNotFoundException.java
@@ -4,13 +4,16 @@ import com.pickpick.exception.NotFoundException;
 
 public class ReminderNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "리마인더를 찾지 못했습니다";
+    private static final String ERROR_CODE = "REMINDER_NOT_FOUND";
+    private static final String SERVER_MESSAGE = "존재하지 않는 리마인더 조회";
+    private static final String CLIENT_MESSAGE = "리마인더를 찾지 못했습니다";
 
     public ReminderNotFoundException(final Long id) {
-        super(String.format("%s -> reminder id: %d", DEFAULT_MESSAGE, id));
+        super(String.format("%s -> reminder id: %d", SERVER_MESSAGE, id), CLIENT_MESSAGE, ERROR_CODE);
     }
 
     public ReminderNotFoundException(final Long messageId, final Long memberId) {
-        super(String.format("%s -> message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
+        super(String.format("%s -> message id: %d, member id: %d", SERVER_MESSAGE, messageId, memberId), CLIENT_MESSAGE,
+                ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/message/ReminderUpdateFailureException.java
+++ b/backend/src/main/java/com/pickpick/exception/message/ReminderUpdateFailureException.java
@@ -4,15 +4,12 @@ import com.pickpick.exception.BadRequestException;
 
 public class ReminderUpdateFailureException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "외래키가 일치하는 리마인더가 없어 수정 목적 조회 실패";
+    private static final String ERROR_CODE = "REMINDER_UPDATE_FAILURE";
+    private static final String SERVER_MESSAGE = "외래키가 일치하는 리마인더가 없어 수정 목적 조회 실패";
     private static final String CLIENT_MESSAGE = "해당 리마인더를 수정할 수 없습니다.";
 
     public ReminderUpdateFailureException(final Long messageId, final Long memberId) {
-        super(String.format("%s -> reminder message id: %d, member id: %d", DEFAULT_MESSAGE, messageId, memberId));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> reminder message id: %d, member id: %d", SERVER_MESSAGE, messageId, memberId),
+                CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventNotFoundException.java
@@ -4,15 +4,11 @@ import com.pickpick.exception.NotFoundException;
 
 public class SlackEventNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "대응하는 enum 값이 없는 Slack Event 요청";
+    private static final String ERROR_CODE = "SLACK_EVENT_NOT_FOUND";
+    private static final String SERVER_MESSAGE = "대응하는 enum 값이 없는 Slack Event 요청";
     private static final String CLIENT_MESSAGE = "지원하지 않는 Slack Event 입니다.";
 
     public SlackEventNotFoundException(final String type, final String subtype) {
-        super(String.format("%s -> type: %s, subtype: %s", DEFAULT_MESSAGE, type, subtype));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> type: %s, subtype: %s", SERVER_MESSAGE, type, subtype), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventServiceNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventServiceNotFoundException.java
@@ -5,15 +5,13 @@ import com.pickpick.slackevent.application.SlackEvent;
 
 public class SlackEventServiceNotFoundException extends NotFoundException {
 
-    private static final String DEFAULT_MESSAGE = "대응하는 Service 클래스가 없는 Slack Event 요청";;
+    private static final String ERROR_CODE = "SLACK_EVENT_SERVICE_NOT_FOUND";
+    private static final String SERVER_MESSAGE = "대응하는 Service 클래스가 없는 Slack Event 요청";
+    ;
     private static final String CLIENT_MESSAGE = "지원하지 않는 SlackEvent입니다.";
 
     public SlackEventServiceNotFoundException(final SlackEvent slackEvent) {
-        super(String.format("%s -> type: %s, subtype: %s", DEFAULT_MESSAGE, slackEvent.getType(),
-                slackEvent.getSubtype()));
-    }
-
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> type: %s, subtype: %s", SERVER_MESSAGE, slackEvent.getType(),
+                slackEvent.getSubtype()), CLIENT_MESSAGE, ERROR_CODE);
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventServiceNotFoundException.java
+++ b/backend/src/main/java/com/pickpick/exception/slackevent/SlackEventServiceNotFoundException.java
@@ -7,7 +7,6 @@ public class SlackEventServiceNotFoundException extends NotFoundException {
 
     private static final String ERROR_CODE = "SLACK_EVENT_SERVICE_NOT_FOUND";
     private static final String SERVER_MESSAGE = "대응하는 Service 클래스가 없는 Slack Event 요청";
-    ;
     private static final String CLIENT_MESSAGE = "지원하지 않는 SlackEvent입니다.";
 
     public SlackEventServiceNotFoundException(final SlackEvent slackEvent) {

--- a/backend/src/main/java/com/pickpick/exception/utils/InvalidJsonRequestException.java
+++ b/backend/src/main/java/com/pickpick/exception/utils/InvalidJsonRequestException.java
@@ -4,15 +4,11 @@ import com.pickpick.exception.BadRequestException;
 
 public class InvalidJsonRequestException extends BadRequestException {
 
-    private static final String DEFAULT_MESSAGE = "유효하지 않은 json 형식";
+    private static final String ERROR_CODE = "INVALID_JSON_REQUEST";
+    private static final String SERVER_MESSAGE = "유효하지 않은 json 형식";
     private static final String CLIENT_MESSAGE = "잘못된 요청 값입니다.";
 
     public InvalidJsonRequestException(final String json) {
-        super(String.format("%s -> json input: %s", DEFAULT_MESSAGE, json));
-    }
-
-    @Override
-    public String getClientMessage() {
-        return CLIENT_MESSAGE;
+        super(String.format("%s -> json input: %s", SERVER_MESSAGE, json), CLIENT_MESSAGE, ERROR_CODE);
     }
 }


### PR DESCRIPTION
# 마지막 approve 하신 분이 머지해주세요!
## 요약
Exception 내부에 ErrorCode 필드가 빠진 것 수정

<br><br>

## 작업 내용
- 정의되어있는 CustomException에 ErrorCode 필드 빠진 곳 채워줌
- CustomException내부 DEFAULT_MESSAGE => SERVER_MESSAGE로 이름 변경
- CustomException 내부에서 Getter 제거 (ControllerAdvice에서 부모의 게터를 사용하므로 제거)

현재 존재하는 Custom Exception에 빠진 ErrorCode를 추가하는 것 뿐만 아니라 앞으로 새로 생길 Custom Exception에 대해서도 개발자에게 강제할 수 있도록 코드 수정
- `NotFoundException`, `BadRequestException`에 상수를 필드로 변경
- `NotFoundException`, `BadRequestException` 생성자를 수정하여 자식 Exception에서 ErrorCode, ClientMessage 선언 강제
<br><br>

## 참고 사항

머지된 후 작업할 것 / 생각할 것
- repository에서 default 메서드 사용
- DebugMessage 객체 도입에 대해서 고민해보기

<br><br>

## 관련 이슈

- Close #557 

<br><br>
