### PR TITLE
refactor: BotInfoDto의 이름을 WorkspaceInfoDto로 변경

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -1,6 +1,6 @@
 package com.pickpick.auth.application;
 
-import com.pickpick.auth.application.dto.BotInfoDto;
+import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.auth.ui.dto.LoginResponse;
 import com.pickpick.channel.domain.Channel;
@@ -58,8 +58,8 @@ public class AuthService {
 
     @Transactional
     public LoginResponse registerWorkspace(final String code) {
-        BotInfoDto botInfoDto = slackClient.callBotInfo(code);
-        Workspace workspace = workspaces.save(botInfoDto.toEntity());
+        WorkspaceInfoDto workspaceInfoDto = slackClient.callWorkspaceInfo(code);
+        Workspace workspace = workspaces.save(workspaceInfoDto.toEntity());
 
         List<Member> allWorkspaceMembers = slackClient.findMembersByWorkspace(workspace);
         members.saveAll(allWorkspaceMembers);

--- a/backend/src/main/java/com/pickpick/auth/application/dto/WorkspaceInfoDto.java
+++ b/backend/src/main/java/com/pickpick/auth/application/dto/WorkspaceInfoDto.java
@@ -4,13 +4,13 @@ import com.pickpick.workspace.domain.Workspace;
 import lombok.Getter;
 
 @Getter
-public class BotInfoDto {
+public class WorkspaceInfoDto {
 
     private final String workspaceSlackId;
     private final String botToken;
     private final String botSlackId;
 
-    public BotInfoDto(final String workspaceSlackId, final String botToken, final String botSlackId) {
+    public WorkspaceInfoDto(final String workspaceSlackId, final String botToken, final String botSlackId) {
         this.workspaceSlackId = workspaceSlackId;
         this.botToken = botToken;
         this.botSlackId = botSlackId;

--- a/backend/src/main/java/com/pickpick/support/ExternalClient.java
+++ b/backend/src/main/java/com/pickpick/support/ExternalClient.java
@@ -1,6 +1,6 @@
 package com.pickpick.support;
 
-import com.pickpick.auth.application.dto.BotInfoDto;
+import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.member.domain.Member;
 import com.pickpick.message.domain.Reminder;
@@ -12,7 +12,7 @@ public interface ExternalClient {
 
     String callUserToken(String code);
 
-    BotInfoDto callBotInfo(String code);
+    WorkspaceInfoDto callWorkspaceInfo(String code);
 
     String callMemberSlackId(String accessToken);
 

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -1,6 +1,6 @@
 package com.pickpick.support;
 
-import com.pickpick.auth.application.dto.BotInfoDto;
+import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.config.SlackProperties;
 import com.pickpick.exception.SlackApiCallException;
@@ -61,9 +61,9 @@ public class SlackClient implements ExternalClient {
     }
 
     @Override
-    public BotInfoDto callBotInfo(final String code) {
+    public WorkspaceInfoDto callWorkspaceInfo(final String code) {
         OAuthV2AccessResponse response = callOAuth2(code);
-        return new BotInfoDto(response.getTeam().getId(), response.getAccessToken(), response.getBotUserId());
+        return new WorkspaceInfoDto(response.getTeam().getId(), response.getAccessToken(), response.getBotUserId());
     }
 
     private OAuthV2AccessResponse callOAuth2(final String code) {

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/ChannelEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/ChannelEventAcceptanceTest.java
@@ -27,7 +27,7 @@ class ChannelEventAcceptanceTest extends AcceptanceTestBase {
     void init() {
         String memberSlackId = MemberFixture.createFirst().getSlackId();
         워크스페이스_초기화_및_로그인(memberSlackId);
-        workspace = externalClient.callBotInfo(memberSlackId).toEntity();
+        workspace = externalClient.callWorkspaceInfo(memberSlackId).toEntity();
     }
 
     @Test

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
@@ -25,7 +25,7 @@ class MemberEventAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         워크스페이스_초기화_및_로그인(MEMBER_SLACK_ID);
-        workspace = externalClient.callBotInfo(MEMBER_SLACK_ID).toEntity();
+        workspace = externalClient.callWorkspaceInfo(MEMBER_SLACK_ID).toEntity();
     }
 
     @Test

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -33,7 +33,7 @@ class MessageEventAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         워크스페이스_초기화_및_로그인(MEMBER_SLACK_ID);
-        workspace = externalClient.callBotInfo(MEMBER_SLACK_ID).toEntity();
+        workspace = externalClient.callWorkspaceInfo(MEMBER_SLACK_ID).toEntity();
     }
 
     @Test

--- a/backend/src/test/java/com/pickpick/support/FakeClient.java
+++ b/backend/src/test/java/com/pickpick/support/FakeClient.java
@@ -1,6 +1,6 @@
 package com.pickpick.support;
 
-import com.pickpick.auth.application.dto.BotInfoDto;
+import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.fixture.ChannelFixture;
 import com.pickpick.fixture.MemberFixture;
@@ -21,8 +21,8 @@ public class FakeClient implements ExternalClient {
     }
 
     @Override
-    public BotInfoDto callBotInfo(final String code) {
-        return new BotInfoDto(code, code, code);
+    public WorkspaceInfoDto callWorkspaceInfo(final String code) {
+        return new WorkspaceInfoDto(code, code, code);
     }
 
     @Override


### PR DESCRIPTION
## 요약

botInfoDto의 이름을 WorkspaceInfoDto로 변경
<br><br>

## 작업 내용

botInfoDto의 이름을 WorkspaceInfoDto로 변경
<br><br>

## 참고 사항

채널 구독 API 수정에 함께 들어갔어야했는데 깜빡하고 커밋을 안했습니다....ㅠ
후에 작업할 테스트 관련 리팩토링에서 함께 진행할까 하다가 테스트 PR에서는 테스트 관련 내용만 수정있으면 좋을 것 같아서 따로 올립니다 ㅠㅠ
<br><br>

