### PR TITLE
fix: 워크스페이스 등록시 oauth.v2.access를 1회만 호출하도록 수정

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -51,12 +51,16 @@ public class AuthService {
         List<Channel> allWorkspaceChannels = slackClient.findChannelsByWorkspace(workspace);
         channels.saveAll(allWorkspaceChannels);
 
-        return login(code);
+        return loginByToken(workspaceInfoDto.getUserToken());
     }
 
     @Transactional
     public LoginResponse login(final String code) {
         String userToken = slackClient.callUserToken(code);
+        return loginByToken(userToken);
+    }
+
+    private LoginResponse loginByToken(final String userToken) {
         String memberSlackId = slackClient.callMemberSlackId(userToken);
 
         Member member = members.getBySlackId(memberSlackId);

--- a/backend/src/main/java/com/pickpick/auth/application/dto/WorkspaceInfoDto.java
+++ b/backend/src/main/java/com/pickpick/auth/application/dto/WorkspaceInfoDto.java
@@ -9,11 +9,14 @@ public class WorkspaceInfoDto {
     private final String workspaceSlackId;
     private final String botToken;
     private final String botSlackId;
+    private final String userToken;
 
-    public WorkspaceInfoDto(final String workspaceSlackId, final String botToken, final String botSlackId) {
+    public WorkspaceInfoDto(final String workspaceSlackId, final String botToken, final String botSlackId,
+                            final String userToken) {
         this.workspaceSlackId = workspaceSlackId;
         this.botToken = botToken;
         this.botSlackId = botSlackId;
+        this.userToken = userToken;
     }
 
     public Workspace toEntity() {

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -28,8 +28,10 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
 public class SlackClient implements ExternalClient {
 
@@ -65,7 +67,9 @@ public class SlackClient implements ExternalClient {
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
         String workspaceRedirectUrl = slackProperties.getWorkspaceRedirectUrl();
         OAuthV2AccessResponse response = callOAuth2(code, workspaceRedirectUrl);
-        return new WorkspaceInfoDto(response.getTeam().getId(), response.getAccessToken(), response.getBotUserId());
+
+        return new WorkspaceInfoDto(response.getTeam().getId(), response.getAccessToken(), response.getBotUserId(),
+                response.getAuthedUser().getAccessToken());
     }
 
     private OAuthV2AccessResponse callOAuth2(final String code, final String redirectUrl) {

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -28,10 +28,8 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
-@Slf4j
 @Component
 public class SlackClient implements ExternalClient {
 

--- a/backend/src/test/java/com/pickpick/support/FakeClient.java
+++ b/backend/src/test/java/com/pickpick/support/FakeClient.java
@@ -22,7 +22,7 @@ public class FakeClient implements ExternalClient {
 
     @Override
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
-        return new WorkspaceInfoDto(code, code, code);
+        return new WorkspaceInfoDto(code, code, code, code);
     }
 
     @Override


### PR DESCRIPTION
## 요약

워크스페이스 등록시 oauth.v2.access를 1회만 호출하도록 수정

<br><br>

## 작업 내용

- 워크스페이스 등록 시 `methodsClient.oauthV2Access(request)`를 1회만 호출하도록 했습니다.

**기존 로직**
callWorkspaceInfo
  -> oauthV2Access
findMembersByWorkspace
-> usersList
findChannelsByWorkspace
-> conversationsList
callUserToken
-> oauthV2Access
callMemberSlackId
-> usersIdentity

**수정한 로직**
callWorkspaceInfo
  -> oauthV2Access
findMembersByWorkspace
-> usersList
findChannelsByWorkspace
-> conversationsList
callMemberSlackId
-> usersIdentity


<br><br>

## 참고 사항

<img width="1182" alt="image" src="https://user-images.githubusercontent.com/55357130/196672211-d5a2bf22-64e1-4b75-b201-93f5ca907e6f.png">

기존 로직대로 진행하면 위의 예외가 발생했습니다.
예상하건데, 기존 로직은 `동일한 code`로 `oauthV2Access`를 2회 호출했는데, 첫번째 호출시에는 올바르게 값을 가져올 수 있었지만 두번째 호출시에는 `invalid_code` 가 발생하는걸로 보아, 한 code로 `oauthV2Access` 의 호출은 1회만 유효한 것 같습니다.

따라서 첫 호출때에 userToken도 함께 호출하게 했습니다. 

<br><br>

## 관련 이슈

- Closes #633 


## 이번 PR이 머지되면 개인화한 워크스페이스로 로그인할 수 있습니다!!!!!!!!!!!!!

<br><br>
