### PR TITLE
feat: RestDocs 에 에러코드 추가

### DIFF
--- a/backend/src/docs/asciidoc/index.adoc
+++ b/backend/src/docs/asciidoc/index.adoc
@@ -96,3 +96,7 @@ operation::reminder-controller-test/delete[snippets='http-request,request-header
 === 리마인더 수정 API
 
 operation::reminder-controller-test/update[snippets='http-request,request-headers,request-fields,http-response']
+
+= 에러
+
+operation::error-code-docs-test/error-codes[snippets='error-code,http-response']

--- a/backend/src/test/java/com/pickpick/support/DocsControllerTest.java
+++ b/backend/src/test/java/com/pickpick/support/DocsControllerTest.java
@@ -47,7 +47,8 @@ import org.springframework.web.context.WebApplicationContext;
         BookmarkController.class,
         MessageController.class,
         ReminderController.class,
-        SlackEventController.class
+        SlackEventController.class,
+        ErrorCodeController.class
 })
 @ExtendWith(RestDocumentationExtension.class)
 @Import(RestDocsConfiguration.class)

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeController.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeController.java
@@ -1,0 +1,16 @@
+package com.pickpick.support;
+
+import com.pickpick.config.dto.ErrorResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class ErrorCodeController {
+
+    @GetMapping("/error-code")
+    public ErrorResponse errorCode() {
+        return new ErrorResponse("ERROR_CODE", "MESSAGE");
+    }
+}

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
@@ -1,0 +1,22 @@
+package com.pickpick.support;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+public class ErrorCodeDocsTest extends DocsControllerTest {
+
+    @DisplayName("Rest Docs에 에러코드를 생성합니다.")
+    @Test
+    void errorCodes() throws Exception {
+        ErrorCodeSnippet errorCodeSnippet = new ErrorCodeSnippet("error-code", "error-code-template");
+
+        ResultActions result = mockMvc.perform(MockMvcRequestBuilders
+                        .get("/test/error-code"))
+                .andExpect(status().isOk())
+                .andDo(restDocs.document(errorCodeSnippet));
+    }
+}

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeSnippet.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeSnippet.java
@@ -28,7 +28,7 @@ public class ErrorCodeSnippet extends TemplatedSnippet {
         try {
             return Class.forName(component.getBeanClassName());
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException(e);
+            throw new IllegalStateException(e);
         }
     }
 
