### PR TITLE
refactor: Repository 인터페이스 내부에 예외를 던지는 default 메서드 추가

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -4,7 +4,6 @@ import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.auth.ui.dto.LoginResponse;
 import com.pickpick.config.SlackProperties;
 import com.pickpick.exception.SlackApiCallException;
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.slack.api.methods.MethodsClient;
@@ -42,8 +41,7 @@ public class AuthService {
         String token = requestSlackToken(code);
         String memberSlackId = requestMemberSlackId(token);
 
-        Member member = members.findBySlackId(memberSlackId)
-                .orElseThrow(() -> new MemberNotFoundException(memberSlackId));
+        Member member = members.getBySlackId(memberSlackId);
 
         boolean isFirstLogin = member.isFirstLogin();
         member.markLoggedIn();

--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -12,7 +12,6 @@ import com.pickpick.exception.channel.ChannelNotFoundException;
 import com.pickpick.exception.channel.SubscriptionDuplicateException;
 import com.pickpick.exception.channel.SubscriptionNotExistException;
 import com.pickpick.exception.channel.SubscriptionOrderDuplicateException;
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import java.util.List;
@@ -43,11 +42,9 @@ public class ChannelSubscriptionService {
     @Transactional
     public void save(final ChannelSubscriptionRequest subscriptionRequest, final Long memberId) {
         Long channelId = subscriptionRequest.getChannelId();
-        Channel channel = channels.findById(channelId)
-                .orElseThrow(() -> new ChannelNotFoundException(channelId));
+        Channel channel = channels.getById(channelId);
 
-        Member member = members.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        Member member = members.getById(memberId);
 
         validateDuplicatedSubscription(channel, member);
 
@@ -139,8 +136,7 @@ public class ChannelSubscriptionService {
         Channel channel = channels.findById(channelId)
                 .orElseThrow(() -> new ChannelNotFoundException(channelId));
 
-        Member member = members.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        Member member = members.getById(memberId);
 
         validateSubscriptionExist(channel, member);
 

--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -8,7 +8,6 @@ import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponses;
-import com.pickpick.exception.channel.ChannelNotFoundException;
 import com.pickpick.exception.channel.SubscriptionDuplicateException;
 import com.pickpick.exception.channel.SubscriptionNotExistException;
 import com.pickpick.exception.channel.SubscriptionOrderDuplicateException;
@@ -133,8 +132,7 @@ public class ChannelSubscriptionService {
 
     @Transactional
     public void delete(final Long channelId, final Long memberId) {
-        Channel channel = channels.findById(channelId)
-                .orElseThrow(() -> new ChannelNotFoundException(channelId));
+        Channel channel = channels.getById(channelId);
 
         Member member = members.getById(memberId);
 

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelRepository.java
@@ -1,5 +1,6 @@
 package com.pickpick.channel.domain;
 
+import com.pickpick.exception.channel.ChannelNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
@@ -12,9 +13,19 @@ public interface ChannelRepository extends Repository<Channel, Long> {
 
     List<Channel> findAllByOrderByName();
 
-    Optional<Channel> findBySlackId(String slackId);
-
     Optional<Channel> findById(Long id);
 
+    Optional<Channel> findBySlackId(String slackId);
+
     void deleteBySlackId(String slackId);
+
+    default Channel getById(final Long id) {
+        return findById(id)
+                .orElseThrow(() -> new ChannelNotFoundException(id));
+    }
+
+    default Channel getBySlackId(final String slackId) {
+        return findBySlackId(slackId)
+                .orElseThrow(() -> new ChannelNotFoundException(slackId));
+    }
 }

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -1,5 +1,6 @@
 package com.pickpick.channel.domain;
 
+import com.pickpick.exception.channel.SubscriptionNotFoundException;
 import com.pickpick.member.domain.Member;
 import java.util.List;
 import java.util.Optional;
@@ -23,4 +24,9 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
     boolean existsByChannelAndMember(Channel channel, Member member);
 
     void deleteAllByChannelAndMember(Channel channel, Member member);
+
+    default ChannelSubscription getFirstByMemberIdOrderByViewOrderAsc(final Long memberId) {
+        return findFirstByMemberIdOrderByViewOrderAsc(memberId)
+                .orElseThrow(() -> new SubscriptionNotFoundException(memberId));
+    }
 }

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -10,8 +10,6 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     ChannelSubscription save(ChannelSubscription channelSubscription);
 
-    void saveAll(Iterable<ChannelSubscription> channelSubscriptions);
-
     @Query("select cs from ChannelSubscription cs where cs.member.id = :memberId")
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 

--- a/backend/src/main/java/com/pickpick/member/domain/MemberRepository.java
+++ b/backend/src/main/java/com/pickpick/member/domain/MemberRepository.java
@@ -1,20 +1,29 @@
 package com.pickpick.member.domain;
 
+import com.pickpick.exception.member.MemberNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
 
 public interface MemberRepository extends Repository<Member, Long> {
 
-    Optional<Member> findById(Long id);
-
-    Optional<Member> findBySlackId(String slackId);
-
     Member save(Member member);
 
     void saveAll(Iterable<Member> members);
 
-    List<Member> findAll();
+    Optional<Member> findById(Long id);
 
-    void deleteAll();
+    Optional<Member> findBySlackId(String slackId);
+
+    List<Member> findAll();
+    
+    default Member getById(final Long id) {
+        return findById(id)
+                .orElseThrow(() -> new MemberNotFoundException(id));
+    }
+
+    default Member getBySlackId(final String slackId) {
+        return findBySlackId(slackId)
+                .orElseThrow(() -> new MemberNotFoundException(slackId));
+    }
 }

--- a/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
+++ b/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
@@ -1,7 +1,6 @@
 package com.pickpick.message.application;
 
 import com.pickpick.exception.message.BookmarkDeleteFailureException;
-import com.pickpick.exception.message.BookmarkNotFoundException;
 import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -82,8 +81,7 @@ public class BookmarkService {
             return null;
         }
 
-        Bookmark bookmark = bookmarks.findById(bookmarkId)
-                .orElseThrow(() -> new BookmarkNotFoundException(bookmarkId));
+        Bookmark bookmark = bookmarks.getById(bookmarkId);
 
         LocalDateTime messageDate = bookmark.getMessage().getPostedDate();
 

--- a/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
+++ b/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
@@ -1,7 +1,6 @@
 package com.pickpick.message.application;
 
 import com.pickpick.exception.message.BookmarkDeleteFailureException;
-import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.Bookmark;
@@ -43,8 +42,7 @@ public class BookmarkService {
     public void save(final Long memberId, final BookmarkRequest bookmarkRequest) {
         Member member = members.getById(memberId);
 
-        Message message = messages.findById(bookmarkRequest.getMessageId())
-                .orElseThrow(() -> new MessageNotFoundException(bookmarkRequest.getMessageId()));
+        Message message = messages.getById(bookmarkRequest.getMessageId());
 
         Bookmark bookmark = new Bookmark(member, message);
         bookmarks.save(bookmark);

--- a/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
+++ b/backend/src/main/java/com/pickpick/message/application/BookmarkService.java
@@ -1,6 +1,5 @@
 package com.pickpick.message.application;
 
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.exception.message.BookmarkDeleteFailureException;
 import com.pickpick.exception.message.BookmarkNotFoundException;
 import com.pickpick.exception.message.MessageNotFoundException;
@@ -43,8 +42,7 @@ public class BookmarkService {
 
     @Transactional
     public void save(final Long memberId, final BookmarkRequest bookmarkRequest) {
-        Member member = members.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        Member member = members.getById(memberId);
 
         Message message = messages.findById(bookmarkRequest.getMessageId())
                 .orElseThrow(() -> new MessageNotFoundException(bookmarkRequest.getMessageId()));

--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -2,7 +2,6 @@ package com.pickpick.message.application;
 
 import com.pickpick.channel.domain.ChannelSubscription;
 import com.pickpick.channel.domain.ChannelSubscriptionRepository;
-import com.pickpick.exception.channel.SubscriptionNotFoundException;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.message.domain.QBookmark;
@@ -63,8 +62,7 @@ public class MessageService {
             return channelIds;
         }
 
-        ChannelSubscription firstSubscription = channelSubscriptions.findFirstByMemberIdOrderByViewOrderAsc(memberId)
-                .orElseThrow(() -> new SubscriptionNotFoundException(memberId));
+        ChannelSubscription firstSubscription = channelSubscriptions.getFirstByMemberIdOrderByViewOrderAsc(memberId);
 
         return List.of(firstSubscription.getChannelId());
     }

--- a/backend/src/main/java/com/pickpick/message/application/MessageService.java
+++ b/backend/src/main/java/com/pickpick/message/application/MessageService.java
@@ -3,7 +3,6 @@ package com.pickpick.message.application;
 import com.pickpick.channel.domain.ChannelSubscription;
 import com.pickpick.channel.domain.ChannelSubscriptionRepository;
 import com.pickpick.exception.channel.SubscriptionNotFoundException;
-import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.message.domain.QBookmark;
@@ -162,8 +161,7 @@ public class MessageService {
 
 
     private Predicate messageIdCondition(final Long messageId, final boolean needPastMessage) {
-        Message message = messages.findById(messageId)
-                .orElseThrow(() -> new MessageNotFoundException(messageId));
+        Message message = messages.getById(messageId);
 
         LocalDateTime messageDate = message.getPostedDate();
 
@@ -212,7 +210,7 @@ public class MessageService {
     }
 
     private boolean hasFuture(final List<Long> channelIds, final MessageRequest messageRequest,
-                            final List<MessageResponse> messages) {
+                              final List<MessageResponse> messages) {
         if (messages.isEmpty()) {
             return false;
         }
@@ -236,7 +234,7 @@ public class MessageService {
     }
 
     private BooleanExpression meetAllHasFutureCondition(final List<Long> channelIds, final MessageRequest request,
-                                                      final List<MessageResponse> messages) {
+                                                        final List<MessageResponse> messages) {
         MessageResponse targetMessage = messages.get(0);
 
         return channelIdsIn(channelIds)

--- a/backend/src/main/java/com/pickpick/message/application/ReminderService.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderService.java
@@ -1,6 +1,5 @@
 package com.pickpick.message.application;
 
-import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.exception.message.ReminderDeleteFailureException;
 import com.pickpick.exception.message.ReminderNotFoundException;
 import com.pickpick.exception.message.ReminderUpdateFailureException;
@@ -49,8 +48,7 @@ public class ReminderService {
     public void save(final Long memberId, final ReminderSaveRequest request) {
         Member member = members.getById(memberId);
 
-        Message message = messages.findById(request.getMessageId())
-                .orElseThrow(() -> new MessageNotFoundException(request.getMessageId()));
+        Message message = messages.getById(request.getMessageId());
 
         Reminder reminder = new Reminder(member, message, request.getReminderDate());
         reminders.save(reminder);

--- a/backend/src/main/java/com/pickpick/message/application/ReminderService.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderService.java
@@ -1,6 +1,5 @@
 package com.pickpick.message.application;
 
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.exception.message.ReminderDeleteFailureException;
 import com.pickpick.exception.message.ReminderNotFoundException;
@@ -48,8 +47,7 @@ public class ReminderService {
 
     @Transactional
     public void save(final Long memberId, final ReminderSaveRequest request) {
-        Member member = members.findById(memberId)
-                .orElseThrow(() -> new MemberNotFoundException(memberId));
+        Member member = members.getById(memberId);
 
         Message message = messages.findById(request.getMessageId())
                 .orElseThrow(() -> new MessageNotFoundException(request.getMessageId()));

--- a/backend/src/main/java/com/pickpick/message/application/ReminderService.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderService.java
@@ -1,7 +1,6 @@
 package com.pickpick.message.application;
 
 import com.pickpick.exception.message.ReminderDeleteFailureException;
-import com.pickpick.exception.message.ReminderNotFoundException;
 import com.pickpick.exception.message.ReminderUpdateFailureException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
@@ -55,8 +54,7 @@ public class ReminderService {
     }
 
     public ReminderResponse findOne(final Long messageId, final Long memberId) {
-        Reminder reminder = reminders.findByMessageIdAndMemberId(messageId, memberId)
-                .orElseThrow(() -> new ReminderNotFoundException(messageId, memberId));
+        Reminder reminder = reminders.getByMessageIdAndMemberId(messageId, memberId);
 
         return ReminderResponse.from(reminder);
     }
@@ -90,8 +88,7 @@ public class ReminderService {
             return QReminder.reminder.remindDate.after(LocalDateTime.now(clock));
         }
 
-        Reminder reminder = reminders.findById(reminderId)
-                .orElseThrow(() -> new ReminderNotFoundException(reminderId));
+        Reminder reminder = reminders.getById(reminderId);
 
         if (isTargetDateMessageLeft(reminder)) {
             return (QReminder.reminder.remindDate.eq(reminder.getRemindDate())

--- a/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/BookmarkRepository.java
@@ -1,5 +1,6 @@
 package com.pickpick.message.domain;
 
+import com.pickpick.exception.message.BookmarkNotFoundException;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
@@ -14,4 +15,9 @@ public interface BookmarkRepository extends Repository<Bookmark, Long> {
     Optional<Bookmark> findByMessageIdAndMemberId(Long messageId, Long memberId);
 
     void deleteById(Long id);
+
+    default Bookmark getById(final Long id) {
+        return findById(id)
+                .orElseThrow(() -> new BookmarkNotFoundException(id));
+    }
 }

--- a/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/MessageRepository.java
@@ -1,5 +1,6 @@
 package com.pickpick.message.domain;
 
+import com.pickpick.exception.message.MessageNotFoundException;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.repository.Repository;
@@ -12,9 +13,19 @@ public interface MessageRepository extends Repository<Message, Long> {
 
     Optional<Message> findById(long id);
 
-    Optional<Message> findBySlackId(String slackMessageId);
+    Optional<Message> findBySlackId(String slackId);
 
     void deleteBySlackId(String slackId);
 
     void deleteAllByChannelSlackId(String channelSlackId);
+
+    default Message getById(final Long id) {
+        return findById(id)
+                .orElseThrow(() -> new MessageNotFoundException(id));
+    }
+
+    default Message getBySlackId(final String slackId) {
+        return findBySlackId(slackId)
+                .orElseThrow(() -> new MessageNotFoundException(slackId));
+    }
 }

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -1,5 +1,6 @@
 package com.pickpick.message.domain;
 
+import com.pickpick.exception.message.ReminderNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -15,7 +16,17 @@ public interface ReminderRepository extends Repository<Reminder, Long> {
     @Query("select r from Reminder r WHERE r.message.id = :messageId and r.member.id = :memberId")
     Optional<Reminder> findByMessageIdAndMemberId(Long messageId, Long memberId);
 
+    List<Reminder> findAllByRemindDate(LocalDateTime remindDate);
+
     void deleteById(Long id);
 
-    List<Reminder> findAllByRemindDate(LocalDateTime remindDate);
+    default Reminder getById(final Long id) {
+        return findById(id)
+                .orElseThrow(() -> new ReminderNotFoundException(id));
+    }
+
+    default Reminder getByMessageIdAndMemberId(Long messageId, Long memberId) {
+        return findByMessageIdAndMemberId(messageId, memberId)
+                .orElseThrow(() -> new ReminderNotFoundException(messageId, memberId));
+    }
 }

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelRenameService.java
@@ -2,7 +2,6 @@ package com.pickpick.slackevent.application.channel;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.channel.ChannelNotFoundException;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
 import com.pickpick.slackevent.application.channel.dto.ChannelRenameRequest;
@@ -25,8 +24,7 @@ public class ChannelRenameService implements SlackEventService {
     public void execute(final String requestBody) {
         SlackChannelRenameDto slackChannelRenameDto = convert(requestBody);
 
-        Channel channel = channels.findBySlackId(slackChannelRenameDto.getSlackId())
-                .orElseThrow(() -> new ChannelNotFoundException(slackChannelRenameDto.getSlackId()));
+        Channel channel = channels.getBySlackId(slackChannelRenameDto.getSlackId());
 
         channel.changeName(slackChannelRenameDto.getNewName());
     }

--- a/backend/src/main/java/com/pickpick/slackevent/application/member/MemberChangedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/member/MemberChangedService.java
@@ -1,6 +1,5 @@
 package com.pickpick.slackevent.application.member;
 
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.slackevent.application.SlackEvent;
@@ -26,8 +25,7 @@ public class MemberChangedService implements SlackEventService {
         MemberProfileChangedDto memberProfileChangedDto = convert(requestBody);
 
         String slackId = memberProfileChangedDto.getSlackId();
-        Member member = members.findBySlackId(slackId)
-                .orElseThrow(() -> new MemberNotFoundException(slackId));
+        Member member = members.getBySlackId(slackId);
 
         member.update(memberProfileChangedDto.getUsername(), memberProfileChangedDto.getThumbnailUrl());
     }

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageChangedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageChangedService.java
@@ -1,6 +1,5 @@
 package com.pickpick.slackevent.application.message;
 
-import com.pickpick.exception.message.MessageNotFoundException;
 import com.pickpick.message.domain.Message;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.slackevent.application.SlackEvent;
@@ -34,8 +33,7 @@ public class MessageChangedService implements SlackEventService {
             return;
         }
 
-        Message message = messages.findBySlackId(slackMessageDto.getSlackId())
-                .orElseThrow(() -> new MessageNotFoundException(slackMessageDto.getSlackId()));
+        Message message = messages.getBySlackId(slackMessageDto.getSlackId());
 
         message.changeText(slackMessageDto.getText(), slackMessageDto.getModifiedDate());
     }

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageCreatedService.java
@@ -3,7 +3,6 @@ package com.pickpick.slackevent.application.message;
 import com.pickpick.channel.application.ChannelCreateService;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.MessageRepository;
@@ -43,8 +42,7 @@ public class MessageCreatedService implements SlackEventService {
         SlackMessageDto slackMessageDto = request.toDto();
 
         String memberSlackId = slackMessageDto.getMemberSlackId();
-        Member member = members.findBySlackId(memberSlackId)
-                .orElseThrow(() -> new MemberNotFoundException(memberSlackId));
+        Member member = members.getBySlackId(memberSlackId);
 
         String channelSlackId = slackMessageDto.getChannelSlackId();
 

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageFileShareService.java
@@ -3,7 +3,6 @@ package com.pickpick.slackevent.application.message;
 import com.pickpick.channel.application.ChannelCreateService;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.MessageRepository;
@@ -50,8 +49,7 @@ public class MessageFileShareService implements SlackEventService {
     private Member findMember(final SlackMessageDto slackMessageDto) {
         String memberSlackId = slackMessageDto.getMemberSlackId();
 
-        return members.findBySlackId(memberSlackId)
-                .orElseThrow(() -> new MemberNotFoundException(memberSlackId));
+        return members.getBySlackId(memberSlackId);
     }
 
     private Channel findChannel(final SlackMessageDto slackMessageDto) {

--- a/backend/src/main/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/message/MessageThreadBroadcastService.java
@@ -3,7 +3,6 @@ package com.pickpick.slackevent.application.message;
 import com.pickpick.channel.application.ChannelCreateService;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
-import com.pickpick.exception.member.MemberNotFoundException;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.MessageRepository;
@@ -55,8 +54,7 @@ public class MessageThreadBroadcastService implements SlackEventService {
 
     private void save(final SlackMessageDto slackMessageDto) {
         String memberSlackId = slackMessageDto.getMemberSlackId();
-        Member member = members.findBySlackId(memberSlackId)
-                .orElseThrow(() -> new MemberNotFoundException(memberSlackId));
+        Member member = members.getBySlackId(memberSlackId);
 
         String channelSlackId = slackMessageDto.getChannelSlackId();
 


### PR DESCRIPTION
## 요약
Repository 인터페이스 내부에 예외를 던지는 default 메서드 추가
<br><br>

## 작업 내용

Repository 인터페이스 내부에 예외를 던지는 default 메서드 추가
- `get~` 으로 시작하는 디폴트 메서드를 만들었습니다/
<br><br>

## 참고 사항

의견을 묻고싶은게 있어요.
현재 Optional로 반환하는 메서드 중 
1. `subscriptions.findFirstByMemberIdOrderByViewOrderAsc()`
2. `bookmarks.findByMemberIdAndMessageId()`


이 두 개는 아직 디폴트 메서드를 만들어주지 않았습니다.

1번은 뭔가 특정 값으로만 조회하는게 아니라 정렬하는 조건까지 있어서 고민이 되더라고요. 프로덕션 코드에서 SubscriptionNotFoundException을 throw 해줘서 괜찮을까 싶다가도, 정렬조건까지 메서드명에 담겨있어서 살짝 고민이 됩니다.

2번은 프로덕션 코드에서 사용할 때 BookmarkDeleteFailureException을 throw해줍니다. BookmarkNotFoundException을 throw 해주는게 아니라서 디폴트 메서드 내부에서 사용하는게 좋지 않을 것 같아 고민입니다.

저는 `XXXXNotFoundException`을 던져주는 경우라면 조회 조건과 상관없이 repository 내부에 디폴트 메서드를 정의하면 어떨까? 라고 생각했는데 써머와 연로그의 의견도 궁금합니다 👍 


-------------------------------------------------------------------------------------
Repository 인터페이스 내부의 메서드들에 final을 달아주지 않았고, default 메서드에는 final을 달아줬어요.
디폴트 메서드는 구현부가 있어서 현재 저희 컨벤션대로 파라미터에 final을 표기해주는게 좋지 않을까? 라는 생각으로 아까 달고 지금 PR 올리려는데, 써머 슬랙 댓글을 보니 또 고민이 되어서요! 연로그 의견 한 번만 부탁드려요 🥺

<br><br>

## 관련 이슈

- Close #564 

<br><br>
