### PR TITLE
refactor: font 설정 변경

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -8,11 +8,34 @@
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://jupjup.site" />
     <meta property="og:title" content="줍줍" />
-    <meta property="og:description" content="사라지는 Slack 메시지, 우리가 주워줄게!" />
+    <meta
+      property="og:description"
+      content="사라지는 Slack 메시지, 우리가 주워줄게!"
+    />
     <meta property="og:site_name" content="줍줍" />
     <meta property="og:locale" content="ko" />
 
-    <link rel="preload" href="./assets/fonts/tway_air.woff2" as="font" type="font/woff2" crossorigin="anonymous" />
+    <link
+      rel="stylesheet"
+      href="./assets//fonts//Roboto-Bold.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="./assets//fonts//Roboto-Light.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
+    <link
+      rel="stylesheet"
+      href="./assets//fonts//Roboto-Regular.woff2"
+      as="font"
+      type="font/woff2"
+      crossorigin="anonymous"
+    />
     <title>줍줍</title>
   </head>
   <body>

--- a/frontend/src/@styles/GlobalStyle.ts
+++ b/frontend/src/@styles/GlobalStyle.ts
@@ -19,23 +19,27 @@ const GlobalStyle = createGlobalStyle<{ theme: Theme }>`
   @font-face {
     font-family: 'Roboto';
     font-weight: 300;
-    src: local('Roboto-Light'), url(${RobotoLightWoff2}) format('woff2'), url(${RobotoLightWoff}) format('woff'), url(${RobotoLightTtf}) format('truetype');
+    font-display: swap;
+    src: url(${RobotoLightWoff2}) format('woff2'), url(${RobotoLightWoff}) format('woff'), url(${RobotoLightTtf}) format('truetype');
   }
 
   @font-face {
     font-family: 'Roboto';
     font-weight: 400;
-    src: local('Roboto-Regular'), url(${RobotoRegularWoff2}) format('woff2'), url(${RobotoRegularWoff}) format('woff'), url(${RobotoRegularTtf}) format('truetype');
+    font-display: swap;
+    src: url(${RobotoRegularWoff2}) format('woff2'), url(${RobotoRegularWoff}) format('woff'), url(${RobotoRegularTtf}) format('truetype');
   }
   
   @font-face {
     font-family: 'Roboto';
     font-weight: 600;
-    src: local('Roboto-Bold'), url(${RobotoBoldWoff2}) format('woff2'), url(${RobotoBoldWoff}) format('woff'), url(${RobotoBoldTtf}) format('truetype');
+    font-display: swap;
+    src: url(${RobotoBoldWoff2}) format('woff2'), url(${RobotoBoldWoff}) format('woff'), url(${RobotoBoldTtf}) format('truetype');
   }
 
   @font-face {
     font-family: 'Twayair';
+    font-display: swap;
     src: url(${TwayairWoff2}) format('woff2'), url(${TwayairWoff}) format('woff'), url(${TwayairTtf}) format('truetype');
   }
 


### PR DESCRIPTION
## 요약
- tway_air 폰트의 preload는 제거해주고, Roboto font의 local 속성을 제거한 후 preload를 할 수 있도록 설정
- 모든 폰트에 font-display: swap 옵션을 설정

<br><br>

## 관련 이슈

- Close #619 

<br><br>
