### PR TITLE
fix: ReminderSender에서 N+1 문제 개선

### DIFF
--- a/backend/src/main/java/com/pickpick/message/application/ReminderSender.java
+++ b/backend/src/main/java/com/pickpick/message/application/ReminderSender.java
@@ -33,7 +33,7 @@ public class ReminderSender {
             externalClient.sendMessage(reminder);
         }
 
-        reminders.deleteAllByRemindDate(nowTime);
+        reminders.deleteInBatch(foundReminders);
     }
 
     private LocalDateTime now() {

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -21,7 +21,7 @@ public interface ReminderRepository extends Repository<Reminder, Long> {
 
     void deleteById(Long id);
 
-    void deleteAllByRemindDate(LocalDateTime remindDate);
+    void deleteInBatch(Iterable<Reminder> reminders);
 
     default Reminder getById(final Long id) {
         return findById(id)

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -16,6 +16,7 @@ public interface ReminderRepository extends Repository<Reminder, Long> {
     @Query("select r from Reminder r WHERE r.message.id = :messageId and r.member.id = :memberId")
     Optional<Reminder> findByMessageIdAndMemberId(Long messageId, Long memberId);
 
+    @Query("select r from Reminder r join fetch r.member join fetch r.message where r.remindDate = :remindDate")
     List<Reminder> findAllByRemindDate(LocalDateTime remindDate);
 
     void deleteById(Long id);

--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -4,6 +4,7 @@ import com.pickpick.exception.message.ReminderNotFoundException;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
 
@@ -21,6 +22,8 @@ public interface ReminderRepository extends Repository<Reminder, Long> {
 
     void deleteById(Long id);
 
+    @Modifying
+    @Query("delete from Reminder r where r in :reminders")
     void deleteInBatch(Iterable<Reminder> reminders);
 
     default Reminder getById(final Long id) {


### PR DESCRIPTION
## 요약

ReminderSender에서 N+1 문제 개선

<br><br>

## 작업 내용

- Reminder 목록 조회 후 각각의 리마인더에 대해 메시지와 멤버 정보를 조회하는 SQL 발생 (1+2N개)
- deleteAll 호출 시 delete문 N개 발생

<br><br>

## 참고 사항

- deleteAll에 관한 문제는 deleteInBatch 메서드를 호출해서 해결하는 방법도 있으나, or절이 반복해서 나가기 때문에 `@Query`로 직접 선언했습니다.

![image](https://user-images.githubusercontent.com/53105735/201507754-7feb2a51-f7a5-4ebf-9524-ee311780457a.png)

<br><br>
