### PR TITLE
refactor: 줍줍 최초 설치 시 로그인 로직 제거

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -42,7 +42,7 @@ public class AuthService {
     }
 
     @Transactional
-    public LoginResponse registerWorkspace(final String code) {
+    public void registerWorkspace(final String code) {
         WorkspaceInfoDto workspaceInfoDto = externalClient.callWorkspaceInfo(code);
 
         validateExistWorkspace(workspaceInfoDto.getWorkspaceSlackId());
@@ -54,8 +54,6 @@ public class AuthService {
 
         List<Channel> allWorkspaceChannels = externalClient.findChannelsByWorkspace(workspace);
         channels.saveAll(allWorkspaceChannels);
-
-        return loginByToken(workspaceInfoDto.getUserToken());
     }
 
     private void validateExistWorkspace(final String workspaceSlackId) {

--- a/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
+++ b/backend/src/main/java/com/pickpick/auth/ui/AuthController.java
@@ -32,7 +32,7 @@ public class AuthController {
     }
 
     @GetMapping("/slack-workspace")
-    public LoginResponse registerWorkspace(@RequestParam @NotEmpty final String code) {
-        return authService.registerWorkspace(code);
+    public void registerWorkspace(@RequestParam @NotEmpty final String code) {
+        authService.registerWorkspace(code);
     }
 }

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthAcceptanceTest.java
@@ -4,7 +4,7 @@ import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
 import static com.pickpick.acceptance.RestHandler.에러코드_확인;
 import static com.pickpick.acceptance.auth.AuthRestHandler.로그인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.auth.AuthRestHandler.토큰_검증;
 import static com.pickpick.fixture.MemberFixture.BOM;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -30,7 +30,10 @@ class AuthAcceptanceTest extends AcceptanceTestBase {
         String code = 슬랙에서_코드_발행(BOM);
 
         // when
-        ExtractableResponse<Response> response = 워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
+
+        String codeForLogin = 슬랙에서_코드_발행(BOM);
+        ExtractableResponse<Response> response = 로그인(codeForLogin);
 
         // then
         상태코드_200_확인(response);
@@ -41,7 +44,7 @@ class AuthAcceptanceTest extends AcceptanceTestBase {
     void 워크스페이스_초기화_후_다시_로그인() {
         // given
         String codeForInit = 슬랙에서_코드_발행(BOM);
-        워크스페이스_초기화_및_로그인(codeForInit);
+        워크스페이스_초기화(codeForInit);
 
         // when
         String codeForLogin = 슬랙에서_코드_발행(BOM);
@@ -56,11 +59,11 @@ class AuthAcceptanceTest extends AcceptanceTestBase {
     void 워크스페이스_등록_후_워크스페이스_재등록시_예외처리() {
         // given
         String codeForInit = 슬랙에서_코드_발행(BOM);
-        워크스페이스_초기화_및_로그인(codeForInit);
+        워크스페이스_초기화(codeForInit);
 
         // when
         String codeForLogin = 슬랙에서_코드_발행(BOM);
-        ExtractableResponse<Response> response = 워크스페이스_초기화_및_로그인(codeForLogin);
+        ExtractableResponse<Response> response = 워크스페이스_초기화(codeForLogin);
 
         // then
         상태코드_400_확인(response);

--- a/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
+++ b/backend/src/test/java/com/pickpick/acceptance/auth/AuthRestHandler.java
@@ -23,7 +23,7 @@ public class AuthRestHandler {
         return getWithToken(CERTIFICATION_API_URL, token);
     }
 
-    public static ExtractableResponse<Response> 워크스페이스_초기화_및_로그인(final String code) {
+    public static ExtractableResponse<Response> 워크스페이스_초기화(final String code) {
         Map<String, Object> request = Map.of("code", code);
         return get(WORKSPACE_API_URL, request);
     }

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelAcceptanceTest.java
@@ -1,7 +1,8 @@
 package com.pickpick.acceptance.channel;
 
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.channel.ChannelRestHandler.유저_전체_채널_목록_조회_요청;
 import static com.pickpick.fixture.MemberFixture.YEONLOG;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -24,7 +25,10 @@ class ChannelAcceptanceTest extends AcceptanceTestBase {
     void 유저_전체_채널_목록_조회() {
         // given
         String code = 슬랙에서_코드_발행(YEONLOG);
-        ExtractableResponse<Response> loginResponse = 워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
+
+        String loginCode = 슬랙에서_코드_발행(YEONLOG);
+        ExtractableResponse<Response> loginResponse = 로그인(loginCode);
         String token = 로그인_응답에서_토큰_추출(loginResponse);
 
         // when

--- a/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/channel/ChannelSubscriptionAcceptanceTest.java
@@ -3,7 +3,7 @@ package com.pickpick.acceptance.channel;
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
 import static com.pickpick.acceptance.RestHandler.에러코드_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.channel.ChannelRestHandler.구독한_채널_순서_변경_요청;
 import static com.pickpick.acceptance.channel.ChannelRestHandler.유저_전체_채널_목록_조회_요청;
 import static com.pickpick.acceptance.channel.ChannelRestHandler.유저가_구독한_채널_목록_조회_요청;
@@ -14,6 +14,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.acceptance.AcceptanceTestBase;
+import com.pickpick.acceptance.auth.AuthRestHandler;
 import com.pickpick.channel.ui.dto.ChannelOrderRequest;
 import com.pickpick.channel.ui.dto.ChannelResponse;
 import com.pickpick.channel.ui.dto.ChannelSubscriptionResponse;
@@ -36,8 +37,11 @@ class ChannelSubscriptionAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void 가입_후_로그인() {
         String code = 슬랙에서_코드_발행(SUMMER);
+        워크스페이스_초기화(code);
 
-        ExtractableResponse<Response> loginResponse = 워크스페이스_초기화_및_로그인(code);
+        String loginCode = 슬랙에서_코드_발행(SUMMER);
+        ExtractableResponse<Response> loginResponse = AuthRestHandler.로그인(loginCode);
+
         token = 로그인_응답에서_토큰_추출(loginResponse);
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/BookmarkAcceptanceTest.java
@@ -5,7 +5,7 @@ import static com.pickpick.acceptance.RestHandler.상태코드_201_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_204_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
 import static com.pickpick.acceptance.RestHandler.에러코드_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.message.BookmarkRestHandler.북마크_삭제;
 import static com.pickpick.acceptance.message.BookmarkRestHandler.북마크_생성;
 import static com.pickpick.acceptance.message.BookmarkRestHandler.북마크_조회;
@@ -15,6 +15,7 @@ import static com.pickpick.fixture.MemberFixture.HOPE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.acceptance.AcceptanceTestBase;
+import com.pickpick.acceptance.auth.AuthRestHandler;
 import com.pickpick.message.ui.dto.BookmarkResponse;
 import com.pickpick.message.ui.dto.BookmarkResponses;
 import io.restassured.response.ExtractableResponse;
@@ -35,10 +36,12 @@ class BookmarkAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         String code = 슬랙에서_코드_발행(HOPE);
-        ExtractableResponse<Response> loginResponse = 워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
+
+        String loginCode = 슬랙에서_코드_발행(HOPE);
+        ExtractableResponse<Response> loginResponse = AuthRestHandler.로그인(loginCode);
 
         token = 로그인_응답에서_토큰_추출(loginResponse);
-
         memberSlackId = 코드로_멤버의_slackId_추출(code);
     }
 

--- a/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/MessageAcceptanceTest.java
@@ -1,7 +1,7 @@
 package com.pickpick.acceptance.message;
 
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.channel.ChannelRestHandler.채널_구독_요청;
 import static com.pickpick.acceptance.message.BookmarkRestHandler.북마크_생성;
 import static com.pickpick.acceptance.message.MessageRestHandler.메시지_조회;
@@ -14,6 +14,7 @@ import static com.pickpick.fixture.MemberFixture.KKOJAE;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.pickpick.acceptance.AcceptanceTestBase;
+import com.pickpick.acceptance.auth.AuthRestHandler;
 import com.pickpick.acceptance.message.MessageRestHandler.MessageRequestBuilder;
 import com.pickpick.fixture.ChannelFixture;
 import com.pickpick.message.ui.dto.MessageResponse;
@@ -37,7 +38,10 @@ class MessageAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         String code = 슬랙에서_코드_발행(KKOJAE);
-        ExtractableResponse<Response> loginResponse = 워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
+
+        String loginCode = 슬랙에서_코드_발행(KKOJAE);
+        ExtractableResponse<Response> loginResponse = AuthRestHandler.로그인(loginCode);
 
         token = 로그인_응답에서_토큰_추출(loginResponse);
         memberSlackId = 코드로_멤버의_slackId_추출(code);

--- a/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/message/ReminderAcceptanceTest.java
@@ -5,7 +5,7 @@ import static com.pickpick.acceptance.RestHandler.상태코드_201_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_204_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_400_확인;
 import static com.pickpick.acceptance.RestHandler.상태코드_404_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.message.ReminderRestHandler.리마인더_단건_조회;
 import static com.pickpick.acceptance.message.ReminderRestHandler.리마인더_목록_조회;
 import static com.pickpick.acceptance.message.ReminderRestHandler.리마인더_삭제;
@@ -18,6 +18,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.pickpick.acceptance.AcceptanceTestBase;
+import com.pickpick.acceptance.auth.AuthRestHandler;
 import com.pickpick.acceptance.message.ReminderRestHandler.ReminderFindRequest;
 import com.pickpick.message.ui.dto.ReminderResponse;
 import com.pickpick.message.ui.dto.ReminderResponses;
@@ -40,7 +41,10 @@ class ReminderAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         String code = 슬랙에서_코드_발행(BOM);
-        ExtractableResponse<Response> loginResponse = 워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
+
+        String loginCode = 슬랙에서_코드_발행(BOM);
+        ExtractableResponse<Response> loginResponse = AuthRestHandler.로그인(loginCode);
 
         token = 로그인_응답에서_토큰_추출(loginResponse);
         memberSlackId = 코드로_멤버의_slackId_추출(code);

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/ChannelEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/ChannelEventAcceptanceTest.java
@@ -1,7 +1,7 @@
 package com.pickpick.acceptance.slackevent;
 
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.채널_삭제;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.채널_생성;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.채널_이름_변경;
@@ -26,7 +26,7 @@ class ChannelEventAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         String code = 슬랙에서_코드_발행(BOM);
-        워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
 
         workspace = 슬랙에서_멤버의_워크스페이스_정보_호출(code);
     }

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MemberEventAcceptanceTest.java
@@ -1,7 +1,7 @@
 package com.pickpick.acceptance.slackevent;
 
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.멤버_정보_수정;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.회원가입;
 import static com.pickpick.fixture.MemberFixture.BOM;
@@ -24,7 +24,7 @@ class MemberEventAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         String code = 슬랙에서_코드_발행(BOM);
-        워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
 
         memberSlackId = 코드로_멤버의_slackId_추출(code);
         workspace = 슬랙에서_멤버의_워크스페이스_정보_호출(code);

--- a/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
+++ b/backend/src/test/java/com/pickpick/acceptance/slackevent/MessageEventAcceptanceTest.java
@@ -1,7 +1,7 @@
 package com.pickpick.acceptance.slackevent;
 
 import static com.pickpick.acceptance.RestHandler.상태코드_200_확인;
-import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화_및_로그인;
+import static com.pickpick.acceptance.auth.AuthRestHandler.워크스페이스_초기화;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.URL_검증;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.메시지_삭제;
 import static com.pickpick.acceptance.slackevent.SlackEventRestHandler.메시지_수정;
@@ -33,7 +33,7 @@ class MessageEventAcceptanceTest extends AcceptanceTestBase {
     @BeforeEach
     void init() {
         String code = 슬랙에서_코드_발행(BOM);
-        워크스페이스_초기화_및_로그인(code);
+        워크스페이스_초기화(code);
         memberSlackId = 코드로_멤버의_slackId_추출(code);
         workspace = 슬랙에서_멤버의_워크스페이스_정보_호출(code);
     }


### PR DESCRIPTION
## 요약

줍줍봇 최초 설치 시 로그인 로직 제거 

<br>

## 작업 내용

줍줍봇 설치 시 필요한 `channels:read / write`와 로그인 시 필요한 `identity.basic`이  한 번에 `OAuth` 요청 시 충돌합니다 
따라서 이 두 권한을 분리할 수 있도록, 설치 시 로그인 로직을 제거합니다  

- 줍줍봇 최초 설치 시 `봇 토큰` 발급 
  - `봇 토큰`으로 워크스페이스 저장
  - `봇 토큰`으로 워크스페이스 멤버 저장
  - `봇 토큰`으로 워크스페이스 채널 저장
 ===== 이하 삭제 =====
  - `유저 토큰`으로 로그인

<br>