@@ -76,8 +76,7 @@ public class ErrorCodeSnippet extends TemplatedSnippet {
             fields.add(model);
         } catch (NoSuchFieldException e) {
             throw new IllegalStateException("커스텀 예외 클래스 내부에 ErrorCode 및 ClientMessage 를 정의해야합니다.");
-        } catch (IllegalAccessException e) {
-            // ignored
+        } catch (IllegalAccessException ignored) {
         }
     }
 

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeSnippet.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeSnippet.java
@@ -1,0 +1,74 @@
+package com.pickpick.support;
+
+import com.pickpick.exception.BadRequestException;
+import com.pickpick.exception.NotFoundException;
+import java.lang.reflect.Field;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.ClassPathScanningCandidateComponentProvider;
+import org.springframework.core.type.filter.AssignableTypeFilter;
+import org.springframework.restdocs.operation.Operation;
+import org.springframework.restdocs.snippet.TemplatedSnippet;
+
+public class ErrorCodeSnippet extends TemplatedSnippet {
+
+    protected ErrorCodeSnippet(final String snippetName, final String templateName) {
+        super(snippetName, templateName, null);
+    }
+
+    private static Class<?> apply(BeanDefinition component) {
+        try {
+            return Class.forName(component.getBeanClassName());
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Override
+    protected Map<String, Object> createModel(final Operation operation) {
+        Map<String, Object> model = new HashMap<>();
+        List<Map<String, Object>> fields = new ArrayList<>();
+        model.put("fields", fields);
+        addErrorCodes(fields);
+
+        return model;
+    }
+
+    public void addErrorCodes(final List<Map<String, Object>> fields) {
+        Set<? extends Class<?>> exceptionClasses = findExceptionClasses();
+        for (Class<?> aClass : exceptionClasses) {
+            Map<String, Object> model = new HashMap<>();
+            try {
+                Field errorCodeField = aClass.getDeclaredField("ERROR_CODE");
+                Field clientMessageField = aClass.getDeclaredField("CLIENT_MESSAGE");
+                errorCodeField.setAccessible(true);
+                clientMessageField.setAccessible(true);
+                String errorCode = errorCodeField.get(null).toString();
+                String errorMessage = clientMessageField.get(null).toString();
+                System.out.println(errorCode);
+                System.out.println(errorMessage);
+                model.put("path", errorCode);
+                model.put("description", errorMessage);
+                fields.add(model);
+            } catch (IllegalAccessException | NoSuchFieldException e) {
+                // ignored
+            }
+        }
+    }
+
+    public Set<? extends Class<?>> findExceptionClasses() {
+        ClassPathScanningCandidateComponentProvider provider = new ClassPathScanningCandidateComponentProvider(false);
+        provider.addIncludeFilter(new AssignableTypeFilter(BadRequestException.class));
+        provider.addIncludeFilter(new AssignableTypeFilter(NotFoundException.class));
+
+        Set<BeanDefinition> components = provider.findCandidateComponents("com.pickpick.exception");
+        return components.stream()
+                .map(ErrorCodeSnippet::apply)
+                .collect(Collectors.toSet());
+    }
+}

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeSnippet.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeSnippet.java
@@ -75,7 +75,7 @@ public class ErrorCodeSnippet extends TemplatedSnippet {
             model.put("errorMessage", errorMessage);
             fields.add(model);
         } catch (NoSuchFieldException e) {
-            throw new BadRequestException("커스텀 예외 클래스 내부에 ErrorCode 및 ClientMessage 를 정의해야합니다.", "", "");
+            throw new IllegalStateException("커스텀 예외 클래스 내부에 ErrorCode 및 ClientMessage 를 정의해야합니다.");
         } catch (IllegalAccessException e) {
             // ignored
         }

--- a/backend/src/test/resources/org/springframework/restdocs/templates/error-code-template.snippet
+++ b/backend/src/test/resources/org/springframework/restdocs/templates/error-code-template.snippet
@@ -1,0 +1,7 @@
+|===
+|Code|Message
+{{#fields}}
+|{{#tableCellContent}}`+{{errorCode}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{errorMessage}}{{/tableCellContent}}
+{{/fields}}
+|===


### PR DESCRIPTION
# 🚨 제가 머지하겠습니다
## 요약

Rest Docs 에 에러코드 추가
<br><br>

## 작업 내용

- 컨트롤러 테스트 리팩토링을 하면서 Docs에 에러코드를 정리했습니다.
- 에러코드를 직접 하나하나 작성하는 것보다, CustomException을 만들면 자동으로 RestDocs에 에러코드가 추가되면 좋을 것 같아 리플렉션을 활용했습니다. 
- NotFoundException과 BadRequestException을 상속한 하위 커스텀 익셉션 내부에 `ERROR_CODE` 필드와 `CLIENT_MESSAGE` 필드가 없으면 테스트가 실패합니다.
- NotFoundException과 BadRequestException은 `ERROR_CODE` 필드와 `CLIENT_MESSAGE` 필드가 없어도 테스트 통과하도록 했습니다.

## 작업 결과
RestDocs에 하단 이미지처럼 추가됩니다.
intellij에서 연 파일이라 다크모드가 적용되어서 안예뻐보이네요 ㅠㅠ
<img width="509" alt="image" src="https://user-images.githubusercontent.com/55357130/193456960-62fb9682-6193-42d9-80c2-39548f593e3f.png">

<br><br>

## 참고 사항

- 컨트롤러 테스트 개선과 같이 작업했었는데, PR 단위가 너무 커서 PR을 분리했습니다.



<br><br>

## 관련 이슈

- Close #572

<br><br>
