### PR TITLE
refactor: Dropdown 컴포넌트에 스크린리더 설명 추가 

### DIFF
--- a/frontend/public/mockServiceWorker.js
+++ b/frontend/public/mockServiceWorker.js
@@ -1,0 +1,367 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.43.1).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = "c9450df6e4dc5e45740c3b0b640727a2";
+const activeClientIds = new Set();
+
+self.addEventListener("install", function () {
+  self.skipWaiting();
+});
+
+self.addEventListener("activate", function (event) {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener("message", async function (event) {
+  const clientId = event.source.id;
+
+  if (!clientId || !self.clients) {
+    return;
+  }
+
+  const client = await self.clients.get(clientId);
+
+  if (!client) {
+    return;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  });
+
+  switch (event.data) {
+    case "KEEPALIVE_REQUEST": {
+      sendToClient(client, {
+        type: "KEEPALIVE_RESPONSE",
+      });
+      break;
+    }
+
+    case "INTEGRITY_CHECK_REQUEST": {
+      sendToClient(client, {
+        type: "INTEGRITY_CHECK_RESPONSE",
+        payload: INTEGRITY_CHECKSUM,
+      });
+      break;
+    }
+
+    case "MOCK_ACTIVATE": {
+      activeClientIds.add(clientId);
+
+      sendToClient(client, {
+        type: "MOCKING_ENABLED",
+        payload: true,
+      });
+      break;
+    }
+
+    case "MOCK_DEACTIVATE": {
+      activeClientIds.delete(clientId);
+      break;
+    }
+
+    case "CLIENT_CLOSED": {
+      activeClientIds.delete(clientId);
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId;
+      });
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister();
+      }
+
+      break;
+    }
+  }
+});
+
+self.addEventListener("fetch", function (event) {
+  const { request } = event;
+  const accept = request.headers.get("accept") || "";
+
+  // Bypass server-sent events.
+  if (accept.includes("text/event-stream")) {
+    return;
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === "navigate") {
+    return;
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === "only-if-cached" && request.mode !== "same-origin") {
+    return;
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return;
+  }
+
+  // Generate unique request ID.
+  const requestId = Math.random().toString(16).slice(2);
+
+  event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === "NetworkError") {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url
+        );
+        return;
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`
+      );
+    })
+  );
+});
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event);
+  const response = await getResponse(event, client, requestId);
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    (async function () {
+      const clonedResponse = response.clone();
+      sendToClient(client, {
+        type: "RESPONSE",
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: Object.fromEntries(clonedResponse.headers.entries()),
+          redirected: clonedResponse.redirected,
+        },
+      });
+    })();
+  }
+
+  return response;
+}
+
+// Resolve the main client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId);
+
+  if (client.frameType === "top-level") {
+    return client;
+  }
+
+  const allClients = await self.clients.matchAll({
+    type: "window",
+  });
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === "visible";
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id);
+    });
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event;
+  const clonedRequest = request.clone();
+
+  function passthrough() {
+    // Clone the request because it might've been already used
+    // (i.e. its body has been read and sent to the cilent).
+    const headers = Object.fromEntries(clonedRequest.headers.entries());
+
+    // Remove MSW-specific request headers so the bypassed requests
+    // comply with the server's CORS preflight check.
+    // Operate with the headers as an object because request "Headers"
+    // are immutable.
+    delete headers["x-msw-bypass"];
+
+    return fetch(clonedRequest, { headers });
+  }
+
+  // Bypass mocking when the client is not active.
+  if (!client) {
+    return passthrough();
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return passthrough();
+  }
+
+  // Bypass requests with the explicit bypass header.
+  // Such requests can be issued by "ctx.fetch()".
+  if (request.headers.get("x-msw-bypass") === "true") {
+    return passthrough();
+  }
+
+  // Create a communication channel scoped to the current request.
+  // This way events can be exchanged outside of the worker's global
+  // "message" event listener (i.e. abstracted into functions).
+  const operationChannel = new BroadcastChannel(
+    `msw-response-stream-${requestId}`
+  );
+
+  // Notify the client that a request has been intercepted.
+  const clientMessage = await sendToClient(client, {
+    type: "REQUEST",
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: Object.fromEntries(request.headers.entries()),
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body: await request.text(),
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  });
+
+  switch (clientMessage.type) {
+    case "MOCK_RESPONSE": {
+      return respondWithMock(clientMessage.payload);
+    }
+
+    case "MOCK_RESPONSE_START": {
+      return respondWithMockStream(operationChannel, clientMessage.payload);
+    }
+
+    case "MOCK_NOT_FOUND": {
+      return passthrough();
+    }
+
+    case "NETWORK_ERROR": {
+      const { name, message } = clientMessage.payload;
+      const networkError = new Error(message);
+      networkError.name = name;
+
+      // Rejecting a "respondWith" promise emulates a network error.
+      throw networkError;
+    }
+
+    case "INTERNAL_ERROR": {
+      const parsedBody = JSON.parse(clientMessage.payload.body);
+
+      console.error(
+        `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+        request.method,
+        request.url
+      );
+
+      return respondWithMock(clientMessage.payload);
+    }
+  }
+
+  return passthrough();
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel();
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error);
+      }
+
+      resolve(event.data);
+    };
+
+    client.postMessage(JSON.stringify(message), [channel.port2]);
+  });
+}
+
+function sleep(timeMs) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeMs);
+  });
+}
+
+async function respondWithMock(response) {
+  await sleep(response.delay);
+  return new Response(response.body, response);
+}
+
+function respondWithMockStream(operationChannel, mockResponse) {
+  let streamCtrl;
+  const stream = new ReadableStream({
+    start: (controller) => (streamCtrl = controller),
+  });
+
+  return new Promise(async (resolve, reject) => {
+    operationChannel.onmessageerror = (event) => {
+      operationChannel.close();
+      return reject(event.data.error);
+    };
+
+    operationChannel.onmessage = (event) => {
+      if (!event.data) {
+        return;
+      }
+
+      switch (event.data.type) {
+        case "MOCK_RESPONSE_CHUNK": {
+          streamCtrl.enqueue(event.data.payload);
+          break;
+        }
+
+        case "MOCK_RESPONSE_END": {
+          streamCtrl.close();
+          operationChannel.close();
+        }
+      }
+    };
+
+    await sleep(mockResponse.delay);
+    return resolve(new Response(stream, mockResponse));
+  });
+}

