### PR TITLE
fix: 토큰 타입 varchar(64) -> varchar(256) 로 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/member/domain/Member.java
+++ b/backend/src/main/java/com/pickpick/member/domain/Member.java
@@ -36,7 +36,7 @@ public class Member {
     @Column(name = "first_login", nullable = false)
     private boolean isFirstLogin = true;
 
-    @Column(name = "token", length = 64, unique = true)
+    @Column(name = "token", length = 256, unique = true)
     private String token;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/backend/src/main/java/com/pickpick/workspace/domain/Workspace.java
+++ b/backend/src/main/java/com/pickpick/workspace/domain/Workspace.java
@@ -20,7 +20,7 @@ public class Workspace {
     @Column(name = "slack_id", length = 15, nullable = false, unique = true, updatable = false)
     private String slackId;
 
-    @Column(name = "bot_token", length = 64, nullable = false, unique = true, updatable = false)
+    @Column(name = "bot_token", length = 256, nullable = false, unique = true, updatable = false)
     private String botToken;
 
     protected Workspace() {


### PR DESCRIPTION
## 요약

토큰 타입 varchar(64) -> varchar(256) 로 수정
<br><br>

## 작업 내용
- member와 workspace 엔티티에서 토큰의 타입을 수정했습니다.
- dev DB의 Member 와 Workspace 에서 token 칼럼의 타입을 varchar(64) -> varchar(256)으로 수정했습니다.

<br><br>

## 참고 사항

<img width="855" alt="image" src="https://user-images.githubusercontent.com/55357130/195764148-bad6adda-84ba-4e95-8f91-e25158d766b6.png">

이런 예외가 발생하더라고요.

그리고 https://api.slack.com/changelog/2016-08-23-token-lengthening 2016년의 슬랙 글이긴한데, 이 떄 한 번 토큰이 길어졌다고 하더라고요. 지금 당장은 varchar(128)로도 충분하긴한데, 문서 내부에서 `앞으로 슬랙에서 256까지 확대할 계획이 있으니 255길이의 칼럼을 사용하는것을 추천한다`라고 되어있어서, varchar(256)으로 수정했습니다!

+) DB 칼럼 계속 수정하다보니 flyway를 적용하면 좋을 것 같다는 생각이 들어서 주말에 살짝 공부하고 적용해보려는데 괜찮을까요?(DB 형상관리가 있으면 좋겠다 라는 생각이 들어서요. 워크스페이스 관련 정리되면 살짝 봐보려고요!)


<br><br>

## 관련 이슈

- Close #603 

<br><br>
