### PR TITLE
fix: channel subscription에서 발생하는 n+1 쿼리 해결

### DIFF
--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -68,7 +68,7 @@ public class ChannelSubscriptionService {
 
     public ChannelSubscriptionResponses findByMemberId(final Long memberId) {
         List<ChannelSubscriptionResponse> channelSubscriptionResponses = channelSubscriptions
-                .findAllByMemberIdOrderByViewOrderJoinFetch(memberId)
+                .findAllByMemberIdOrderByViewOrder(memberId)
                 .stream()
                 .map(ChannelSubscriptionResponse::from)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
+++ b/backend/src/main/java/com/pickpick/channel/application/ChannelSubscriptionService.java
@@ -68,7 +68,7 @@ public class ChannelSubscriptionService {
 
     public ChannelSubscriptionResponses findByMemberId(final Long memberId) {
         List<ChannelSubscriptionResponse> channelSubscriptionResponses = channelSubscriptions
-                .findAllByMemberIdOrderByViewOrder(memberId)
+                .findAllByMemberIdOrderByViewOrderJoinFetch(memberId)
                 .stream()
                 .map(ChannelSubscriptionResponse::from)
                 .collect(Collectors.toList());

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -15,7 +15,7 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
     @Query("select cs from ChannelSubscription cs join fetch cs.channel where cs.member.id = :memberId order by cs.viewOrder")
-    List<ChannelSubscription> findAllByMemberIdOrderByViewOrderJoinFetch(Long memberId);
+    List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
 
     Optional<ChannelSubscription> findFirstByMemberOrderByViewOrderDesc(Member member);
 

--- a/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
+++ b/backend/src/main/java/com/pickpick/channel/domain/ChannelSubscriptionRepository.java
@@ -14,8 +14,8 @@ public interface ChannelSubscriptionRepository extends Repository<ChannelSubscri
     @Query("select cs from ChannelSubscription cs where cs.member.id = :memberId")
     List<ChannelSubscription> findAllByMemberId(Long memberId);
 
-    @Query("select cs from ChannelSubscription cs where cs.member.id = :memberId order by cs.viewOrder")
-    List<ChannelSubscription> findAllByMemberIdOrderByViewOrder(Long memberId);
+    @Query("select cs from ChannelSubscription cs join fetch cs.channel where cs.member.id = :memberId order by cs.viewOrder")
+    List<ChannelSubscription> findAllByMemberIdOrderByViewOrderJoinFetch(Long memberId);
 
     Optional<ChannelSubscription> findFirstByMemberOrderByViewOrderDesc(Member member);
 


### PR DESCRIPTION
## 요약

channel subscription에서 발생하는 n+1 쿼리 해결
<br><br>

## 작업 내용

channel subscription 조회시 연관 엔티티인 channel 을 다시 조회하는 n+1 쿼리가 발생하여 이를 fetch join으로 해결했습니다
<br><br>

## 참고 사항

관련해서 노션에 정리한 내용입니다!! 👍 
https://selective-archeology-e38.notion.site/n-1-1ea4aa5f1b9f4233a94cb246bb4b9446
<br><br>

<br><br>