--- a/frontend/src/components/@shared/Dropdown/index.tsx
+++ b/frontend/src/components/@shared/Dropdown/index.tsx
@@ -4,6 +4,7 @@ import useDropdown from "@src/components/@shared/Dropdown/@hooks/useDropdown";
 
 import useOuterClick from "@src/hooks/@shared/useOuterClick";
 
+import { SrOnlyDescription } from "@src/@styles/shared";
 import { PropsWithFunctionChildren } from "@src/@types/utils";
 
 interface ChildrenProps {
@@ -41,6 +42,18 @@ function Dropdown({
 
   return (
     <>
+      <SrOnlyDescription id="description">
+        {isDropdownOpened
+          ? "드랍다운 메뉴가 열려있습니다. 드랍다운 메뉴를 닫으려면 클릭해주세요."
+          : "드랍다운 메뉴가 닫혀있습니다. 드랍다운 메뉴를 열려면 클릭해주세요."}
+      </SrOnlyDescription>
+
+      <SrOnlyDescription aria-live="assertive">
+        {isDropdownOpened
+          ? "드랍다운 메뉴가 열렸습니다."
+          : "드랍다운 메뉴가 닫혔습니다."}
+      </SrOnlyDescription>
+
       {children({
         innerRef,
         isDropdownOpened,

--- a/frontend/src/components/DateDropdown/index.tsx
+++ b/frontend/src/components/DateDropdown/index.tsx
@@ -2,7 +2,6 @@ import Dropdown from "@src/components/@shared/Dropdown";
 import DateDropdownMenu from "@src/components/DateDropdown/DateDropdownMenu";
 import DateDropdownToggle from "@src/components/DateDropdown/DateDropdownToggle";
 
-import { SrOnlyDescription } from "@src/@styles/shared";
 import { getMessagesDate } from "@src/@utils/date";
 
 import * as Styled from "./style";
@@ -24,18 +23,6 @@ function DateDropdown({ postedDate, channelId, handleOpenCalendar }: Props) {
               onClick={handleToggleDropdown}
               aria-describedby="description"
             />
-            <SrOnlyDescription id="description">
-              {isDropdownOpened
-                ? "드랍다운 메뉴가 열려있습니다. 드랍다운 메뉴를 닫으려면 클릭해주세요."
-                : "드랍다운 메뉴가 닫혀있습니다. 드랍다운 메뉴를 열려면 클릭해주세요."}
-            </SrOnlyDescription>
-
-            <SrOnlyDescription aria-live="assertive">
-              {isDropdownOpened
-                ? "드랍다운 메뉴가 열렸습니다."
-                : "드랍다운 메뉴가 닫혔습니다."}
-            </SrOnlyDescription>
-
             {isDropdownOpened && (
               <DateDropdownMenu
                 date={getMessagesDate(postedDate)}


### PR DESCRIPTION
## 요약

- Dropdown 공용 컴포넌트에 스크린리더 설명 추가 

## 작업 내용

- 기존에 Date Dropdown 컴포넌트에만 있던 드랍다운 열림/닫힘 여부를 알려주는 스크린리더 설명을 공용 Dropdown 컴포넌트로 이동했습니다!
- 따라서 모든 드랍다운류 컴포넌트에서, 해당 스크린리더 설명이 읽히도록 리팩터링했어요! 
- MSW 구동이 안되길래 찾아봣더니 mockServiceWorker.js 파일이 삭제되어있었더라구요 그래서 다시 추가해줬습니당~!


