### PR TITLE
refactor: code smell 최소화

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
@@ -10,6 +10,9 @@ public class AuthorizationExtractor {
     private static final String ACCESS_TOKEN_TYPE = AuthorizationExtractor.class.getSimpleName() + ".ACCESS_TOKEN_TYPE";
     private static final char COMMA = ',';
 
+    private AuthorizationExtractor() {
+    }
+
     public static String extract(HttpServletRequest request) {
         Enumeration<String> headers = request.getHeaders(AUTHORIZATION);
         while (headers.hasMoreElements()) {

--- a/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
@@ -1,6 +1,6 @@
 package com.pickpick.auth.support;
 
-import com.pickpick.exception.auth.InvalidTokenException;
+import com.pickpick.exception.auth.ExtractTokenFailException;
 import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 
@@ -29,6 +29,6 @@ public class AuthorizationExtractor {
             }
         }
 
-        throw new InvalidTokenException("EXTRACT_FAILED");
+        throw new ExtractTokenFailException();
     }
 }

--- a/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
+++ b/backend/src/main/java/com/pickpick/auth/support/AuthorizationExtractor.java
@@ -1,5 +1,6 @@
 package com.pickpick.auth.support;
 
+import com.pickpick.exception.auth.InvalidTokenException;
 import java.util.Enumeration;
 import javax.servlet.http.HttpServletRequest;
 
@@ -28,6 +29,6 @@ public class AuthorizationExtractor {
             }
         }
 
-        throw new RuntimeException("잘못된 토큰 정보입니다.");
+        throw new InvalidTokenException("EXTRACT_FAILED");
     }
 }

--- a/backend/src/main/java/com/pickpick/exception/auth/ExtractTokenFailException.java
+++ b/backend/src/main/java/com/pickpick/exception/auth/ExtractTokenFailException.java
@@ -1,0 +1,14 @@
+package com.pickpick.exception.auth;
+
+import com.pickpick.exception.BadRequestException;
+
+public class ExtractTokenFailException extends BadRequestException {
+
+    private static final String ERROR_CODE = "INVALID_TOKEN";
+    private static final String SERVER_MESSAGE = "토큰 추출 실패";
+    private static final String CLIENT_MESSAGE = "유효하지 않은 토큰입니다.";
+
+    public ExtractTokenFailException() {
+        super(SERVER_MESSAGE, CLIENT_MESSAGE, ERROR_CODE);
+    }
+}

