### PR TITLE
refactor: @EnableJpaAuditing 설정 클래스 분리

### DIFF
--- a/backend/src/main/java/com/pickpick/PickpickApplication.java
+++ b/backend/src/main/java/com/pickpick/PickpickApplication.java
@@ -3,11 +3,9 @@ package com.pickpick;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
 @EnableScheduling
-@EnableJpaAuditing
 @ConfigurationPropertiesScan
 @SpringBootApplication
 public class PickpickApplication {

--- a/backend/src/main/java/com/pickpick/config/JpaAuditingConfig.java
+++ b/backend/src/main/java/com/pickpick/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com.pickpick.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/backend/src/test/java/com/pickpick/support/DocsControllerTestBase.java
+++ b/backend/src/test/java/com/pickpick/support/DocsControllerTestBase.java
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.mapping.JpaMetamodelMappingContext;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
@@ -36,7 +35,6 @@ import org.springframework.web.context.WebApplicationContext;
 @WebMvcTest
 @ExtendWith(RestDocumentationExtension.class)
 @Import(RestDocsConfiguration.class)
-@MockBean(JpaMetamodelMappingContext.class)
 public class DocsControllerTestBase {
 
     private static final String BEARER_JWT_TOKEN = "Bearer provided.jwt.token";


### PR DESCRIPTION
## 요약

`@EnableJpaAuditing` 설정 클래스 분리

<br>

## 작업 내용

`@EnableJpaAuditing`이 원래 메인 클래스에 붙어있었는데요, 
`@WebMvcTest` 같이 JPA 관련 빈을 생성하지 않는 테스트를 추가하는 경우, `@MockBean`을 반복적으로 설정해줘야 합니다  
그래서 별도의 `@Configuration` 클래스로 분리했습니다 

<br>

## 참고 사항

[블로그에 해당 내용 관련 포스팅](https://hyewoncc.github.io/jpa-auditing-and-ci/)을 작성했었으니 궁금하시면 읽어보세요!  

<br>

## 관련 이슈

- Close #611 

<br>
