### PR TITLE
fix: 채널이 삭제되지 않는 현상 개선

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -25,6 +25,8 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
 
     void deleteAllByChannelAndMember(Channel channel, Member member);
 
+    void deleteAllByChannelSlackId(String channelSlackId);
+
     default ChannelSubscription getFirstByMemberIdOrderByViewOrderAsc(final Long memberId) {
         return findFirstByMemberIdOrderByViewOrderAsc(memberId)
                 .orElseThrow(() -> new SubscriptionNotFoundException(memberId));

--- a/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
+++ b/backend/src/main/java/com/pickpick/slackevent/application/channel/ChannelDeletedService.java
@@ -1,6 +1,7 @@
 package com.pickpick.slackevent.application.channel;
 
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.channel.domain.ChannelSubscriptionRepository;
 import com.pickpick.message.domain.MessageRepository;
 import com.pickpick.slackevent.application.SlackEvent;
 import com.pickpick.slackevent.application.SlackEventService;
@@ -14,10 +15,14 @@ import org.springframework.stereotype.Service;
 public class ChannelDeletedService implements SlackEventService {
 
     private final ChannelRepository channels;
+    private final ChannelSubscriptionRepository channelSubscriptions;
     private final MessageRepository messages;
 
-    public ChannelDeletedService(final ChannelRepository channels, final MessageRepository messages) {
+    public ChannelDeletedService(final ChannelRepository channels,
+                                 final ChannelSubscriptionRepository channelSubscriptions,
+                                 final MessageRepository messages) {
         this.channels = channels;
+        this.channelSubscriptions = channelSubscriptions;
         this.messages = messages;
     }
 
@@ -26,6 +31,7 @@ public class ChannelDeletedService implements SlackEventService {
         String channelSlackId = extractChannelSlackId(requestBody);
 
         messages.deleteAllByChannelSlackId(channelSlackId);
+        channelSubscriptions.deleteAllByChannelSlackId(channelSlackId);
         channels.deleteBySlackId(channelSlackId);
     }
 

--- a/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
+++ b/backend/src/test/java/com/pickpick/slackevent/application/channel/ChannelDeletedServiceTest.java
@@ -2,6 +2,7 @@ package com.pickpick.slackevent.application.channel;
 
 import static com.pickpick.fixture.ChannelFixture.NOTICE;
 import static com.pickpick.fixture.MemberFixture.HOPE;
+import static com.pickpick.fixture.MemberFixture.KKOJAE;
 import static com.pickpick.fixture.MessageFixtures.PLAIN_20220712_18_00_00;
 import static com.pickpick.fixture.MessageFixtures.PLAIN_20220715_14_00_00;
 import static com.pickpick.fixture.WorkspaceFixture.JUPJUP;
@@ -11,6 +12,8 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.channel.domain.ChannelRepository;
+import com.pickpick.channel.domain.ChannelSubscription;
+import com.pickpick.channel.domain.ChannelSubscriptionRepository;
 import com.pickpick.member.domain.Member;
 import com.pickpick.member.domain.MemberRepository;
 import com.pickpick.message.domain.MessageRepository;
@@ -32,6 +35,9 @@ class ChannelDeletedServiceTest {
     private ChannelRepository channels;
 
     @Autowired
+    private ChannelSubscriptionRepository channelSubscriptions;
+
+    @Autowired
     private MessageRepository messages;
 
     @Autowired
@@ -51,9 +57,25 @@ class ChannelDeletedServiceTest {
         databaseCleaner.clear();
     }
 
-    @DisplayName("채널 삭제 이벤트가 전달되면 채널과 메시지들이 삭제된다")
+    @DisplayName("채널 삭제 이벤트가 전달되면 채널이 삭제된다")
     @Test
-    void channelAndMessagesShouldBeDeletedOnChannelDeletedEvent() {
+    void channelShouldBeDeletedOnChannelDeletedEvent() {
+        // given
+        Workspace jupjup = workspaces.save(JUPJUP.create());
+        Channel notice = channels.save(NOTICE.create(jupjup));
+
+        String request = createChannelDeletedRequest(notice);
+
+        // when
+        channelDeletedService.execute(request);
+
+        //then
+        assertThat(channels.findAll()).isEmpty();
+    }
+
+    @DisplayName("채널 삭제 이벤트가 전달되면 채널과 관련된 메시지들이 삭제된다")
+    @Test
+    void messagesShouldBeDeletedOnChannelDeletedEvent() {
         // given
         Workspace jupjup = workspaces.save(JUPJUP.create());
         Member hope = members.save(HOPE.createLogin(jupjup));
@@ -67,9 +89,30 @@ class ChannelDeletedServiceTest {
         channelDeletedService.execute(request);
 
         //then
+        assertThat(messages.findAll()).isEmpty();
+    }
+
+    @DisplayName("채널 삭제 이벤트가 전달되면 채널과 관련된 채널 구독 목록이 삭제된다")
+    @Test
+    void channelSubscriptionsShouldBeDeletedOnChannelDeletedEvent() {
+        // given
+        Workspace jupjup = workspaces.save(JUPJUP.create());
+        Channel notice = channels.save(NOTICE.create(jupjup));
+
+        Member hope = members.save(HOPE.createLogin(jupjup));
+        Member kkojae = members.save(KKOJAE.createLogin(jupjup));
+        channelSubscriptions.save(new ChannelSubscription(notice, hope, 1));
+        channelSubscriptions.save(new ChannelSubscription(notice, kkojae, 1));
+
+        String request = createChannelDeletedRequest(notice);
+
+        // when
+        channelDeletedService.execute(request);
+
+        //then
         assertAll(
-                () -> assertThat(channels.findAll()).isEmpty(),
-                () -> assertThat(messages.findAll()).isEmpty()
+                () -> assertThat(channelSubscriptions.findAllByMemberId(hope.getId())).isEmpty(),
+                () -> assertThat(channelSubscriptions.findAllByMemberId(kkojae.getId())).isEmpty()
         );
     }
 


### PR DESCRIPTION
## 요약

채널이 삭제되지 않는 현상 개선

<br><br>

## 작업 내용

채널 구독이 삭제되지 않은 상태로 채널 삭제를 시도하는 경우 DataIntegrityViolationException가 발생합니다.
채널 삭제 이벤트 발생 시 메시지, 채널 구독, 채널을 삭제하도록 로직을 수정하였습니다.

<br><br>

## 관련 이슈

- Close #645 

<br><br>
