### PR TITLE
feat: 슬랙 API 호출 예외 메시지 구체화

### DIFF
--- a/backend/src/main/java/com/pickpick/exception/SlackApiCallException.java
+++ b/backend/src/main/java/com/pickpick/exception/SlackApiCallException.java
@@ -1,19 +1,22 @@
 package com.pickpick.exception;
 
+import com.slack.api.methods.SlackApiTextResponse;
+
 public class SlackApiCallException extends RuntimeException {
 
     private static final String DEFAULT_MESSAGE = "슬랙 API 호출 실패";
-
-    public SlackApiCallException(final Exception e) {
-        super(e);
-    }
 
     public SlackApiCallException(final String apiMethod) {
         super(String.format("%s -> api method : %s", DEFAULT_MESSAGE, apiMethod));
     }
 
-    public SlackApiCallException(final String apiMethod, final String slackErrorMessage) {
-        super(String.format("%s -> api method : %s, slack message : %S", DEFAULT_MESSAGE, apiMethod,
-                slackErrorMessage));
+    public SlackApiCallException(final String apiMethod, final SlackApiTextResponse response) {
+        super(String.format("%s -> api method : %s, slack message : %s, slack needed: %s, slack provided: %s",
+                DEFAULT_MESSAGE,
+                apiMethod,
+                response.getError(),
+                response.getNeeded(),
+                response.getProvided()
+        ));
     }
 }

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -212,7 +212,7 @@ public class SlackClient implements ExternalClient {
 
     private <T extends SlackApiTextResponse> void validateResponse(final String methodName, final T response) {
         if (!response.isOk()) {
-            throw new SlackApiCallException(methodName, response.getError());
+            throw new SlackApiCallException(methodName, response);
         }
     }
 }


### PR DESCRIPTION
## 요약

슬랙 API 호출 예외 메시지 구체화

<br><br>

## 작업 내용

슬랙 API 호출 예외 메시지 구체화

<br><br>

## 참고 사항

슬랙 API 호출하는 경우 데이터가 아래와 같은 형식으로 옵니다.
```
{ 
  ok: false,
  error: 'missing_scope',
  needed: 'channels:write',
  provided: 'identify,bot:basic'
}
```

기존에는 ok를 검증한 뒤 error에 담긴 값만 로그에 찍었는데
needed, provided도 함께 찍히도록 수정했습니다.

<br><br>
