### PR TITLE
fix: 로그인/워크스페이스 관련 oauth 요청시 다른 redirect uri를 보내주도록 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/config/SlackProperties.java
+++ b/backend/src/main/java/com/pickpick/config/SlackProperties.java
@@ -17,11 +17,16 @@ public class SlackProperties {
     private final String clientSecret;
 
     @NotBlank
-    private final String redirectUrl;
+    private final String loginRedirectUrl;
 
-    public SlackProperties(final String clientId, final String clientSecret, final String redirectUrl) {
+    @NotBlank
+    private final String workspaceRedirectUrl;
+
+    public SlackProperties(final String clientId, final String clientSecret, final String loginRedirectUrl,
+                           final String workspaceRedirectUrl) {
         this.clientId = clientId;
         this.clientSecret = clientSecret;
-        this.redirectUrl = redirectUrl;
+        this.loginRedirectUrl = loginRedirectUrl;
+        this.workspaceRedirectUrl = workspaceRedirectUrl;
     }
 }

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -55,19 +55,21 @@ public class SlackClient implements ExternalClient {
 
     @Override
     public String callUserToken(final String code) {
-        OAuthV2AccessResponse response = callOAuth2(code);
+        String loginRedirectUrl = slackProperties.getLoginRedirectUrl();
+        OAuthV2AccessResponse response = callOAuth2(code, loginRedirectUrl);
         validateResponse(OAUTH_ACCESS_METHOD_NAME, response);
         return response.getAuthedUser().getAccessToken();
     }
 
     @Override
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
-        OAuthV2AccessResponse response = callOAuth2(code);
+        String workspaceRedirectUrl = slackProperties.getWorkspaceRedirectUrl();
+        OAuthV2AccessResponse response = callOAuth2(code, workspaceRedirectUrl);
         return new WorkspaceInfoDto(response.getTeam().getId(), response.getAccessToken(), response.getBotUserId());
     }
 
-    private OAuthV2AccessResponse callOAuth2(final String code) {
-        OAuthV2AccessRequest request = generateOAuthRequest(code);
+    private OAuthV2AccessResponse callOAuth2(final String code, final String redirectUrl) {
+        OAuthV2AccessRequest request = generateOAuthRequest(code, redirectUrl);
 
         try {
             OAuthV2AccessResponse response = methodsClient
@@ -80,11 +82,11 @@ public class SlackClient implements ExternalClient {
         }
     }
 
-    private OAuthV2AccessRequest generateOAuthRequest(final String code) {
+    private OAuthV2AccessRequest generateOAuthRequest(final String code, final String redirectUrl) {
         return OAuthV2AccessRequest.builder()
                 .clientId(slackProperties.getClientId())
                 .clientSecret(slackProperties.getClientSecret())
-                .redirectUri(slackProperties.getRedirectUrl())
+                .redirectUri(redirectUrl)
                 .code(code)
                 .build();
     }


### PR DESCRIPTION
## 요약

로그인/워크스페이스 관련 oauth 요청시 다른 redirect uri를 보내주도록 수정
<br><br>

## 작업 내용

워크스페이스 등록 요청시 redirect uri가 로그인 요청 redirect uri로 되어있어서 문제 발생한 것 해결했씁니다.
<br><br>

## 참고 사항

<br><br>

## 관련 이슈

- #633 과 관련있는 것 같은데 확실히 해결되는 것을 확인한 후 이슈는 닫겠습니다!

<br><br>