--- a/backend/src/test/java/com/pickpick/acceptance/AcceptanceTestBase.java
+++ b/backend/src/test/java/com/pickpick/acceptance/AcceptanceTestBase.java
@@ -17,7 +17,7 @@ import org.springframework.context.annotation.Import;
 @Import(value = TestConfig.class)
 @DisplayNameGeneration(DisplayNameGenerator.ReplaceUnderscores.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class AcceptanceTest {
+public class AcceptanceTestBase {
 
     @LocalServerPort
     int port;

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -7,7 +7,7 @@ import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_�
 import static com.pickpick.acceptance.auth.AuthRestHandler.토큰_검증;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.fixture.MemberFixture;
 import io.restassured.response.ExtractableResponse;
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayName("인증 & 인가 인수 테스트")
-class AuthAcceptanceTest extends AcceptanceTest {
+class AuthAcceptanceTest extends AcceptanceTestBase {
 
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -18,7 +18,7 @@ import org.springframework.beans.factory.annotation.Value;
 
 @SuppressWarnings("NonAsciiCharacters")
 @DisplayName("인증 & 인가 인수 테스트")
-public class AuthAcceptanceTest extends AcceptanceTest {
+class AuthAcceptanceTest extends AcceptanceTest {
 
     @Value("${security.jwt.token.secret-key}")
     private String secretKey;

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("채널 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-public class ChannelAcceptanceTest extends AcceptanceTest {
+class ChannelAcceptanceTest extends AcceptanceTest {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -5,7 +5,7 @@ import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_�
 import static com.pickpick.acceptance.channel.ChannelRestHandler.유저_전체_채널_목록_조회_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.channel.ui.dto.ChannelResponse;
 import com.pickpick.fixture.ChannelFixture;
 import com.pickpick.fixture.MemberFixture;
@@ -17,7 +17,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("채널 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class ChannelAcceptanceTest extends AcceptanceTest {
+class ChannelAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -12,7 +12,7 @@ import static com.pickpick.acceptance.channel.ChannelRestHandler.채널_구독_�
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
@@ -29,7 +29,7 @@ import org.junit.jupiter.params.provider.ValueSource;
 
 @DisplayName("채널 구독 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class ChannelSubscriptionAcceptanceTest extends AcceptanceTest {
+class ChannelSubscriptionAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("북마크 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-public class BookmarkAcceptanceTest extends AcceptanceTest {
+class BookmarkAcceptanceTest extends AcceptanceTest {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -13,7 +13,7 @@ import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.메시지
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.메시지_전송;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.fixture.MemberFixture;
 import com.pickpick.message.ui.dto.BookmarkResponse;
 import com.pickpick.message.ui.dto.BookmarkResponses;
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("북마크 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class BookmarkAcceptanceTest extends AcceptanceTest {
+class BookmarkAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -12,7 +12,7 @@ import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.빈_메�
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.키워드를_포함한_메시지_목록_생성;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.acceptance.message.MessageRestHandler.MessageRequestBuilder;
 import com.pickpick.fixture.ChannelFixture;
 import com.pickpick.fixture.MemberFixture;
@@ -29,7 +29,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("메시지 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class MessageAcceptanceTest extends AcceptanceTest {
+class MessageAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("리마인더 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-public class ReminderAcceptanceTest extends AcceptanceTest {
+class ReminderAcceptanceTest extends AcceptanceTest {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -16,7 +16,7 @@ import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.메시지
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.acceptance.message.ReminderRestHandler.ReminderFindRequest;
 import com.pickpick.fixture.MemberFixture;
 import com.pickpick.message.ui.dto.ReminderResponse;
@@ -32,7 +32,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("리마인더 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class ReminderAcceptanceTest extends AcceptanceTest {
+class ReminderAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
@@ -5,7 +5,7 @@ import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_�
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.멤버_정보_수정;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.회원가입;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.fixture.MemberFixture;
 import com.pickpick.workspace.domain.Workspace;
 import io.restassured.response.ExtractableResponse;
@@ -16,7 +16,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("멤버 관련 슬랙 이벤트 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class MemberEventAcceptanceTest extends AcceptanceTest {
+class MemberEventAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
 

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -10,7 +10,7 @@ import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.브로드
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.회원가입;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.pickpick.acceptance.AcceptanceTest;
+import com.pickpick.acceptance.AcceptanceTestBase;
 import com.pickpick.fixture.MemberFixture;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.workspace.domain.Workspace;
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.Test;
 
 @DisplayName("메시지 관련 슬랙 이벤트 인수 테스트")
 @SuppressWarnings("NonAsciiCharacters")
-class MessageEventAcceptanceTest extends AcceptanceTest {
+class MessageEventAcceptanceTest extends AcceptanceTestBase {
 
     private static final String MEMBER_SLACK_ID = MemberFixture.BOM.getSlackId();
     private static final String MESSAGE_SLACK_ID = UUID.randomUUID().toString();

--- a/backend/src/test/java/com/pickpick/channel/ui/ChannelControllerTest.java
+++ b/backend/src/test/java/com/pickpick/channel/ui/ChannelControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.pickpick.channel.ui.dto.ChannelResponse;
 import com.pickpick.channel.ui.dto.ChannelResponses;
-import com.pickpick.support.DocsControllerTest;
+import com.pickpick.support.DocsControllerTestBase;
 import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.restdocs.payload.JsonFieldType;
 import org.springframework.test.web.servlet.ResultActions;
 
-class ChannelControllerTest extends DocsControllerTest {
+class ChannelControllerTest extends DocsControllerTestBase {
 
     private static final String CHANNEL_API_URL = "/api/channels";
 

--- a/backend/src/test/java/com/pickpick/channel/ui/ChannelSubscriptionControllerTest.java
+++ b/backend/src/test/java/com/pickpick/channel/ui/ChannelSubscriptionControllerTest.java
@@ -18,7 +18,7 @@ import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionRequest;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponses;
-import com.pickpick.support.DocsControllerTest;
+import com.pickpick.support.DocsControllerTestBase;
 import java.util.List;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.DisplayName;
@@ -28,7 +28,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-class ChannelSubscriptionControllerTest extends DocsControllerTest {
+class ChannelSubscriptionControllerTest extends DocsControllerTestBase {
 
     private static final String API_CHANNEL_SUBSCRIPTION = "/api/channel-subscription";
 

--- a/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.pickpick.message.ui.dto.BookmarkRequest;
 import com.pickpick.message.ui.dto.BookmarkResponse;
 import com.pickpick.message.ui.dto.BookmarkResponses;
-import com.pickpick.support.DocsControllerTest;
+import com.pickpick.support.DocsControllerTestBase;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.http.HttpHeaders;
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-class BookmarkControllerTest extends DocsControllerTest {
+class BookmarkControllerTest extends DocsControllerTestBase {
 
     private static final String BOOKMARK_API_URL = "/api/bookmarks";
 

--- a/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/BookmarkControllerTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-public class BookmarkControllerTest extends DocsControllerTest {
+class BookmarkControllerTest extends DocsControllerTest {
 
     private static final String BOOKMARK_API_URL = "/api/bookmarks";
 

--- a/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/MessageControllerTest.java
@@ -13,7 +13,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.pickpick.message.ui.dto.MessageResponse;
 import com.pickpick.message.ui.dto.MessageResponses;
-import com.pickpick.support.DocsControllerTest;
+import com.pickpick.support.DocsControllerTestBase;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.http.HttpHeaders;
@@ -25,7 +25,7 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
 
-class MessageControllerTest extends DocsControllerTest {
+class MessageControllerTest extends DocsControllerTestBase {
 
     private static final String MESSAGES_API_URL = "/api/messages";
 

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-public class ReminderControllerTest extends DocsControllerTest {
+class ReminderControllerTest extends DocsControllerTest {
 
     private static final String REMINDER_API_URL = "/api/reminders";
 

--- a/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
+++ b/backend/src/test/java/com/pickpick/message/ui/ReminderControllerTest.java
@@ -16,7 +16,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
 import com.pickpick.message.ui.dto.ReminderSaveRequest;
-import com.pickpick.support.DocsControllerTest;
+import com.pickpick.support.DocsControllerTestBase;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.apache.http.HttpHeaders;
@@ -27,7 +27,7 @@ import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
-class ReminderControllerTest extends DocsControllerTest {
+class ReminderControllerTest extends DocsControllerTestBase {
 
     private static final String REMINDER_API_URL = "/api/reminders";
 

--- a/backend/src/test/java/com/pickpick/support/DocsControllerTest.java
+++ b/backend/src/test/java/com/pickpick/support/DocsControllerTest.java
@@ -3,7 +3,6 @@ package com.pickpick.support;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pickpick.auth.application.AuthService;
 import com.pickpick.auth.support.JwtTokenProvider;
@@ -105,8 +104,7 @@ public class DocsControllerTest {
                 .params(requestParam);
     }
 
-    protected MockHttpServletRequestBuilder post(final String uri, final String body)
-            throws JsonProcessingException {
+    protected MockHttpServletRequestBuilder post(final String uri, final String body) {
         return MockMvcRequestBuilders
                 .post(uri)
                 .header(HttpHeaders.AUTHORIZATION, BEARER_JWT_TOKEN)

--- a/backend/src/test/java/com/pickpick/support/DocsControllerTestBase.java
+++ b/backend/src/test/java/com/pickpick/support/DocsControllerTestBase.java
@@ -37,7 +37,7 @@ import org.springframework.web.context.WebApplicationContext;
 @ExtendWith(RestDocumentationExtension.class)
 @Import(RestDocsConfiguration.class)
 @MockBean(JpaMetamodelMappingContext.class)
-public class DocsControllerTest {
+public class DocsControllerTestBase {
 
     private static final String BEARER_JWT_TOKEN = "Bearer provided.jwt.token";
 

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
@@ -4,7 +4,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
 class ErrorCodeDocsTest extends DocsControllerTestBase {
@@ -14,7 +13,7 @@ class ErrorCodeDocsTest extends DocsControllerTestBase {
     void errorCodes() throws Exception {
         ErrorCodeSnippet errorCodeSnippet = new ErrorCodeSnippet("error-code", "error-code-template");
 
-        ResultActions result = mockMvc.perform(MockMvcRequestBuilders
+        mockMvc.perform(MockMvcRequestBuilders
                         .get("/test/error-code"))
                 .andExpect(status().isOk())
                 .andDo(restDocs.document(errorCodeSnippet));

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-public class ErrorCodeDocsTest extends DocsControllerTest {
+class ErrorCodeDocsTest extends DocsControllerTest {
 
     @DisplayName("Rest Docs에 에러코드를 생성합니다.")
     @Test

--- a/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
+++ b/backend/src/test/java/com/pickpick/support/ErrorCodeDocsTest.java
@@ -7,7 +7,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-class ErrorCodeDocsTest extends DocsControllerTest {
+class ErrorCodeDocsTest extends DocsControllerTestBase {
 
     @DisplayName("Rest Docs에 에러코드를 생성합니다.")
     @Test


### PR DESCRIPTION
## 요약

code smell 최소화

<br><br>

## 작업 내용

소나큐브의 code smell 최소화
- 모든 메서드가 static인 클래스에서 private 빈 생성자 private 생성
- RuntimeException 제거
- 테스트 클래스에서 불필요한 public 제거
- assertThatThrownBy 시 런타임 예외가 발생할 수 있는 경우를 1개로 제한
- 인수테스트, 컨트롤러 테스트의 부모 클래스 이름 변경
- 사용하지 않는 결과값 제거

<br><br>