### PR TITLE
hotfix: 슬랙 권한 문제 해결

### DIFF
--- a/backend/src/main/java/com/pickpick/auth/application/AuthService.java
+++ b/backend/src/main/java/com/pickpick/auth/application/AuthService.java
@@ -1,5 +1,6 @@
 package com.pickpick.auth.application;
 
+import com.pickpick.auth.application.dto.MemberInfoDto;
 import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.auth.support.JwtTokenProvider;
 import com.pickpick.auth.ui.dto.LoginResponse;
@@ -64,17 +65,11 @@ public class AuthService {
 
     @Transactional
     public LoginResponse login(final String code) {
-        String userToken = externalClient.callUserToken(code);
-        return loginByToken(userToken);
-    }
-
-    private LoginResponse loginByToken(final String userSlackToken) {
-        String memberSlackId = externalClient.callMemberSlackId(userSlackToken);
-
-        Member member = members.getBySlackId(memberSlackId);
+        MemberInfoDto memberInfoDto = externalClient.callMemberSlackIdByCode(code);
+        Member member = members.getBySlackId(memberInfoDto.getSlackId());
 
         boolean isFirstLogin = member.isFirstLogin();
-        member.firstLogin(userSlackToken);
+        member.firstLogin(memberInfoDto.getUserToken());
 
         return LoginResponse.builder()
                 .token(jwtTokenProvider.createToken(String.valueOf(member.getId())))

--- a/backend/src/main/java/com/pickpick/auth/application/dto/MemberInfoDto.java
+++ b/backend/src/main/java/com/pickpick/auth/application/dto/MemberInfoDto.java
@@ -1,0 +1,15 @@
+package com.pickpick.auth.application.dto;
+
+import lombok.Getter;
+
+@Getter
+public class MemberInfoDto {
+
+    private final String slackId;
+    private final String userToken;
+
+    public MemberInfoDto(final String slackId, final String userToken) {
+        this.slackId = slackId;
+        this.userToken = userToken;
+    }
+}

--- a/backend/src/main/java/com/pickpick/message/application/MentionReplacer.java
+++ b/backend/src/main/java/com/pickpick/message/application/MentionReplacer.java
@@ -1,0 +1,8 @@
+package com.pickpick.message.application;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class MentionReplacer {
+    
+}

--- a/backend/src/main/java/com/pickpick/message/application/MentionReplacer.java
+++ b/backend/src/main/java/com/pickpick/message/application/MentionReplacer.java
@@ -1,8 +1,0 @@
-package com.pickpick.message.application;
-
-import org.springframework.stereotype.Component;
-
-@Component
-public class MentionReplacer {
-    
-}

--- a/backend/src/main/java/com/pickpick/support/ExternalClient.java
+++ b/backend/src/main/java/com/pickpick/support/ExternalClient.java
@@ -10,10 +10,8 @@ import com.pickpick.workspace.domain.Workspace;
 import java.util.List;
 
 public interface ExternalClient {
-    
-    WorkspaceInfoDto callWorkspaceInfo(String code);
 
-    String callMemberSlackId(String userToken);
+    WorkspaceInfoDto callWorkspaceInfo(String code);
 
     MemberInfoDto callMemberSlackIdByCode(String code);
 

--- a/backend/src/main/java/com/pickpick/support/ExternalClient.java
+++ b/backend/src/main/java/com/pickpick/support/ExternalClient.java
@@ -1,5 +1,6 @@
 package com.pickpick.support;
 
+import com.pickpick.auth.application.dto.MemberInfoDto;
 import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.member.domain.Member;
@@ -9,12 +10,12 @@ import com.pickpick.workspace.domain.Workspace;
 import java.util.List;
 
 public interface ExternalClient {
-
-    String callUserToken(String code);
-
+    
     WorkspaceInfoDto callWorkspaceInfo(String code);
 
     String callMemberSlackId(String userToken);
+
+    MemberInfoDto callMemberSlackIdByCode(String code);
 
     List<Member> findMembersByWorkspace(Workspace workspace);
 

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -17,12 +17,10 @@ import com.slack.api.methods.request.chat.ChatPostMessageRequest;
 import com.slack.api.methods.request.conversations.ConversationsInviteRequest;
 import com.slack.api.methods.request.conversations.ConversationsListRequest;
 import com.slack.api.methods.request.oauth.OAuthV2AccessRequest;
-import com.slack.api.methods.request.users.UsersIdentityRequest;
 import com.slack.api.methods.request.users.UsersListRequest;
 import com.slack.api.methods.response.conversations.ConversationsInviteResponse;
 import com.slack.api.methods.response.conversations.ConversationsListResponse;
 import com.slack.api.methods.response.oauth.OAuthV2AccessResponse;
-import com.slack.api.methods.response.users.UsersIdentityResponse;
 import com.slack.api.methods.response.users.UsersListResponse;
 import com.slack.api.model.Conversation;
 import com.slack.api.model.User;
@@ -57,13 +55,20 @@ public class SlackClient implements ExternalClient {
         this.slackProperties = slackProperties;
         this.methodsClient = methodsClient;
     }
-    
+
 
     @Override
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
         OAuthV2AccessResponse response = callOAuth2(code, slackProperties.getWorkspaceRedirectUrl());
         return new WorkspaceInfoDto(response.getTeam().getId(), response.getAccessToken(), response.getBotUserId(),
                 response.getAuthedUser().getAccessToken());
+    }
+    
+    @Override
+    public MemberInfoDto callMemberSlackIdByCode(final String code) {
+        OAuthV2AccessResponse response = callOAuth2(code, slackProperties.getLoginRedirectUrl());
+
+        return new MemberInfoDto(response.getAuthedUser().getId(), response.getAuthedUser().getAccessToken());
     }
 
     private OAuthV2AccessResponse callOAuth2(final String code, final String redirectUrl) {
@@ -78,27 +83,6 @@ public class SlackClient implements ExternalClient {
                 .redirectUri(redirectUrl)
                 .code(code)
                 .build();
-    }
-
-    @Override
-    public String callMemberSlackId(final String userToken) {
-        UsersIdentityRequest request = UsersIdentityRequest.builder()
-                .token(userToken)
-                .build();
-
-        UsersIdentityResponse response = execute(
-                methodsClient::usersIdentity,
-                USERS_IDENTITY_METHOD_NAME,
-                request);
-
-        return response.getUser().getId();
-    }
-
-    @Override
-    public MemberInfoDto callMemberSlackIdByCode(final String code) {
-        OAuthV2AccessResponse response = callOAuth2(code, slackProperties.getLoginRedirectUrl());
-
-        return new MemberInfoDto(response.getAuthedUser().getId(), response.getAuthedUser().getAccessToken());
     }
 
     @Override

--- a/backend/src/main/java/com/pickpick/support/SlackClient.java
+++ b/backend/src/main/java/com/pickpick/support/SlackClient.java
@@ -1,5 +1,6 @@
 package com.pickpick.support;
 
+import com.pickpick.auth.application.dto.MemberInfoDto;
 import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.config.SlackProperties;
@@ -56,12 +57,7 @@ public class SlackClient implements ExternalClient {
         this.slackProperties = slackProperties;
         this.methodsClient = methodsClient;
     }
-
-    @Override
-    public String callUserToken(final String code) {
-        OAuthV2AccessResponse response = callOAuth2(code, slackProperties.getLoginRedirectUrl());
-        return response.getAuthedUser().getAccessToken();
-    }
+    
 
     @Override
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
@@ -96,6 +92,13 @@ public class SlackClient implements ExternalClient {
                 request);
 
         return response.getUser().getId();
+    }
+
+    @Override
+    public MemberInfoDto callMemberSlackIdByCode(final String code) {
+        OAuthV2AccessResponse response = callOAuth2(code, slackProperties.getLoginRedirectUrl());
+
+        return new MemberInfoDto(response.getAuthedUser().getId(), response.getAuthedUser().getAccessToken());
     }
 
     @Override

--- a/backend/src/test/java/com/pickpick/support/FakeClient.java
+++ b/backend/src/test/java/com/pickpick/support/FakeClient.java
@@ -37,7 +37,7 @@ public class FakeClient implements ExternalClient {
     private final Map<String, Member> tokenAndMember = Arrays.stream(MemberFixture.values())
             .map(memberFixture -> memberFixture.createLogin(jupjup))
             .collect(Collectors.toMap(Member::getSlackToken, member -> member));
-    
+
 
     @Override
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
@@ -45,11 +45,6 @@ public class FakeClient implements ExternalClient {
         Member member = codeAndMember.get(code);
         return new WorkspaceInfoDto(workspace.getSlackId(), workspace.getBotToken(), workspace.getBotSlackId(),
                 member.getSlackToken());
-    }
-
-    @Override
-    public String callMemberSlackId(final String userToken) {
-        return tokenAndMember.get(userToken).getSlackId();
     }
 
     @Override

--- a/backend/src/test/java/com/pickpick/support/FakeClient.java
+++ b/backend/src/test/java/com/pickpick/support/FakeClient.java
@@ -3,6 +3,7 @@ package com.pickpick.support;
 
 import static com.pickpick.fixture.WorkspaceFixture.JUPJUP;
 
+import com.pickpick.auth.application.dto.MemberInfoDto;
 import com.pickpick.auth.application.dto.WorkspaceInfoDto;
 import com.pickpick.channel.domain.Channel;
 import com.pickpick.fixture.ChannelFixture;
@@ -36,11 +37,7 @@ public class FakeClient implements ExternalClient {
     private final Map<String, Member> tokenAndMember = Arrays.stream(MemberFixture.values())
             .map(memberFixture -> memberFixture.createLogin(jupjup))
             .collect(Collectors.toMap(Member::getSlackToken, member -> member));
-
-    @Override
-    public String callUserToken(final String code) {
-        return codeAndMember.get(code).getSlackToken();
-    }
+    
 
     @Override
     public WorkspaceInfoDto callWorkspaceInfo(final String code) {
@@ -53,6 +50,11 @@ public class FakeClient implements ExternalClient {
     @Override
     public String callMemberSlackId(final String userToken) {
         return tokenAndMember.get(userToken).getSlackId();
+    }
+
+    @Override
+    public MemberInfoDto callMemberSlackIdByCode(final String code) {
+        return new MemberInfoDto(codeAndMember.get(code).getSlackId(), codeAndMember.get(code).getSlackToken());
     }
 
     @Override


### PR DESCRIPTION
## 요약

슬랙 권한 문제 해결
<br><br>

## 작업 내용

슬랙 권한 문제 해결
- 현재 로그인 시 
1. `OAuthV2Aceess` 호출하여 user token(xoxp-xxxxx) 가져옴
2. 해당 user token으로  `user.identity` 호출하여 memberSlackId를 가져옴

- 위 과정은 `OAuthV2Aceess` 메서드 호출 한 번에 해결이 가능합니다.
- `OAuthV2Aceess` 호출하여 user token(xoxp-xxxxx)과 memberSlackId 모두가져올 수 있습니다.

<br><br>

## 참고 사항
![image (8)](https://user-images.githubusercontent.com/55357130/197662018-d4a61012-9790-4131-9ef0-721caa60d231.png)

![image](https://user-images.githubusercontent.com/55357130/197662319-46e3297d-cd2a-4a6b-ac36-8fdb97e73110.png)

로깅 찍었을 때 AuthedUser 내부의 id에 memberSlackId가 있는걸 확인할 수 있습니다.
보안상 가렸습니다!



+) 머지된다면 프론트에서 권한 Redirect uri 수정이 필요합니다. 호프가 가까이에 있었어서 호프에게 전달해뒀습니다!

<br><br>

## 관련 이슈

- Close #669 

<br><br>
