### PR TITLE
feat: delete jpql 에 `@Transactional` 추가

### DIFF
--- a/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
+++ b/backend/src/main/java/com/pickpick/message/domain/ReminderRepository.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.Repository;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface ReminderRepository extends Repository<Reminder, Long> {
 
@@ -22,6 +23,7 @@ public interface ReminderRepository extends Repository<Reminder, Long> {
 
     void deleteById(Long id);
 
+    @Transactional
     @Modifying
     @Query("delete from Reminder r where r in :reminders")
     void deleteInBatch(Iterable<Reminder> reminders);


### PR DESCRIPTION
## 요약

<br><br>

## 작업 내용

delete 하는 JPQL에 `@Transactional` 추가

<br><br>

## 참고 사항

- 해당 어노테이션을 붙인 이유에 대해서는 이슈에 정리해두었습니다.

- 해당 메서드들에도 `@Transactional`을 붙일지 고민됩니다.
  - 고민하는 이유: 이번 리팩터링의 목적이 트랜잭션 없는 환경에서 Repository를 호출해도 예외가 발생하지 않게 하기 위함인데 조회 JPQL은 트랜잭션이 없어도 동작은 됩니다. 다만 트랜잭션이 없는 상태에서 호출하는 경우 영속성 관련 이슈가 발생할 수 있는데 조회만 하는 상황에서 영속성을 관리해야할까? 라는 의문이 들기도 하고 고민되네요🤔

<br><br>

## 관련 이슈

- Close #711

<br><br>
