### PR TITLE
fix: SlackBot은 DB에 저장하지 않도록 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -120,7 +120,12 @@ public class SlackClient implements ExternalClient {
     private List<Member> toMembers(final List<User> users, final Workspace workspace) {
         return users.stream()
                 .map(user -> toMember(user, workspace))
+                .filter(this::isNotSlackBot)
                 .collect(Collectors.toList());
+    }
+
+    private boolean isNotSlackBot(final Member member) {
+        return !"USLACKBOT".equalsIgnoreCase(member.getSlackId());
     }
 
     private Member toMember(final User user, final Workspace workspace) {


### PR DESCRIPTION
## 요약

SlackBot은 DB에 저장하지 않도록 수정
<br><br>

## 작업 내용

- SlackClient에서 member로 변환할 때 slackId가 USLACKBOT인 경우를 제외하고 저장하도록 수정했습니다.

<br><br>

## 참고 사항

<img width="1432" alt="image" src="https://user-images.githubusercontent.com/55357130/196641782-53e29009-effa-40b4-bb0e-8e0e078774c9.png">


<br><br>

## 관련 이슈

- #633 

<br><br>
